### PR TITLE
Harden Account Manager contract handling

### DIFF
--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -63,17 +64,40 @@ type LoginResult struct {
 	Tokens Tokens `json:"tokens"`
 }
 
+type RefreshResult struct {
+	Tokens Tokens `json:"tokens"`
+}
+
 type MeResult struct {
 	User          User           `json:"user"`
 	Organizations []Organization `json:"organizations"`
 }
 
+type HTTPError struct {
+	Method     string
+	Path       string
+	StatusCode int
+	Body       string
+}
+
+func (e *HTTPError) Error() string {
+	if e.Body != "" {
+		return fmt.Sprintf("upstream %s %s returned %d: %s", e.Method, e.Path, e.StatusCode, e.Body)
+	}
+	return fmt.Sprintf("upstream %s %s returned %d", e.Method, e.Path, e.StatusCode)
+}
+
 func New(baseURL string) *Client {
+	return NewWithHTTPClient(baseURL, &http.Client{Timeout: 6 * time.Second})
+}
+
+func NewWithHTTPClient(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 6 * time.Second}
+	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		httpClient: &http.Client{
-			Timeout: 6 * time.Second,
-		},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
 	}
 }
 
@@ -86,6 +110,14 @@ func (c *Client) Login(ctx context.Context, email, password string) (LoginResult
 	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/login", "", map[string]string{
 		"email":    email,
 		"password": password,
+	}, &out)
+	return out, err
+}
+
+func (c *Client) Refresh(ctx context.Context, refreshToken string) (RefreshResult, error) {
+	var out RefreshResult
+	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/refresh", "", map[string]string{
+		"refresh_token": refreshToken,
 	}, &out)
 	return out, err
 }
@@ -189,7 +221,13 @@ func (c *Client) doJSON(ctx context.Context, method, path, token string, in any,
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return fmt.Errorf("upstream %s %s returned %d", method, path, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		return &HTTPError{
+			Method:     method,
+			Path:       path,
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(body)),
+		}
 	}
 	if out == nil {
 		return nil

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -40,3 +40,28 @@ func TestClientLoginAndMe(t *testing.T) {
 		t.Fatalf("organizations = %#v", me.Organizations)
 	}
 }
+
+func TestClientRefresh(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/refresh":
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s", r.Method)
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"tokens":{"access_token":"refreshed","refresh_token":"refresh-2","expires_in":1800}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL)
+	refresh, err := client.Refresh(t.Context(), "refresh-1")
+	if err != nil {
+		t.Fatalf("Refresh returned error: %v", err)
+	}
+	if refresh.Tokens.AccessToken != "refreshed" || refresh.Tokens.RefreshToken != "refresh-2" {
+		t.Fatalf("tokens = %#v", refresh.Tokens)
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -190,15 +190,15 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 			AccessToken:  session.AccessToken,
 			RefreshToken: session.RefreshToken,
 		})
+		if tokens.AccessToken != "" && (tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken) {
+			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
+		}
 		if err != nil {
 			if errors.Is(err, errCustomerSessionInvalid) {
 				s.invalidateCustomerSession(w, session.ID)
 			}
 			s.writeCustomerError(w, err)
 			return
-		}
-		if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
-			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 		}
 		me.UserID = upstream.User.ID
 		me.Email = upstream.User.Email
@@ -270,11 +270,12 @@ func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	me, tokens, err := s.resolveCustomerProfile(r.Context(), login.Tokens)
 	if err != nil {
-		s.writeCustomerError(w, err)
-		return
+		if tokens.AccessToken == "" {
+			tokens = login.Tokens
+		}
 	}
 	activeOrgID := ""
