### PR TITLE
Split admin and customer API surfaces

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -66,16 +66,21 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) routes() {
 	s.mux.HandleFunc("GET /healthz", s.health)
 	s.mux.HandleFunc("GET /api/summary", s.apiSummary)
+	s.mux.HandleFunc("GET /api/admin/summary", s.apiAdminSummary)
 	s.mux.HandleFunc("GET /api/me", s.apiMe)
 	s.mux.HandleFunc("POST /api/me/active-org", s.apiActiveOrg)
 	s.mux.HandleFunc("POST /api/auth/customer/login", s.apiCustomerLogin)
 	s.mux.HandleFunc("POST /api/auth/platform/login", s.apiPlatformLogin)
 	s.mux.HandleFunc("POST /api/auth/logout", s.apiLogout)
 	s.mux.HandleFunc("GET /api/customers", s.apiCustomers)
+	s.mux.HandleFunc("GET /api/admin/customers", s.apiAdminCustomers)
 	s.mux.HandleFunc("GET /api/devices", s.apiDevices)
+	s.mux.HandleFunc("GET /api/admin/devices", s.apiAdminDevices)
 	s.mux.HandleFunc("GET /api/devices/{id}", s.apiDevice)
 	s.mux.HandleFunc("GET /api/operations", s.apiOperations)
+	s.mux.HandleFunc("GET /api/admin/operations", s.apiAdminOperations)
 	s.mux.HandleFunc("GET /api/service-health", s.apiServiceHealth)
+	s.mux.HandleFunc("GET /api/admin/service-health", s.apiAdminServiceHealth)
 	s.mux.HandleFunc("GET /api/audit", s.apiAudit)
 	s.mux.HandleFunc("GET /api/admin/audit", s.apiAdminAudit)
 	s.mux.HandleFunc("POST /api/devices/{id}/provision", s.apiProvisionDevice)
@@ -153,7 +158,28 @@ func serveDistIndex(w http.ResponseWriter, r *http.Request) bool {
 	return true
 }
 
-func (s *Server) apiSummary(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) apiSummary(w http.ResponseWriter, r *http.Request) {
+	if session, ok := s.customerSession(r); ok {
+		summary, err := s.customerSummary(r.Context(), session)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, summary)
+		return
+	}
+	summary, err := s.store.Summary()
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, summary)
+}
+
+func (s *Server) apiAdminSummary(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
 	summary, err := s.store.Summary()
 	if err != nil {
 		writeError(w, err)
@@ -203,6 +229,10 @@ func (s *Server) apiActiveOrg(w http.ResponseWriter, r *http.Request) {
 	session, ok := s.requestSession(r)
 	if !ok {
 		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	if session.Kind != "customer" {
+		http.Error(w, "customer session required", http.StatusForbidden)
 		return
 	}
 	var body struct {
@@ -283,7 +313,12 @@ func (s *Server) apiLogout(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiDevices(w http.ResponseWriter, r *http.Request) {
-	if devices, ok := s.upstreamDevices(w, r); ok {
+	if session, ok := s.customerSession(r); ok {
+		devices, err := s.customerDevices(r.Context(), session)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 		writeJSON(w, devices)
 		return
 	}
@@ -295,8 +330,25 @@ func (s *Server) apiDevices(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, devices)
 }
 
+func (s *Server) apiAdminDevices(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
+	devices, err := s.store.ListDevices()
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, devices)
+}
+
 func (s *Server) apiDevice(w http.ResponseWriter, r *http.Request) {
-	if devices, ok := s.upstreamDevices(w, r); ok {
+	if session, ok := s.customerSession(r); ok {
+		devices, err := s.customerDevices(r.Context(), session)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 		for _, device := range devices {
 			if device.ID == r.PathValue("id") {
 				writeJSON(w, device)
@@ -319,7 +371,12 @@ func (s *Server) apiDevice(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiCustomers(w http.ResponseWriter, r *http.Request) {
-	if customers, ok := s.upstreamCustomers(w, r); ok {
+	if session, ok := s.customerSession(r); ok {
+		customers, err := s.customerCustomers(r.Context(), session)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 		writeJSON(w, customers)
 		return
 	}
@@ -331,7 +388,40 @@ func (s *Server) apiCustomers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, customers)
 }
 
-func (s *Server) apiOperations(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) apiAdminCustomers(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
+	customers, err := s.store.ListCustomers()
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, customers)
+}
+
+func (s *Server) apiOperations(w http.ResponseWriter, r *http.Request) {
+	if session, ok := s.customerSession(r); ok {
+		ops, err := s.customerOperations(r.Context(), session)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, ops)
+		return
+	}
+	ops, err := s.store.ListOperations()
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, ops)
+}
+
+func (s *Server) apiAdminOperations(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
 	ops, err := s.store.ListOperations()
 	if err != nil {
 		writeError(w, err)
@@ -341,19 +431,26 @@ func (s *Server) apiOperations(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) apiServiceHealth(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, []contracts.ServiceHealth{
-		s.upstreamHealth(r.Context(), "Account Manager", s.cfg.AccountManagerBaseURL, func(ctx context.Context) error {
-			if !s.accountClient.Enabled() {
-				return nil
-			}
-			return s.accountClient.Health(ctx)
-		}),
-		s.httpHealth(r.Context(), "Video Cloud", s.cfg.VideoCloudBaseURL),
-		{Name: "SQLite", Status: "ok", Detail: "Local console cache is available.", LastCheckedAt: time.Now().UTC().Format(time.RFC3339)},
-	})
+	writeJSON(w, s.serviceHealth(r.Context()))
 }
 
-func (s *Server) apiAudit(w http.ResponseWriter, _ *http.Request) {
+func (s *Server) apiAdminServiceHealth(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
+	writeJSON(w, s.serviceHealth(r.Context()))
+}
+
+func (s *Server) apiAudit(w http.ResponseWriter, r *http.Request) {
+	if session, ok := s.customerSession(r); ok {
+		events, err := s.customerAudit(r.Context(), session)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		writeJSON(w, events)
+		return
+	}
 	events, err := s.store.ListAuditEvents()
 	if err != nil {
 		writeError(w, err)
@@ -363,15 +460,196 @@ func (s *Server) apiAudit(w http.ResponseWriter, _ *http.Request) {
 }
 
 func (s *Server) apiAdminAudit(w http.ResponseWriter, r *http.Request) {
-	session, ok := s.requestSession(r)
-	if !ok || session.Kind != "platform_admin" {
-		http.Error(w, "platform admin authentication required", http.StatusUnauthorized)
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
 		return
 	}
-	s.apiAudit(w, r)
+	events, err := s.store.ListAuditEvents()
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, events)
+}
+
+func (s *Server) requirePlatformAdmin(w http.ResponseWriter, r *http.Request) (store.Session, bool) {
+	session, ok := s.requestSession(r)
+	if !ok {
+		http.Error(w, "platform admin authentication required", http.StatusUnauthorized)
+		return store.Session{}, false
+	}
+	if session.Kind != "platform_admin" {
+		http.Error(w, "platform admin authentication required", http.StatusForbidden)
+		return store.Session{}, false
+	}
+	return session, true
+}
+
+func (s *Server) customerSession(r *http.Request) (store.Session, bool) {
+	session, ok := s.requestSession(r)
+	if !ok || session.Kind != "customer" || !s.accountClient.Enabled() {
+		return store.Session{}, false
+	}
+	return session, true
+}
+
+func (s *Server) serviceHealth(ctx context.Context) []contracts.ServiceHealth {
+	return []contracts.ServiceHealth{
+		s.upstreamHealth(ctx, "Account Manager", s.cfg.AccountManagerBaseURL, func(ctx context.Context) error {
+			if !s.accountClient.Enabled() {
+				return nil
+			}
+			return s.accountClient.Health(ctx)
+		}),
+		s.httpHealth(ctx, "Video Cloud", s.cfg.VideoCloudBaseURL),
+		{Name: "SQLite", Status: "ok", Detail: "Local console cache is available.", LastCheckedAt: time.Now().UTC().Format(time.RFC3339)},
+	}
+}
+
+func (s *Server) customerDevices(ctx context.Context, session store.Session) ([]contracts.Device, error) {
+	org, err := s.activeCustomerOrg(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	devices, err := s.accountClient.Devices(ctx, session.AccessToken, org.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]contracts.Device, 0, len(devices))
+	for _, device := range devices {
+		out = append(out, mapUpstreamDevice(org, device))
+	}
+	return out, nil
+}
+
+func (s *Server) customerCustomers(ctx context.Context, session store.Session) ([]contracts.CustomerSummary, error) {
+	org, err := s.activeCustomerOrg(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	devices, err := s.customerDevices(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	summary := contracts.CustomerSummary{
+		OrganizationID: org.ID,
+		Organization:   org.Name,
+	}
+	for _, device := range devices {
+		summary.TotalDevices++
+		switch device.Readiness {
+		case contracts.ReadinessOnline:
+			summary.OnlineDevices++
+			summary.ActivatedDevices++
+		case contracts.ReadinessActivated:
+			summary.ActivatedDevices++
+		case contracts.ReadinessCloudActivationPending, contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending, contracts.ReadinessDeactivationPending:
+			summary.PendingDevices++
+		case contracts.ReadinessFailed:
+			summary.FailedDevices++
+		}
+		if device.LastSeenAt > summary.LastSeenAt {
+			summary.LastSeenAt = device.LastSeenAt
+		}
+	}
+	return []contracts.CustomerSummary{summary}, nil
+}
+
+func (s *Server) customerSummary(ctx context.Context, session store.Session) (contracts.Summary, error) {
+	devices, err := s.customerDevices(ctx, session)
+	if err != nil {
+		return contracts.Summary{}, err
+	}
+	summary := contracts.Summary{Customers: 1}
+	for _, device := range devices {
+		summary.TotalDevices++
+		switch device.Readiness {
+		case contracts.ReadinessOnline:
+			summary.OnlineDevices++
+			summary.ActivatedDevices++
+		case contracts.ReadinessActivated:
+			summary.ActivatedDevices++
+		case contracts.ReadinessCloudActivationPending, contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending, contracts.ReadinessDeactivationPending:
+			summary.PendingDevices++
+		case contracts.ReadinessFailed:
+			summary.FailedDevices++
+		}
+	}
+	return summary, nil
+}
+
+func (s *Server) customerOperations(ctx context.Context, session store.Session) ([]contracts.Operation, error) {
+	devices, err := s.customerDevices(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]struct{}, len(devices))
+	for _, device := range devices {
+		allowed[device.ID] = struct{}{}
+	}
+	ops, err := s.store.ListOperations()
+	if err != nil {
+		return nil, err
+	}
+	if len(allowed) == 0 {
+		return []contracts.Operation{}, nil
+	}
+	filtered := make([]contracts.Operation, 0, len(ops))
+	for _, op := range ops {
+		if _, ok := allowed[op.DeviceID]; ok {
+			filtered = append(filtered, op)
+		}
+	}
+	return filtered, nil
+}
+
+func (s *Server) customerAudit(ctx context.Context, session store.Session) ([]contracts.AuditEvent, error) {
+	devices, err := s.customerDevices(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	allowed := make(map[string]struct{}, len(devices))
+	for _, device := range devices {
+		allowed[device.ID] = struct{}{}
+	}
+	events, err := s.store.ListAuditEvents()
+	if err != nil {
+		return nil, err
+	}
+	if len(allowed) == 0 {
+		return []contracts.AuditEvent{}, nil
+	}
+	filtered := make([]contracts.AuditEvent, 0, len(events))
+	for _, event := range events {
+		if _, ok := allowed[event.Target]; ok {
+			filtered = append(filtered, event)
+		}
+	}
+	return filtered, nil
+}
+
+func (s *Server) activeCustomerOrg(ctx context.Context, session store.Session) (accountclient.Organization, error) {
+	me, err := s.accountClient.Me(ctx, session.AccessToken)
+	if err != nil {
+		return accountclient.Organization{}, err
+	}
+	if session.ActiveOrgID != "" {
+		for _, org := range me.Organizations {
+			if org.ID == session.ActiveOrgID {
+				return org, nil
+			}
+		}
+	}
+	if len(me.Organizations) > 0 {
+		return me.Organizations[0], nil
+	}
+	return accountclient.Organization{}, fmt.Errorf("no accessible organizations available")
 }
 
 func (s *Server) apiProvisionDevice(w http.ResponseWriter, r *http.Request) {
+	if session, ok := s.requestSession(r); ok && session.Kind == "platform_admin" {
+		http.Error(w, "customer session required", http.StatusForbidden)
+		return
+	}
 	if s.tryUpstreamLifecycle(w, r, "provision") {
 		return
 	}
@@ -385,6 +663,10 @@ func (s *Server) apiProvisionDevice(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiDeactivateDevice(w http.ResponseWriter, r *http.Request) {
+	if session, ok := s.requestSession(r); ok && session.Kind == "platform_admin" {
+		http.Error(w, "customer session required", http.StatusForbidden)
+		return
+	}
 	if s.tryUpstreamLifecycle(w, r, "deactivate") {
 		return
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"rtk_cloud_admin/internal/accountclient"
 	"rtk_cloud_admin/internal/config"
@@ -107,15 +108,15 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 			if r.Header.Get("Authorization") != "Bearer access" {
 				t.Fatalf("missing bearer token")
 			}
-			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
-		case "/v1/orgs":
-			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"},{"id":"org-other","name":"Other Org","role":"member"}]}`))
 		case "/v1/orgs/org-up/devices":
 			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-up","name":"edge-01","model":"RTK-CAM-X","serial_number":"UP-1","readiness":"online","status":"online","metadata":{"video_cloud_devid":"video-up"}}]}`))
+		case "/v1/orgs/org-other/devices":
+			t.Fatalf("should not request devices for non-active org")
 		case "/v1/orgs/org-up/devices/dev-up/provision":
 			_, _ = w.Write([]byte(`{"operation":{"id":"op-up","state":"published","message":"accepted"}}`))
 		default:
-			http.NotFound(w, r)
+			t.Fatalf("unexpected request path: %s", r.URL.Path)
 		}
 	}))
 	defer upstream.Close()
@@ -153,6 +154,20 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	if !strings.Contains(devices.Body.String(), "edge-01") || strings.Contains(devices.Body.String(), "cam-a-001") {
 		t.Fatalf("devices should use upstream projection, got %s", devices.Body.String())
 	}
+	summary := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/summary", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(summary, req)
+	if summary.Code != http.StatusOK {
+		t.Fatalf("summary status = %d, body=%s", summary.Code, summary.Body.String())
+	}
+	var gotSummary contracts.Summary
+	if err := json.NewDecoder(summary.Body).Decode(&gotSummary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if gotSummary.TotalDevices != 1 || gotSummary.Customers != 1 || gotSummary.OnlineDevices != 1 {
+		t.Fatalf("summary = %#v, want active-org-only counts", gotSummary)
+	}
 
 	provision := httptest.NewRecorder()
 	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-up/provision", nil)
@@ -163,6 +178,68 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	}
 	if !strings.Contains(provision.Body.String(), "op-up") {
 		t.Fatalf("provision body = %s", provision.Body.String())
+	}
+}
+
+func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	if err := st.CreateAuditEvent("demo-platform-operator", "DeviceProvisionRequested", "dev-001"); err != nil {
+		t.Fatalf("CreateAuditEvent returned error: %v", err)
+	}
+	if err := st.BootstrapPlatformAdmin("admin@example.com", "secret"); err != nil {
+		t.Fatalf("BootstrapPlatformAdmin returned error: %v", err)
+	}
+	srv := New(st)
+
+	unauth := httptest.NewRecorder()
+	srv.ServeHTTP(unauth, httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil))
+	if unauth.Code != http.StatusUnauthorized {
+		t.Fatalf("admin audit without session status = %d, want %d", unauth.Code, http.StatusUnauthorized)
+	}
+
+	customerSession, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession customer returned error: %v", err)
+	}
+
+	blocked := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: customerSession.ID})
+	srv.ServeHTTP(blocked, req)
+	if blocked.Code != http.StatusForbidden {
+		t.Fatalf("admin audit with customer session status = %d, want %d", blocked.Code, http.StatusForbidden)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/platform/login", strings.NewReader(`{"email":"admin@example.com","password":"secret"}`)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("platform login status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if len(rec.Result().Cookies()) == 0 {
+		t.Fatalf("platform login did not set session cookie")
+	}
+
+	audit := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil)
+	req.AddCookie(rec.Result().Cookies()[0])
+	srv.ServeHTTP(audit, req)
+	if audit.Code != http.StatusOK {
+		t.Fatalf("admin audit with session status = %d, want %d", audit.Code, http.StatusOK)
+	}
+	if !strings.Contains(audit.Body.String(), "DeviceProvisionRequested") {
+		t.Fatalf("admin audit body does not contain demo audit events: %s", audit.Body.String())
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -203,10 +203,21 @@ func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 	}
 	srv := New(st)
 
-	unauth := httptest.NewRecorder()
-	srv.ServeHTTP(unauth, httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil))
-	if unauth.Code != http.StatusUnauthorized {
-		t.Fatalf("admin audit without session status = %d, want %d", unauth.Code, http.StatusUnauthorized)
+	adminPaths := []string{
+		"/api/admin/summary",
+		"/api/admin/customers",
+		"/api/admin/devices",
+		"/api/admin/operations",
+		"/api/admin/service-health",
+		"/api/admin/audit",
+	}
+
+	for _, path := range adminPaths {
+		unauth := httptest.NewRecorder()
+		srv.ServeHTTP(unauth, httptest.NewRequest(http.MethodGet, path, nil))
+		if unauth.Code != http.StatusUnauthorized {
+			t.Fatalf("%s without session status = %d, want %d", path, unauth.Code, http.StatusUnauthorized)
+		}
 	}
 
 	customerSession, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
@@ -214,12 +225,14 @@ func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 		t.Fatalf("CreateSession customer returned error: %v", err)
 	}
 
-	blocked := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil)
-	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: customerSession.ID})
-	srv.ServeHTTP(blocked, req)
-	if blocked.Code != http.StatusForbidden {
-		t.Fatalf("admin audit with customer session status = %d, want %d", blocked.Code, http.StatusForbidden)
+	for _, path := range adminPaths {
+		blocked := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: customerSession.ID})
+		srv.ServeHTTP(blocked, req)
+		if blocked.Code != http.StatusForbidden {
+			t.Fatalf("%s with customer session status = %d, want %d", path, blocked.Code, http.StatusForbidden)
+		}
 	}
 
 	rec := httptest.NewRecorder()
@@ -231,13 +244,20 @@ func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 		t.Fatalf("platform login did not set session cookie")
 	}
 
+	for _, path := range adminPaths {
+		admin := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(rec.Result().Cookies()[0])
+		srv.ServeHTTP(admin, req)
+		if admin.Code != http.StatusOK {
+			t.Fatalf("%s with session status = %d, want %d", path, admin.Code, http.StatusOK)
+		}
+	}
+
 	audit := httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil)
 	req.AddCookie(rec.Result().Cookies()[0])
 	srv.ServeHTTP(audit, req)
-	if audit.Code != http.StatusOK {
-		t.Fatalf("admin audit with session status = %d, want %d", audit.Code, http.StatusOK)
-	}
 	if !strings.Contains(audit.Body.String(), "DeviceProvisionRequested") {
 		t.Fatalf("admin audit body does not contain demo audit events: %s", audit.Body.String())
 	}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -201,7 +201,7 @@ function App() {
           />
         ) : null}
         {active === 'operations' ? <Operations operations={operations} /> : null}
-        {active === 'admin' ? <PlatformAdmin summary={summary} health={health} devices={devices} customers={customers} audit={audit} me={me} onLogin={handleLogin} /> : null}
+        {active === 'admin' ? <PlatformAdmin summary={summary} health={health} devices={devices} customers={customers} operations={operations} audit={audit} me={me} onLogin={handleLogin} /> : null}
         {active === 'audit' ? <AuditLog audit={audit} /> : null}
       </main>
     </div>
@@ -439,7 +439,7 @@ function OperationList({ operations, detailed = false }) {
   );
 }
 
