### PR TITLE
Harden CI smoke and cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,28 +48,34 @@ jobs:
           container_id=""
           cleanup() {
             if [ -n "$container_id" ]; then
-              docker stop "$container_id" >/dev/null 2>&1 || true
+              docker rm -f "$container_id" >/dev/null 2>&1 || true
             fi
             rm -rf "$smoke_dir"
           }
           trap cleanup EXIT
 
-          container_id="$(docker run -d --rm \
+          container_id="$(docker run -d \
+            --name rtk-cloud-admin-ci-smoke \
+            -p 127.0.0.1:18080:8080 \
             -e PORT=8080 \
             -e DATABASE_PATH=/data/ci.db \
             -v "$smoke_dir:/data" \
             rtk-cloud-admin:ci)"
 
           for _ in $(seq 1 30); do
-            if docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'; then
+            if curl -fsS http://127.0.0.1:18080/healthz | grep -qx 'ok'; then
               break
+            fi
+            if ! docker inspect -f '{{.State.Running}}' "$container_id" >/dev/null 2>&1; then
+              docker logs "$container_id" >&2 || true
+              exit 1
             fi
             sleep 1
           done
 
-          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'
-          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/api/summary | grep -q '"total_devices"'
-          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/console | grep -q 'id="root"'
+          curl -fsS http://127.0.0.1:18080/healthz | grep -qx 'ok'
+          curl -fsS http://127.0.0.1:18080/api/summary | grep -q '"total_devices"'
+          curl -fsS http://127.0.0.1:18080/console | grep -q 'id="root"'
 
       - name: Docker cleanup
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,13 @@ jobs:
 
           container_id="$(docker run -d \
             --name rtk-cloud-admin-ci-smoke \
-            -p 127.0.0.1:18080:8080 \
             -e PORT=8080 \
             -e DATABASE_PATH=/data/ci.db \
             -v "$smoke_dir:/data" \
             rtk-cloud-admin:ci)"
 
           for _ in $(seq 1 30); do
-            if curl -fsS http://127.0.0.1:18080/healthz | grep -qx 'ok'; then
+            if docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'; then
               break
             fi
             if ! docker inspect -f '{{.State.Running}}' "$container_id" >/dev/null 2>&1; then
@@ -73,9 +72,9 @@ jobs:
             sleep 1
           done
 
-          curl -fsS http://127.0.0.1:18080/healthz | grep -qx 'ok'
-          curl -fsS http://127.0.0.1:18080/api/summary | grep -q '"total_devices"'
-          curl -fsS http://127.0.0.1:18080/console | grep -q 'id="root"'
+          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'
+          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/api/summary | grep -q '"total_devices"'
+          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/console | grep -q 'id="root"'
 
       - name: Docker cleanup
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
         run: |
           set -euo pipefail
           smoke_dir="$(mktemp -d)"
+          chmod 0777 "$smoke_dir"
           container_id=""
           cleanup() {
             if [ -n "$container_id" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,39 @@ jobs:
 
       - name: Docker build
         run: docker build -t rtk-cloud-admin:ci .
+
+      - name: Container smoke
+        run: |
+          set -euo pipefail
+          smoke_dir="$(mktemp -d)"
+          container_id=""
+          cleanup() {
+            if [ -n "$container_id" ]; then
+              docker stop "$container_id" >/dev/null 2>&1 || true
+            fi
+            rm -rf "$smoke_dir"
+          }
+          trap cleanup EXIT
+
+          container_id="$(docker run -d --rm \
+            -e PORT=8080 \
+            -e DATABASE_PATH=/data/ci.db \
+            -v "$smoke_dir:/data" \
+            rtk-cloud-admin:ci)"
+
+          for _ in $(seq 1 30); do
+            if docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'; then
+              break
+            fi
+            sleep 1
+          done
+
+          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'
+          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/api/summary | grep -q '"total_devices"'
+          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/console | grep -q 'id="root"'
+
+      - name: Docker cleanup
+        if: always()
+        run: |
+          docker image rm rtk-cloud-admin:ci >/dev/null 2>&1 || true
+          docker builder prune -af >/dev/null 2>&1 || true

--- a/README.md
+++ b/README.md
@@ -165,7 +165,10 @@ Container health uses `/healthz`.
 ## CI
 
 `.github/workflows/ci.yml` checks out submodules and runs `go test ./...`,
-`go build ./cmd/server`, `npm ci`, and `npm run build`.
+`go build ./cmd/server`, `npm ci`, `npm run build`, a container smoke test, and
+Docker cache cleanup on the self-hosted `rtk-cloud-admin-ci` runner.
+
+Runner health and recovery notes live in [`docs/ci-runner.md`](docs/ci-runner.md).
 
 ## Contracts
 

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -1,0 +1,35 @@
+# CI Runner Notes
+
+The GitHub Actions workflow runs on the self-hosted `rtk-cloud-admin-ci`
+runner. The current pipeline is intentionally local-only: it builds the Go
+server, builds the React frontend, builds a Docker image, and runs container
+smoke checks against the built image.
+
+The workflow does not push images to a registry. It tags the image as
+`rtk-cloud-admin:ci` for the duration of the run and then removes the image and
+build cache so the runner disk does not grow without bound.
+
+## Quick Health Checks
+
+On the runner host, verify:
+
+- the runner service is still connected to GitHub
+- Docker is available and has free disk space
+- the last workflow run finished with the expected smoke checks
+
+Useful commands:
+
+```sh
+docker ps
+docker system df
+docker info
+```
+
+## Recovery
+
+If the runner gets stuck or disk usage climbs too high:
+
+1. Restart the runner service on `cloud-admin-ci.local`.
+2. Prune the Docker build cache with `docker builder prune -af`.
+3. Remove any stale local CI image with `docker image rm rtk-cloud-admin:ci`.
+4. Rerun the workflow from GitHub.


### PR DESCRIPTION
Refs #9

Summary:
- add a container smoke test that verifies /healthz, /api/summary, and /console from the built image
- add Docker image and build-cache cleanup so the self-hosted runner does not accumulate stale layers
- document the runner health and recovery steps in a dedicated CI runbook and link it from the README

Validation:
- go test ./...
- go build ./cmd/server
- cd web && npm ci
- cd web && npm run build
- docker build -t rtk-cloud-admin:ci .
- container smoke checks against /healthz, /api/summary, and /console
- docker image rm rtk-cloud-admin:ci
- docker builder prune -af