-	if len(me.Organizations) > 0 {
+	if err == nil && len(me.Organizations) > 0 {
 		activeOrgID = me.Organizations[0].ID
 	}
 	session, err := s.store.CreateSession("customer", login.User.ID, login.User.Email, tokens.AccessToken, tokens.RefreshToken, activeOrgID, tokenTTL(tokens))
@@ -478,7 +479,7 @@ func (s *Server) resolveCustomerProfile(ctx context.Context, tokens accountclien
 		return callErr
 	})
 	if err != nil {
-		return accountclient.MeResult{}, accountclient.Tokens{}, err
+		return upstream, nextTokens, err
 	}
 	return upstream, nextTokens, nil
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -186,14 +186,25 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 	}
 	me := contracts.Me{UserID: session.Subject, Email: session.Email, Name: session.Email, Kind: session.Kind, ActiveOrgID: session.ActiveOrgID, Authenticated: true}
 	if s.accountClient.Enabled() {
-		upstream, err := s.accountClient.Me(r.Context(), session.AccessToken)
-		if err == nil {
-			me.UserID = upstream.User.ID
-			me.Email = upstream.User.Email
-			me.Name = fallback(upstream.User.Name, upstream.User.Email)
-			for _, org := range upstream.Organizations {
-				me.Memberships = append(me.Memberships, contracts.Membership{OrganizationID: org.ID, Organization: org.Name, Role: org.Role})
+		upstream, tokens, err := s.resolveCustomerProfile(r.Context(), accountclient.Tokens{
+			AccessToken:  session.AccessToken,
+			RefreshToken: session.RefreshToken,
+		})
+		if err != nil {
+			if errors.Is(err, errCustomerSessionInvalid) {
+				s.invalidateCustomerSession(w, session.ID)
 			}
+			s.writeCustomerError(w, err)
+			return
+		}
+		if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
+		}
+		me.UserID = upstream.User.ID
+		me.Email = upstream.User.Email
+		me.Name = fallback(upstream.User.Name, upstream.User.Email)
+		for _, org := range upstream.Organizations {
+			me.Memberships = append(me.Memberships, contracts.Membership{OrganizationID: org.ID, Organization: org.Name, Role: org.Role})
 		}
 	}
 	writeJSON(w, me)
@@ -211,6 +222,26 @@ func (s *Server) apiActiveOrg(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.OrganizationID == "" {
 		http.Error(w, "organization_id is required", http.StatusBadRequest)
 		return
+	}
+	if s.accountClient.Enabled() && session.Kind == "customer" {
+		orgs, tokens, err := s.customerOrganizations(r.Context(), accountclient.Tokens{
+			AccessToken:  session.AccessToken,
+			RefreshToken: session.RefreshToken,
+		})
+		if err != nil {
+			if errors.Is(err, errCustomerSessionInvalid) {
+				s.invalidateCustomerSession(w, session.ID)
+			}
+			s.writeCustomerError(w, err)
+			return
+		}
+		if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
+		}
+		if !organizationAllowed(orgs, body.OrganizationID) {
+			http.Error(w, "organization is not part of the current customer memberships", http.StatusForbidden)
+			return
+		}
 	}
 	if err := s.store.UpdateSessionActiveOrg(session.ID, body.OrganizationID); err != nil {
 		writeError(w, err)
@@ -237,12 +268,16 @@ func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)
 		return
 	}
-	me, _ := s.accountClient.Me(r.Context(), login.Tokens.AccessToken)
+	me, tokens, err := s.resolveCustomerProfile(r.Context(), login.Tokens)
+	if err != nil {
+		s.writeCustomerError(w, err)
+		return
+	}
 	activeOrgID := ""
 	if len(me.Organizations) > 0 {
 		activeOrgID = me.Organizations[0].ID
 	}