-function PlatformAdmin({ summary, health, devices, customers, audit, me, onLogin }) {
+function PlatformAdmin({ summary, health, devices, customers, operations, audit, me, onLogin }) {
   const customerCount = summary?.customers ?? '-';
   return (
     <>
@@ -454,6 +454,15 @@ function PlatformAdmin({ summary, health, devices, customers, audit, me, onLogin
           </div>
         </div>
         <ServiceHealth health={health} compact />
+      </section>
+      <section className="panel">
+        <div className="panel-head">
+          <div>
+            <h2>Lifecycle operations</h2>
+            <p>Cross-customer provisioning and deactivation activity.</p>
+          </div>
+        </div>
+        <OperationList operations={operations} detailed />
       </section>
       <Customers customers={customers} />
       <AuditLog audit={audit.slice(0, 5)} compact />

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -23,39 +23,53 @@ function App() {
   const [query, setQuery] = useState('');
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
   const [error, setError] = useState('');
+  const [refreshTick, setRefreshTick] = useState(0);
 
-  const loadData = () => {
+  useEffect(() => {
     let alive = true;
-    Promise.all([
-      fetchJSON('/api/me'),
-      fetchJSON('/api/summary'),
-      fetchJSON('/api/customers'),
-      fetchJSON('/api/devices'),
-      fetchJSON('/api/operations'),
-      fetchJSON('/api/service-health'),
-      fetchJSON('/api/audit'),
-    ])
-      .then(([nextMe, nextSummary, nextCustomers, nextDevices, nextOperations, nextHealth, nextAudit]) => {
+    async function loadData() {
+      setError('');
+      try {
+        const nextMe = await fetchJSON('/api/me');
         if (!alive) return;
         setMe(nextMe);
+
+        const useAdminApi = active === 'admin' && nextMe.kind === 'platform_admin';
+        if (active === 'admin' && nextMe.kind !== 'platform_admin') {
+          setSummary(null);
+          setCustomers([]);
+          setDevices([]);
+          setOperations([]);
+          setHealth([]);
+          setAudit([]);
+          return;
+        }
+
+        const prefix = useAdminApi ? '/api/admin' : '/api';
+        const [nextSummary, nextCustomers, nextDevices, nextOperations, nextHealth, nextAudit] = await Promise.all([
+          fetchJSON(`${prefix}/summary`),
+          fetchJSON(`${prefix}/customers`),
+          fetchJSON(`${prefix}/devices`),
+          fetchJSON(`${prefix}/operations`),
+          fetchJSON(`${prefix}/service-health`),
+          fetchJSON(`${prefix}/audit`),
+        ]);
+        if (!alive) return;
         setSummary(nextSummary);
         setCustomers(nextCustomers);
         setDevices(nextDevices);
         setOperations(nextOperations);
         setHealth(nextHealth);
         setAudit(nextAudit);
-      })
-      .catch((err) => {
+      } catch (err) {
         if (alive) setError(err.message);
-      });
+      }
+    }
+    loadData();
     return () => {
       alive = false;
     };
-  };
-
-  useEffect(() => {
-    return loadData();
-  }, []);
+  }, [active, refreshTick]);
 
   useEffect(() => {
     const onPopState = () => setActive(routeFromLocation());
@@ -88,7 +102,7 @@ function App() {
       setError(`${action} failed with ${response.status}`);
       return;
     }
-    loadData();
+    setRefreshTick((tick) => tick + 1);
     window.history.pushState({}, '', '/console/operations');
     setActive('operations');
   }
@@ -105,7 +119,17 @@ function App() {
       setError(`${kind} login failed with ${response.status}`);
       return;
     }
-    loadData();
+    setRefreshTick((tick) => tick + 1);
+  }
+
+  async function handleLogout() {
+    setError('');
+    const response = await fetch('/api/auth/logout', { method: 'POST' });
+    if (!response.ok) {
+      setError(`logout failed with ${response.status}`);
+      return;
+    }
+    setRefreshTick((tick) => tick + 1);
   }
 
   const filteredDevices = useMemo(() => {
@@ -158,6 +182,7 @@ function App() {
           <div className="session-strip">
             <span>{me?.authenticated ? `${me.email} / ${me.kind}` : 'Demo mode'}</span>
             <span>{me?.active_org_id || 'all orgs'}</span>
+            {me?.authenticated ? <button onClick={handleLogout}>Logout</button> : null}
           </div>
         </header>
 


### PR DESCRIPTION
Refs #3

Summary:
- add `/api/admin/*` routes for summary, customers, devices, operations, service health, and audit
- require platform admin sessions on the admin API surface
- scope customer API projections to the active customer org when Account Manager is available
- keep `/console` usable in demo/local mode and add logout handling in the React shell

Validation:
- `go test ./...`
- `npm run build`
