### PR TITLE
Backend-owned readiness source facts model

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -15,6 +15,7 @@ import (
 	"rtk_cloud_admin/internal/accountclient"
 	"rtk_cloud_admin/internal/config"
 	"rtk_cloud_admin/internal/contracts"
+	"rtk_cloud_admin/internal/readinessfacts"
 	"rtk_cloud_admin/internal/store"
 )
 
@@ -535,7 +536,7 @@ func mapUpstreamDevice(org accountclient.Organization, device accountclient.Devi
 	status := fallback(device.Status, metadataString(device.Metadata, "status", "unknown"))
 	videoID := fallback(device.VideoCloudDevID, metadataString(device.Metadata, "video_cloud_devid", ""))
 	updatedAt := fallback(device.UpdatedAt, now)
-	return contracts.Device{
+	mapped := contracts.Device{
 		ID:              device.ID,
 		OrganizationID:  fallback(device.OrganizationID, org.ID),
 		Organization:    fallback(device.Organization, org.Name),
@@ -548,18 +549,23 @@ func mapUpstreamDevice(org accountclient.Organization, device accountclient.Devi
 		Readiness:       readiness,
 		LastSeenAt:      fallback(device.LastSeenAt, metadataString(device.Metadata, "last_seen_at", "")),
 		UpdatedAt:       updatedAt,
-		SourceFacts: []contracts.SourceFact{
-			{Layer: "account_registry", State: "present", Detail: "Device returned by Account Manager.", UpdatedAt: updatedAt},
-			{Layer: "cloud_activation", State: status, Detail: sourceFactDetail(videoID), UpdatedAt: updatedAt},
-		},
 	}
+	mapped.SourceFacts = readinessfacts.Build(mapped, upstreamOperationFromMetadata(device, updatedAt))
+	return mapped
 }
 
-func sourceFactDetail(videoID string) string {
-	if videoID == "" {
-		return "Missing video_cloud_devid from Account Manager metadata."
+func upstreamOperationFromMetadata(device accountclient.Device, fallbackUpdatedAt string) *contracts.Operation {
+	operationID := metadataString(device.Metadata, "operation_id", "")
+	if operationID == "" {
+		return nil
 	}
-	return "Video Cloud device identity is present."
+	return &contracts.Operation{
+		ID:        operationID,
+		Type:      metadataString(device.Metadata, "operation_type", "DeviceProvisionRequested"),
+		State:     mapOperationState(metadataString(device.Metadata, "operation_state", string(contracts.OperationPublished))),
+		Message:   metadataString(device.Metadata, "operation_message", "Account Manager projection metadata"),
+		UpdatedAt: fallback(metadataString(device.Metadata, "operation_updated_at", ""), fallbackUpdatedAt),
+	}
 }
 
 func mapOperationState(state string) contracts.OperationState {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -153,6 +153,9 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	if !strings.Contains(devices.Body.String(), "edge-01") || strings.Contains(devices.Body.String(), "cam-a-001") {
 		t.Fatalf("devices should use upstream projection, got %s", devices.Body.String())
 	}
+	if !strings.Contains(devices.Body.String(), "source_facts") {
+		t.Fatalf("devices response does not include source_facts: %s", devices.Body.String())
+	}
 
 	provision := httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-up/provision", nil)
@@ -163,6 +166,27 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	}
 	if !strings.Contains(provision.Body.String(), "op-up") {
 		t.Fatalf("provision body = %s", provision.Body.String())
+	}
+}
+
+func TestDeviceAPIIncludesSourceFacts(t *testing.T) {
+	t.Parallel()
+
+	srv, err := NewTestServer(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("NewTestServer returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/devices/dev-004", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("device status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "\"source_facts\"") {
+		t.Fatalf("device body does not include source_facts: %s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "\"failed\"") {
+		t.Fatalf("device body does not include failed source fact: %s", rec.Body.String())
 	}
 }
 

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -36,7 +36,7 @@ type Device struct {
 	VideoCloudDevID string         `json:"video_cloud_devid"`
 	Status          string         `json:"status"`
 	Readiness       ReadinessState `json:"readiness"`
-	SourceFacts     []SourceFact   `json:"source_facts,omitempty"`
+	SourceFacts     []SourceFact   `json:"source_facts"`
 	LastSeenAt      string         `json:"last_seen_at"`
 	UpdatedAt       string         `json:"updated_at"`
 }

--- a/internal/readinessfacts/facts.go
+++ b/internal/readinessfacts/facts.go
@@ -1,0 +1,148 @@
+package readinessfacts
+
+import (
+	"strings"
+	"unicode"
+
+	"rtk_cloud_admin/internal/contracts"
+)
+
+func Build(device contracts.Device, latestOp *contracts.Operation) []contracts.SourceFact {
+	updatedAt := device.UpdatedAt
+	if updatedAt == "" && latestOp != nil {
+		updatedAt = latestOp.UpdatedAt
+	}
+
+	return []contracts.SourceFact{
+		{
+			Layer:     "account_registry",
+			State:     "present",
+			Detail:    "Device exists in the registry projection.",
+			UpdatedAt: updatedAt,
+		},
+		cloudActivationFact(device, latestOp, updatedAt),
+		transportOnlineFact(device, updatedAt),
+	}
+}
+
+func cloudActivationFact(device contracts.Device, latestOp *contracts.Operation, fallbackUpdatedAt string) contracts.SourceFact {
+	fact := contracts.SourceFact{
+		Layer:     "cloud_activation",
+		UpdatedAt: fallbackUpdatedAt,
+	}
+
+	if device.VideoCloudDevID == "" {
+		fact.State = "missing"
+		fact.Detail = "Missing video_cloud_devid from Account Manager metadata."
+		return fact
+	}
+
+	switch device.Readiness {
+	case contracts.ReadinessFailed:
+		fact.State = "failed"
+		fact.Detail = "Cloud activation failed."
+		fact.Retryable = true
+	case contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending, contracts.ReadinessCloudActivationPending, contracts.ReadinessDeactivationPending:
+		fact.State = "pending"
+		fact.Detail = "Waiting for cloud activation to complete."
+	case contracts.ReadinessActivated, contracts.ReadinessOnline:
+		fact.State = "present"
+		fact.Detail = "Video Cloud device identity is present."
+	case contracts.ReadinessDeactivated:
+		fact.State = "stale"
+		fact.Detail = "Device is deactivated and cloud activation evidence is stale."
+	default:
+		fact.State = "present"
+		fact.Detail = "Video Cloud device identity is present."
+	}
+
+	if latestOp == nil {
+		return fact
+	}
+
+	fact.OperationID = latestOp.ID
+	if latestOp.UpdatedAt != "" {
+		fact.UpdatedAt = latestOp.UpdatedAt
+	}
+
+	switch latestOp.State {
+	case contracts.OperationPending, contracts.OperationPublished, contracts.OperationRetrying:
+		fact.State = "pending"
+		if latestOp.Message != "" {
+			fact.Detail = latestOp.Message
+		}
+	case contracts.OperationSucceeded:
+		if fact.State != "failed" {
+			fact.State = "present"
+		}
+		if latestOp.Message != "" {
+			fact.Detail = latestOp.Message
+		}
+	case contracts.OperationFailed, contracts.OperationDeadLettered:
+		fact.State = "failed"
+		if latestOp.Message != "" {
+			fact.Detail = latestOp.Message
+			fact.ErrorCode = normalizeErrorCode(latestOp.Message)
+			fact.Retryable = retryableFromMessage(latestOp.Message)
+		}
+	default:
+		if latestOp.Message != "" && fact.Detail == "" {
+			fact.Detail = latestOp.Message
+		}
+	}
+
+	return fact
+}
+
+func transportOnlineFact(device contracts.Device, fallbackUpdatedAt string) contracts.SourceFact {
+	fact := contracts.SourceFact{
+		Layer:     "transport_online",
+		UpdatedAt: fallbackUpdatedAt,
+	}
+
+	if device.LastSeenAt == "" {
+		fact.State = "missing"
+		fact.Detail = "No transport evidence."
+		return fact
+	}
+
+	fact.UpdatedAt = device.LastSeenAt
+	fact.Detail = "Last transport evidence at " + device.LastSeenAt + "."
+	switch strings.ToLower(device.Status) {
+	case "online":
+		fact.State = "present"
+	case "offline", "unknown", "disabled":
+		fact.State = "stale"
+	default:
+		fact.State = "present"
+	}
+	return fact
+}
+
+func normalizeErrorCode(text string) string {
+	text = strings.ToLower(text)
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range text {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			lastUnderscore = false
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteRune('_')
+			lastUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func retryableFromMessage(message string) bool {
+	lower := strings.ToLower(message)
+	for _, blocked := range []string{"mismatch", "invalid", "forbidden", "unauthorized", "rejected"} {
+		if strings.Contains(lower, blocked) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/readinessfacts/facts_test.go
+++ b/internal/readinessfacts/facts_test.go
@@ -1,0 +1,131 @@
+package readinessfacts
+
+import (
+	"testing"
+
+	"rtk_cloud_admin/internal/contracts"
+)
+
+func TestBuildSourceFacts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		device          contracts.Device
+		latestOp        *contracts.Operation
+		wantStates      []string
+		wantErrorCode   string
+		wantRetryable   bool
+		wantOperationID string
+	}{
+		{
+			name: "online",
+			device: contracts.Device{
+				ID:              "dev-1",
+				VideoCloudDevID: "video-1",
+				Status:          "online",
+				Readiness:       contracts.ReadinessOnline,
+				LastSeenAt:      "2026-05-01T10:00:00Z",
+				UpdatedAt:       "2026-05-01T10:01:00Z",
+			},
+			wantStates: []string{"present", "present", "present"},
+		},
+		{
+			name: "activated",
+			device: contracts.Device{
+				ID:              "dev-2",
+				VideoCloudDevID: "video-2",
+				Status:          "offline",
+				Readiness:       contracts.ReadinessActivated,
+				LastSeenAt:      "2026-05-01T10:00:00Z",
+				UpdatedAt:       "2026-05-01T10:01:00Z",
+			},
+			wantStates: []string{"present", "present", "stale"},
+		},
+		{
+			name: "pending",
+			device: contracts.Device{
+				ID:              "dev-3",
+				VideoCloudDevID: "video-3",
+				Status:          "unknown",
+				Readiness:       contracts.ReadinessCloudActivationPending,
+				UpdatedAt:       "2026-05-01T10:01:00Z",
+			},
+			latestOp: &contracts.Operation{
+				ID:        "op-1",
+				State:     contracts.OperationPublished,
+				Message:   "Waiting for upstream activation.",
+				UpdatedAt: "2026-05-01T10:02:00Z",
+			},
+			wantStates:      []string{"present", "pending", "missing"},
+			wantOperationID: "op-1",
+		},
+		{
+			name: "failed",
+			device: contracts.Device{
+				ID:              "dev-4",
+				VideoCloudDevID: "video-4",
+				Status:          "disabled",
+				Readiness:       contracts.ReadinessFailed,
+				LastSeenAt:      "2026-05-01T10:00:00Z",
+				UpdatedAt:       "2026-05-01T10:01:00Z",
+			},
+			latestOp: &contracts.Operation{
+				ID:        "op-2",
+				State:     contracts.OperationFailed,
+				Message:   "subject mapping rejected: video_cloud_devid mismatch",
+				UpdatedAt: "2026-05-01T10:03:00Z",
+			},
+			wantStates:      []string{"present", "failed", "stale"},
+			wantErrorCode:   "subject_mapping_rejected_video_cloud_devid_mismatch",
+			wantRetryable:   false,
+			wantOperationID: "op-2",
+		},
+		{
+			name: "missing",
+			device: contracts.Device{
+				ID:        "dev-5",
+				Readiness: contracts.ReadinessRegistered,
+			},
+			wantStates: []string{"present", "missing", "missing"},
+		},
+		{
+			name: "stale",
+			device: contracts.Device{
+				ID:              "dev-6",
+				VideoCloudDevID: "video-6",
+				Status:          "offline",
+				Readiness:       contracts.ReadinessActivated,
+				LastSeenAt:      "2026-04-30T22:45:00Z",
+				UpdatedAt:       "2026-05-01T10:01:00Z",
+			},
+			wantStates: []string{"present", "present", "stale"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			facts := Build(tt.device, tt.latestOp)
+			if len(facts) != 3 {
+				t.Fatalf("facts len = %d, want 3", len(facts))
+			}
+			for i, want := range tt.wantStates {
+				if got := facts[i].State; got != want {
+					t.Fatalf("fact[%d].state = %q, want %q", i, got, want)
+				}
+			}
+			if tt.wantErrorCode != "" && facts[1].ErrorCode != tt.wantErrorCode {
+				t.Fatalf("cloud activation error_code = %q, want %q", facts[1].ErrorCode, tt.wantErrorCode)
+			}
+			if facts[1].Retryable != tt.wantRetryable {
+				t.Fatalf("cloud activation retryable = %v, want %v", facts[1].Retryable, tt.wantRetryable)
+			}
+			if tt.wantOperationID != "" && facts[1].OperationID != tt.wantOperationID {
+				t.Fatalf("cloud activation operation_id = %q, want %q", facts[1].OperationID, tt.wantOperationID)
+			}
+		})
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,6 +11,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"rtk_cloud_admin/internal/contracts"
+	"rtk_cloud_admin/internal/readinessfacts"
 )
 
 type Store struct {
@@ -223,7 +224,17 @@ ORDER BY organization, name`)
 		}
 		devices = append(devices, d)
 	}
-	return devices, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for i := range devices {
+		facts, err := s.sourceFactsForDevice(devices[i])
+		if err != nil {
+			return nil, err
+		}
+		devices[i].SourceFacts = facts
+	}
+	return devices, nil
 }
 
 func (s *Store) GetDevice(id string) (contracts.Device, error) {
@@ -232,6 +243,10 @@ func (s *Store) GetDevice(id string) (contracts.Device, error) {
 SELECT id, organization_id, organization, name, category, model, serial_number, video_cloud_devid, status, readiness, last_seen_at, updated_at
 FROM devices
 WHERE id = ?`, id).Scan(&d.ID, &d.OrganizationID, &d.Organization, &d.Name, &d.Category, &d.Model, &d.SerialNumber, &d.VideoCloudDevID, &d.Status, &d.Readiness, &d.LastSeenAt, &d.UpdatedAt)
+	if err != nil {
+		return d, err
+	}
+	d.SourceFacts, err = s.sourceFactsForDevice(d)
 	return d, err
 }
 
@@ -516,4 +531,29 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		return contracts.Operation{}, err
 	}
 	return op, nil
+}
+
+func (s *Store) sourceFactsForDevice(device contracts.Device) ([]contracts.SourceFact, error) {
+	latest, err := s.latestOperationForDevice(device.ID)
+	if err != nil {
+		return nil, err
+	}
+	return readinessfacts.Build(device, latest), nil
+}
+
+func (s *Store) latestOperationForDevice(deviceID string) (*contracts.Operation, error) {
+	var op contracts.Operation
+	err := s.db.QueryRow(`
+SELECT id, device_id, device_name, organization, type, state, message, updated_at
+FROM operations
+WHERE device_id = ?
+ORDER BY updated_at DESC, id DESC
+LIMIT 1`, deviceID).Scan(&op.ID, &op.DeviceID, &op.DeviceName, &op.Organization, &op.Type, &op.State, &op.Message, &op.UpdatedAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &op, nil
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -4,6 +4,8 @@ import (
 	"database/sql"
 	"testing"
 	"time"
+
+	"rtk_cloud_admin/internal/contracts"
 )
 
 func TestStoreInitializesWithSeedData(t *testing.T) {
@@ -31,6 +33,23 @@ func TestStoreInitializesWithSeedData(t *testing.T) {
 	}
 	if devices[0].Readiness == "" {
 		t.Fatalf("first device readiness is empty")
+	}
+	acmeOnline := deviceByID(t, devices, "dev-001")
+	if len(acmeOnline.SourceFacts) != 3 {
+		t.Fatalf("dev-001 source facts = %d, want 3", len(acmeOnline.SourceFacts))
+	}
+	if acmeOnline.SourceFacts[0].State != "present" || acmeOnline.SourceFacts[1].State != "present" || acmeOnline.SourceFacts[2].State != "present" {
+		t.Fatalf("dev-001 source facts = %#v", acmeOnline.SourceFacts)
+	}
+	failed := deviceByID(t, devices, "dev-004")
+	if failed.SourceFacts[1].State != "failed" {
+		t.Fatalf("dev-004 cloud activation state = %q, want failed", failed.SourceFacts[1].State)
+	}
+	if failed.SourceFacts[1].OperationID == "" {
+		t.Fatalf("dev-004 cloud activation missing operation id: %#v", failed.SourceFacts[1])
+	}
+	if failed.SourceFacts[1].ErrorCode == "" {
+		t.Fatalf("dev-004 cloud activation missing error code: %#v", failed.SourceFacts[1])
 	}
 
 	ops, err := st.ListOperations()
@@ -191,4 +210,15 @@ func TestCreateLifecycleOperationUpdatesDeviceReadiness(t *testing.T) {
 	if auditEvents[0].Target != "dev-002" {
 		t.Fatalf("audit target = %q, want dev-002", auditEvents[0].Target)
 	}
+}
+
+func deviceByID(t *testing.T, devices []contracts.Device, id string) contracts.Device {
+	t.Helper()
+	for _, device := range devices {
+		if device.ID == id {
+			return device
+		}
+	}
+	t.Fatalf("device %s not found", id)
+	return contracts.Device{}
 }

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -362,17 +362,19 @@ function DeviceDetail({ device, onAction }) {
       </div>
       <div className="source-facts">
         <h3>Source facts</h3>
-        {(device.source_facts?.length ? device.source_facts : fallbackFacts(device)).map((fact) => (
+        {(device.source_facts || []).length ? (device.source_facts || []).map((fact) => (
           <article className="source-fact" key={`${fact.layer}-${fact.state}-${fact.operation_id || ''}`}>
             <div>
               <strong>{fact.layer}</strong>
               <span>{fact.detail}</span>
+              {fact.updated_at ? <time>{fact.updated_at}</time> : null}
               {fact.error_code ? <small>{fact.error_code}</small> : null}
               {fact.operation_id ? <small>{fact.operation_id}</small> : null}
+              {fact.state === 'failed' ? <small>{fact.retryable ? 'retryable' : 'not retryable'}</small> : null}
             </div>
             <StatusBadge value={fact.state || 'missing'} />
           </article>
-        ))}
+        )) : <p>No source facts available.</p>}
       </div>
       <div className="detail-actions">
         <button onClick={() => onAction(device.id, 'provision')}>Provision device</button>
@@ -525,26 +527,6 @@ function routeFromLocation() {
   if (path === '/console/operations') return 'operations';
   if (path === '/console/audit') return 'audit';
   return 'console';
-}
-
-function fallbackFacts(device) {
-  return [
-    {
-      layer: 'account_registry',
-      state: device.id ? 'present' : 'missing',
-      detail: device.id ? 'Registry device exists in current projection.' : 'Missing registry device id.',
-    },
-    {
-      layer: 'cloud_activation',
-      state: device.video_cloud_devid ? 'present' : 'missing',
-      detail: device.video_cloud_devid ? 'Video Cloud device identity is present.' : 'Missing video_cloud_devid.',
-    },
-    {
-      layer: 'transport_online',
-      state: device.last_seen_at ? device.status : 'stale',
-      detail: device.last_seen_at ? `Last transport evidence at ${device.last_seen_at}.` : 'No recent transport evidence.',
-    },
-  ];
 }
 
 async function fetchJSON(url) {


### PR DESCRIPTION
Refs #4

Summary:
- add a backend readiness-facts package that derives layer-specific source facts from device and latest operation state
- include source_facts on demo store devices, upstream-mapped devices, and device detail responses
- surface failed, pending, missing, stale, retryable, operation_id, error_code, and updated_at data in the UI

Validation:
- go test ./...
- go build ./cmd/server
- npm run build (web)