-	session, err := s.store.CreateSession("customer", login.User.ID, login.User.Email, login.Tokens.AccessToken, login.Tokens.RefreshToken, activeOrgID, tokenTTL(login.Tokens))
+	session, err := s.store.CreateSession("customer", login.User.ID, login.User.Email, tokens.AccessToken, tokens.RefreshToken, activeOrgID, tokenTTL(tokens))
 	if err != nil {
 		writeError(w, err)
 		return
@@ -428,15 +463,146 @@ func tokenTTL(tokens accountclient.Tokens) time.Duration {
 	return time.Hour
 }
 
+var errCustomerSessionInvalid = errors.New("customer session is invalid")
+
+func (s *Server) invalidateCustomerSession(w http.ResponseWriter, sessionID string) {
+	_ = s.store.DeleteSession(sessionID)
+	http.SetCookie(w, &http.Cookie{Name: "rtk_admin_session", Value: "", Path: "/", MaxAge: -1, HttpOnly: true, SameSite: http.SameSiteLaxMode})
+}
+
+func (s *Server) resolveCustomerProfile(ctx context.Context, tokens accountclient.Tokens) (accountclient.MeResult, accountclient.Tokens, error) {
+	var upstream accountclient.MeResult
+	nextTokens, err := s.customerCall(ctx, tokens, func(token string) error {
+		var callErr error
+		upstream, callErr = s.accountClient.Me(ctx, token)
+		return callErr
+	})
+	if err != nil {
+		return accountclient.MeResult{}, accountclient.Tokens{}, err
+	}
+	return upstream, nextTokens, nil
+}
+
+func (s *Server) customerOrganizations(ctx context.Context, tokens accountclient.Tokens) ([]accountclient.Organization, accountclient.Tokens, error) {
+	var orgs []accountclient.Organization
+	nextTokens, err := s.customerCall(ctx, tokens, func(token string) error {
+		var callErr error
+		orgs, callErr = s.accountClient.Organizations(ctx, token)
+		return callErr
+	})
+	if err != nil {
+		return nil, accountclient.Tokens{}, err
+	}
+	return orgs, nextTokens, nil
+}
+
+func (s *Server) customerCall(ctx context.Context, tokens accountclient.Tokens, call func(token string) error) (accountclient.Tokens, error) {
+	if !s.accountClient.Enabled() {
+		return tokens, errors.New("ACCOUNT_MANAGER_BASE_URL is not configured")
+	}
+	err := call(tokens.AccessToken)
+	if err == nil {
+		return tokens, nil
+	}
+	if status, ok := customerUpstreamStatus(err); !ok || status != http.StatusUnauthorized {
+		return tokens, err
+	}
+	if tokens.RefreshToken == "" {
+		return accountclient.Tokens{}, errCustomerSessionInvalid
+	}
+	refreshed, refreshErr := s.accountClient.Refresh(ctx, tokens.RefreshToken)
+	if refreshErr != nil {
+		if status, ok := customerUpstreamStatus(refreshErr); ok && status == http.StatusUnauthorized {
+			return accountclient.Tokens{}, errCustomerSessionInvalid
+		}
+		return tokens, refreshErr
+	}
+	nextTokens := refreshed.Tokens
+	if nextTokens.AccessToken == "" {
+		return accountclient.Tokens{}, errCustomerSessionInvalid
+	}
+	err = call(nextTokens.AccessToken)
+	if err == nil {
+		return nextTokens, nil
+	}
+	if status, ok := customerUpstreamStatus(err); ok && status == http.StatusUnauthorized {
+		return accountclient.Tokens{}, errCustomerSessionInvalid
+	}
+	return nextTokens, err
+}
+
+func customerUpstreamStatus(err error) (int, bool) {
+	var httpErr *accountclient.HTTPError
+	if errors.As(err, &httpErr) {
+		switch httpErr.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return httpErr.StatusCode, true
+		case http.StatusNotFound, http.StatusBadRequest, http.StatusConflict, http.StatusTooManyRequests, http.StatusInternalServerError, http.StatusBadGateway, http.StatusServiceUnavailable:
+			return http.StatusBadGateway, true
+		}
+	}
+	var timeoutErr interface{ Timeout() bool }
+	if errors.As(err, &timeoutErr) && timeoutErr.Timeout() {
+		return http.StatusGatewayTimeout, true
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout, true
+	}
+	return 0, false
+}
+
+func (s *Server) writeCustomerError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errCustomerSessionInvalid) {
+		http.Error(w, "customer session expired; please sign in again", http.StatusUnauthorized)
+		return
+	}
+	if status, ok := customerUpstreamStatus(err); ok {
+		switch status {
+		case http.StatusUnauthorized:
+			http.Error(w, "customer session expired; please sign in again", http.StatusUnauthorized)
+		case http.StatusForbidden:
+			http.Error(w, "Account Manager denied access to the requested resource", http.StatusForbidden)
+		case http.StatusGatewayTimeout:
+			http.Error(w, "Account Manager request timed out", http.StatusGatewayTimeout)
+		default:
+			http.Error(w, "Account Manager request failed", http.StatusBadGateway)
+		}
+		return
+	}
+	writeError(w, err)
+}
+
+func organizationAllowed(orgs []accountclient.Organization, orgID string) bool {
+	for _, org := range orgs {
+		if org.ID == orgID {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *Server) upstreamCustomers(w http.ResponseWriter, r *http.Request) ([]contracts.CustomerSummary, bool) {
 	session, ok := s.requestSession(r)
 	if !ok || !s.accountClient.Enabled() || session.Kind != "customer" {
 		return nil, false
 	}
-	orgs, err := s.accountClient.Organizations(r.Context(), session.AccessToken)
+	tokens := accountclient.Tokens{AccessToken: session.AccessToken, RefreshToken: session.RefreshToken}
+	var orgs []accountclient.Organization
+	var err error
+	tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
+		var callErr error
+		orgs, callErr = s.accountClient.Organizations(r.Context(), token)
+		return callErr
+	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
+		if errors.Is(err, errCustomerSessionInvalid) {
+			s.invalidateCustomerSession(w, session.ID)
+		}
+		s.writeCustomerError(w, err)
 		return nil, true
+	}
+	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 	}
 	customers := make([]contracts.CustomerSummary, 0, len(orgs))
 	for _, org := range orgs {
@@ -444,10 +610,21 @@ func (s *Server) upstreamCustomers(w http.ResponseWriter, r *http.Request) ([]co
 			OrganizationID: org.ID,
 			Organization:   org.Name,
 		}
-		devices, err := s.accountClient.Devices(r.Context(), session.AccessToken, org.ID)
+		var devices []accountclient.Device
+		tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
+			var callErr error
+			devices, callErr = s.accountClient.Devices(r.Context(), token, org.ID)
+			return callErr
+		})
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			if errors.Is(err, errCustomerSessionInvalid) {
+				s.invalidateCustomerSession(w, session.ID)
+			}
+			s.writeCustomerError(w, err)
 			return nil, true
+		}
+		if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 		}
 		for _, device := range devices {
 			mapped := mapUpstreamDevice(org, device)
@@ -477,17 +654,41 @@ func (s *Server) upstreamDevices(w http.ResponseWriter, r *http.Request) ([]cont
 	if !ok || !s.accountClient.Enabled() || session.Kind != "customer" {
 		return nil, false
 	}
-	orgs, err := s.accountClient.Organizations(r.Context(), session.AccessToken)
+	tokens := accountclient.Tokens{AccessToken: session.AccessToken, RefreshToken: session.RefreshToken}
+	var orgs []accountclient.Organization
+	var err error
+	tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
+		var callErr error
+		orgs, callErr = s.accountClient.Organizations(r.Context(), token)
+		return callErr
+	})
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
+		if errors.Is(err, errCustomerSessionInvalid) {
+			s.invalidateCustomerSession(w, session.ID)
+		}
+		s.writeCustomerError(w, err)
 		return nil, true
+	}
+	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 	}
 	var out []contracts.Device
 	for _, org := range orgs {
-		devices, err := s.accountClient.Devices(r.Context(), session.AccessToken, org.ID)
+		var devices []accountclient.Device
+		tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
+			var callErr error
+			devices, callErr = s.accountClient.Devices(r.Context(), token, org.ID)
+			return callErr
+		})
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadGateway)
+			if errors.Is(err, errCustomerSessionInvalid) {
+				s.invalidateCustomerSession(w, session.ID)
+			}
+			s.writeCustomerError(w, err)
 			return nil, true
+		}
+		if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 		}
 		for _, device := range devices {
 			out = append(out, mapUpstreamDevice(org, device))
@@ -501,21 +702,56 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 	if !ok || !s.accountClient.Enabled() || session.Kind != "customer" || session.ActiveOrgID == "" {
 		return false
 	}
+	tokens := accountclient.Tokens{AccessToken: session.AccessToken, RefreshToken: session.RefreshToken}
+	var orgs []accountclient.Organization
+	var err error
+	tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
+		var callErr error
+		orgs, callErr = s.accountClient.Organizations(r.Context(), token)
+		return callErr
+	})
+	if err != nil {
+		if errors.Is(err, errCustomerSessionInvalid) {
+			s.invalidateCustomerSession(w, session.ID)
+		}
+		s.writeCustomerError(w, err)
+		return true
+	}
+	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
+	}
+	if !organizationAllowed(orgs, session.ActiveOrgID) {
+		http.Error(w, "active organization is not part of the current customer memberships", http.StatusForbidden)
+		return true
+	}
 	deviceID := r.PathValue("id")
 	operationType := "DeviceProvisionRequested"
 	var op accountclient.Operation
-	var err error
 	if action == "deactivate" {
 		operationType = "DeviceDeactivateRequested"
-		op, err = s.accountClient.Deactivate(r.Context(), session.AccessToken, session.ActiveOrgID, deviceID)
+		tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
+			var callErr error
+			op, callErr = s.accountClient.Deactivate(r.Context(), token, session.ActiveOrgID, deviceID)
+			return callErr
+		})
 	} else {
-		op, err = s.accountClient.Provision(r.Context(), session.AccessToken, session.ActiveOrgID, deviceID)
+		tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
+			var callErr error
+			op, callErr = s.accountClient.Provision(r.Context(), token, session.ActiveOrgID, deviceID)
+			return callErr
+		})
 	}
 	_ = s.store.CreateAuditEvent(session.Email, operationType+".attempted", deviceID)
 	if err != nil {
+		if errors.Is(err, errCustomerSessionInvalid) {
+			s.invalidateCustomerSession(w, session.ID)
+		}
 		_ = s.store.CreateAuditEvent(session.Email, operationType+".failed", deviceID)
-		http.Error(w, err.Error(), http.StatusBadGateway)
+		s.writeCustomerError(w, err)
 		return true
+	}
+	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 	}
 	_ = s.store.CreateAuditEvent(session.Email, operationType+".completed", deviceID)
 	writeJSON(w, contracts.Operation{

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,11 +1,14 @@
 package app
 
 import (
+	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"rtk_cloud_admin/internal/accountclient"
 	"rtk_cloud_admin/internal/config"
@@ -96,24 +99,53 @@ func TestCustomersAPI(t *testing.T) {
 	}
 }
 
-func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
+func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 	t.Parallel()
 
+	var refreshCalls int
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/auth/login":
-			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"tokens":{"access_token":"expired-access","refresh_token":"refresh-1","expires_in":3600}}`))
 		case "/v1/me":
-			if r.Header.Get("Authorization") != "Bearer access" {
-				t.Fatalf("missing bearer token")
+			switch r.Header.Get("Authorization") {
+			case "Bearer expired-access":
+				http.Error(w, "expired", http.StatusUnauthorized)
+			case "Bearer refreshed-access":
+				_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+			default:
+				http.Error(w, fmt.Sprintf("unexpected bearer token %q", r.Header.Get("Authorization")), http.StatusUnauthorized)
 			}
-			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/auth/refresh":
+			refreshCalls++
+			if refreshCalls > 1 {
+				t.Fatalf("unexpected extra refresh call")
+			}
+			_, _ = w.Write([]byte(`{"tokens":{"access_token":"refreshed-access","refresh_token":"refresh-2","expires_in":1800}}`))
 		case "/v1/orgs":
+			if r.Header.Get("Authorization") != "Bearer refreshed-access" {
+				http.Error(w, "unexpected bearer token", http.StatusUnauthorized)
+				return
+			}
 			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
 		case "/v1/orgs/org-up/devices":
+			if r.Header.Get("Authorization") != "Bearer refreshed-access" {
+				http.Error(w, "unexpected bearer token", http.StatusUnauthorized)
+				return
+			}
 			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-up","name":"edge-01","model":"RTK-CAM-X","serial_number":"UP-1","readiness":"online","status":"online","metadata":{"video_cloud_devid":"video-up"}}]}`))
 		case "/v1/orgs/org-up/devices/dev-up/provision":
+			if r.Header.Get("Authorization") != "Bearer refreshed-access" {
+				http.Error(w, "unexpected bearer token", http.StatusUnauthorized)
+				return
+			}
 			_, _ = w.Write([]byte(`{"operation":{"id":"op-up","state":"published","message":"accepted"}}`))
+		case "/v1/orgs/org-up/devices/dev-up/deactivate":
+			if r.Header.Get("Authorization") != "Bearer refreshed-access" {
+				http.Error(w, "unexpected bearer token", http.StatusUnauthorized)
+				return
+			}
+			_, _ = w.Write([]byte(`{"operation":{"id":"op-down","state":"published","message":"accepted"}}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -141,10 +173,51 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
+	if len(login.Result().Cookies()) != 1 {
+		t.Fatalf("login did not set cookie")
+	}
 	cookie := login.Result().Cookies()[0]
 
+	session, err := st.GetSession(cookie.Value)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if session.AccessToken != "refreshed-access" || session.RefreshToken != "refresh-2" {
+		t.Fatalf("session tokens = %#v, want refreshed tokens", session)
+	}
+	if session.ActiveOrgID != "org-up" {
+		t.Fatalf("session active org = %q, want org-up", session.ActiveOrgID)
+	}
+
+	me := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(me, req)
+	if me.Code != http.StatusOK {
+		t.Fatalf("me status = %d, body=%s", me.Code, me.Body.String())
+	}
+	if !strings.Contains(me.Body.String(), "user@example.com") || !strings.Contains(me.Body.String(), "org-up") {
+		t.Fatalf("me body should include upstream profile and membership: %s", me.Body.String())
+	}
+
+	switchOrg := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/me/active-org", strings.NewReader(`{"organization_id":"org-bad"}`))
+	req.AddCookie(cookie)
+	srv.ServeHTTP(switchOrg, req)
+	if switchOrg.Code != http.StatusForbidden {
+		t.Fatalf("switch org status = %d, body=%s", switchOrg.Code, switchOrg.Body.String())
+	}
+
+	validSwitch := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/me/active-org", strings.NewReader(`{"organization_id":"org-up"}`))
+	req.AddCookie(cookie)
+	srv.ServeHTTP(validSwitch, req)
+	if validSwitch.Code != http.StatusOK {
+		t.Fatalf("valid switch status = %d, body=%s", validSwitch.Code, validSwitch.Body.String())
+	}
+
 	devices := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/devices", nil)
 	req.AddCookie(cookie)
 	srv.ServeHTTP(devices, req)
 	if devices.Code != http.StatusOK {
@@ -163,6 +236,124 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	}
 	if !strings.Contains(provision.Body.String(), "op-up") {
 		t.Fatalf("provision body = %s", provision.Body.String())
+	}
+
+	deactivate := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-up/deactivate", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(deactivate, req)
+	if deactivate.Code != http.StatusOK {
+		t.Fatalf("deactivate status = %d, body=%s", deactivate.Code, deactivate.Body.String())
+	}
+}
+
+func TestCustomerSessionInvalidRefreshClearsStoredSession(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			if r.Header.Get("Authorization") == "Bearer expired-access" {
+				http.Error(w, "expired", http.StatusUnauthorized)
+				return
+			}
+			http.NotFound(w, r)
+		case "/v1/auth/refresh":
+			http.Error(w, "refresh expired", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u1", "user@example.com", "expired-access", "refresh-1", "org-up", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("me status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if _, err := st.GetSession(session.ID); err != sql.ErrNoRows {
+		t.Fatalf("session should be cleared, got %v", err)
+	}
+}
+
+func TestCustomerUpstreamErrorsMapDeterministically(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/login":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs":
+			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs/org-up/devices":
+			http.Error(w, "upstream failure", http.StatusInternalServerError)
+		case "/v1/orgs/org-up/devices/dev-up/provision":
+			time.Sleep(200 * time.Millisecond)
+			_, _ = w.Write([]byte(`{"operation":{"id":"op-up","state":"published","message":"accepted"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.NewWithHTTPClient(upstream.URL, &http.Client{Timeout: 50 * time.Millisecond}),
+	})
+
+	login := httptest.NewRecorder()
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	if login.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
+	}
+	cookie := login.Result().Cookies()[0]
+
+	devices := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(devices, req)
+	if devices.Code != http.StatusBadGateway {
+		t.Fatalf("devices status = %d, body=%s", devices.Code, devices.Body.String())
+	}
+
+	provision := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-up/provision", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(provision, req)
+	if provision.Code != http.StatusGatewayTimeout {
+		t.Fatalf("provision status = %d, body=%s", provision.Code, provision.Body.String())
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -247,6 +247,64 @@ func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 	}
 }
 
+func TestCustomerLoginSurvivesProfileRetryFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/login":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"tokens":{"access_token":"expired-access","refresh_token":"refresh-1","expires_in":3600}}`))
+		case "/v1/me":
+			switch r.Header.Get("Authorization") {
+			case "Bearer expired-access":
+				http.Error(w, "expired", http.StatusUnauthorized)
+			case "Bearer refreshed-access":
+				http.Error(w, "profile unavailable", http.StatusInternalServerError)
+			default:
+				http.Error(w, fmt.Sprintf("unexpected bearer token %q", r.Header.Get("Authorization")), http.StatusUnauthorized)
+			}
+		case "/v1/auth/refresh":
+			_, _ = w.Write([]byte(`{"tokens":{"access_token":"refreshed-access","refresh_token":"refresh-2","expires_in":1800}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	login := httptest.NewRecorder()
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	if login.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
+	}
+	if len(login.Result().Cookies()) != 1 {
+		t.Fatalf("login did not set cookie")
+	}
+
+	session, err := st.GetSession(login.Result().Cookies()[0].Value)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if session.AccessToken != "refreshed-access" || session.RefreshToken != "refresh-2" {
+		t.Fatalf("session tokens = %#v, want refreshed tokens", session)
+	}
+	if session.ActiveOrgID != "" {
+		t.Fatalf("session active org = %q, want empty", session.ActiveOrgID)
+	}
+}
+
 func TestCustomerSessionInvalidRefreshClearsStoredSession(t *testing.T) {
 	t.Parallel()
 
@@ -292,6 +350,62 @@ func TestCustomerSessionInvalidRefreshClearsStoredSession(t *testing.T) {
 	}
 	if _, err := st.GetSession(session.ID); err != sql.ErrNoRows {
 		t.Fatalf("session should be cleared, got %v", err)
+	}
+}
+
+func TestCustomerMePersistsRotatedTokensOnRetryFailure(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			switch r.Header.Get("Authorization") {
+			case "Bearer expired-access":
+				http.Error(w, "expired", http.StatusUnauthorized)
+			case "Bearer refreshed-access":
+				http.Error(w, "profile unavailable", http.StatusInternalServerError)
+			default:
+				http.Error(w, fmt.Sprintf("unexpected bearer token %q", r.Header.Get("Authorization")), http.StatusUnauthorized)
+			}
+		case "/v1/auth/refresh":
+			_, _ = w.Write([]byte(`{"tokens":{"access_token":"refreshed-access","refresh_token":"refresh-2","expires_in":1800}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u1", "user@example.com", "expired-access", "refresh-1", "org-up", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("me status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	updated, err := st.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if updated.AccessToken != "refreshed-access" || updated.RefreshToken != "refresh-2" {
+		t.Fatalf("session tokens = %#v, want refreshed tokens", updated)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -456,6 +456,12 @@ func (s *Store) UpdateSessionActiveOrg(id, orgID string) error {
 	return err
 }
 
+func (s *Store) UpdateSessionTokens(id, accessToken, refreshToken string, ttl time.Duration) error {
+	expiresAt := time.Now().UTC().Add(ttl).Format(time.RFC3339)
+	_, err := s.db.Exec(`UPDATE sessions SET access_token = ?, refresh_token = ?, expires_at = ? WHERE id = ?`, accessToken, refreshToken, expiresAt, id)
+	return err
+}
+
 func (s *Store) DeleteSession(id string) error {
 	_, err := s.db.Exec(`DELETE FROM sessions WHERE id = ?`, id)
 	return err


### PR DESCRIPTION
Refs #2\n\nSummary:\n- add Account Manager refresh-token handling and typed upstream errors\n- validate customer org membership before switching active org or proxying lifecycle calls\n- persist refreshed session tokens back into SQLite\n- add tests for refresh success, invalid refresh cleanup, 500 mapping, and timeout mapping\n\nValidation:\n- go test ./...\n- go build ./cmd/server\n- (frontend) npm ci\n- (frontend) npm run build