### PR TITLE
Expand SQLite cache and audit schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ The product and integration contracts live in the
 Implemented in this first version:
 
 - Go HTTP server using `net/http`
-- SQLite persistence for local demo/cache data
+- SQLite persistence for local demo data, upstream cache projections, settings,
+  sessions, and audit metadata
 - React frontend built with Vite
 - device fleet dashboard
 - customer overview with organization-level fleet health
@@ -140,7 +141,10 @@ plaintext credentials.
 
 SQLite schema changes are applied through versioned migrations. Existing local
 databases are upgraded in place and applied versions are stored in
-`schema_migrations`.
+`schema_migrations`. Upstream cache tables are non-authoritative mirrors of
+Account Manager and Video Cloud facts; they can be refreshed or rebuilt from the
+owning services. Local SQLite remains authoritative only for console-local
+sessions, platform admins, integration settings, and audit metadata.
 
 ## Docker
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -67,7 +67,8 @@ Runtime components:
 
 Data ownership:
 
-- SQLite is authoritative only for console-local data: platform admins, sessions, audit, settings, preferences, and cache/demo projections.
+- SQLite is authoritative only for console-local data: platform admins, sessions, audit, settings, preferences, and demo projections.
+- SQLite cache tables for upstream organizations, devices, operations, and readiness facts are non-authoritative mirrors that can be refreshed from Account Manager and Video Cloud.
 - Account Manager remains authoritative for customer users, organizations, membership, and registry devices.
 - Video Cloud remains authoritative for activation, transport, streaming, media, firmware, and device runtime facts.
 
@@ -122,7 +123,7 @@ Account Manager proxy mode:
 - `POST /api/devices/{id}/provision` calls the Account Manager provision endpoint
 - `POST /api/devices/{id}/deactivate` calls the Account Manager deactivate endpoint
 - upstream failures return a gateway error instead of silently falling back
-- attempted, completed, and failed lifecycle actions are recorded in audit
+- attempted, accepted/completed, and failed lifecycle actions are recorded in audit with actor kind, organization id, result, request id, and upstream operation id fields where available
 
 Service health:
 
@@ -183,7 +184,7 @@ Environment variables:
 ## Test Plan
 
 - Unit tests for app wiring, health endpoint, JSON API handlers, and SPA fallback.
-- Store tests for SQLite schema creation, seed data, device queries, operation queries, and audit insertion.
+- Store tests for SQLite schema creation, seed data, device queries, operation queries, audit metadata insertion, migration idempotence, and upgrade from the current v2 schema.
 - Store tests for versioned migrations, admin password verification, and session expiry.
 - App tests for customer login, upstream proxy mode, provision proxy, and platform admin route guards.
 - Frontend build verification with `npm run build`.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -511,13 +511,35 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 	} else {
 		op, err = s.accountClient.Provision(r.Context(), session.AccessToken, session.ActiveOrgID, deviceID)
 	}
-	_ = s.store.CreateAuditEvent(session.Email, operationType+".attempted", deviceID)
+	_ = s.store.CreateAuditEventWithMetadata(store.AuditEventInput{
+		Actor:          session.Email,
+		ActorKind:      session.Kind,
+		Action:         operationType + ".attempted",
+		Target:         deviceID,
+		OrganizationID: session.ActiveOrgID,
+		Result:         "attempted",
+	})
 	if err != nil {
-		_ = s.store.CreateAuditEvent(session.Email, operationType+".failed", deviceID)
+		_ = s.store.CreateAuditEventWithMetadata(store.AuditEventInput{
+			Actor:          session.Email,
+			ActorKind:      session.Kind,
+			Action:         operationType + ".failed",
+			Target:         deviceID,
+			OrganizationID: session.ActiveOrgID,
+			Result:         "failed",
+		})
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return true
 	}
-	_ = s.store.CreateAuditEvent(session.Email, operationType+".completed", deviceID)
+	_ = s.store.CreateAuditEventWithMetadata(store.AuditEventInput{
+		Actor:               session.Email,
+		ActorKind:           session.Kind,
+		Action:              operationType + ".completed",
+		Target:              deviceID,
+		OrganizationID:      session.ActiveOrgID,
+		Result:              "accepted",
+		UpstreamOperationID: op.ID,
+	})
 	writeJSON(w, contracts.Operation{
 		ID:        fallback(op.ID, fmt.Sprintf("op-%d", time.Now().UTC().UnixNano())),
 		DeviceID:  deviceID,

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -109,9 +109,14 @@ type Me struct {
 }
 
 type AuditEvent struct {
-	ID        int64  `json:"id"`
-	Actor     string `json:"actor"`
-	Action    string `json:"action"`
-	Target    string `json:"target"`
-	CreatedAt string `json:"created_at"`
+	ID                  int64  `json:"id"`
+	Actor               string `json:"actor"`
+	ActorKind           string `json:"actor_kind"`
+	Action              string `json:"action"`
+	Target              string `json:"target"`
+	OrganizationID      string `json:"organization_id,omitempty"`
+	Result              string `json:"result"`
+	RequestID           string `json:"request_id,omitempty"`
+	UpstreamOperationID string `json:"upstream_operation_id,omitempty"`
+	CreatedAt           string `json:"created_at"`
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -36,6 +36,18 @@ type PlatformAdmin struct {
 	CreatedAt string
 }
 
+type AuditEventInput struct {
+	Actor               string
+	ActorKind           string
+	Action              string
+	Target              string
+	OrganizationID      string
+	Result              string
+	RequestID           string
+	UpstreamOperationID string
+	CreatedAt           string
+}
+
 func Open(path string) (*Store, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
@@ -152,6 +164,77 @@ CREATE TABLE IF NOT EXISTS sessions (
 	expires_at TEXT NOT NULL,
 	created_at TEXT NOT NULL
 );
+`,
+	},
+	{
+		version: 3,
+		name:    "cache_settings_audit_metadata",
+		sql: `
+CREATE TABLE IF NOT EXISTS upstream_organizations (
+	id TEXT PRIMARY KEY,
+	name TEXT NOT NULL,
+	role TEXT NOT NULL,
+	source TEXT NOT NULL,
+	fetched_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS upstream_devices (
+	id TEXT PRIMARY KEY,
+	organization_id TEXT NOT NULL,
+	name TEXT NOT NULL,
+	category TEXT NOT NULL,
+	model TEXT NOT NULL,
+	serial_number TEXT NOT NULL,
+	video_cloud_devid TEXT NOT NULL,
+	status TEXT NOT NULL,
+	readiness TEXT NOT NULL,
+	last_seen_at TEXT NOT NULL,
+	source TEXT NOT NULL,
+	fetched_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS upstream_operations (
+	id TEXT PRIMARY KEY,
+	device_id TEXT NOT NULL,
+	organization_id TEXT NOT NULL,
+	type TEXT NOT NULL,
+	state TEXT NOT NULL,
+	message TEXT NOT NULL,
+	source TEXT NOT NULL,
+	fetched_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS readiness_facts (
+	id INTEGER PRIMARY KEY AUTOINCREMENT,
+	device_id TEXT NOT NULL,
+	organization_id TEXT NOT NULL,
+	layer TEXT NOT NULL,
+	state TEXT NOT NULL,
+	detail TEXT NOT NULL,
+	retryable INTEGER NOT NULL DEFAULT 0,
+	error_code TEXT NOT NULL DEFAULT '',
+	operation_id TEXT NOT NULL DEFAULT '',
+	source TEXT NOT NULL,
+	fetched_at TEXT NOT NULL,
+	updated_at TEXT NOT NULL,
+	UNIQUE(device_id, layer)
+);
+CREATE TABLE IF NOT EXISTS integration_settings (
+	key TEXT PRIMARY KEY,
+	value TEXT NOT NULL,
+	source TEXT NOT NULL,
+	updated_at TEXT NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_upstream_devices_org ON upstream_devices (organization_id, name);
+CREATE INDEX IF NOT EXISTS idx_upstream_operations_device ON upstream_operations (device_id, updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_readiness_facts_device ON readiness_facts (device_id, layer);
+ALTER TABLE audit_events ADD COLUMN actor_kind TEXT NOT NULL DEFAULT 'operator';
+ALTER TABLE audit_events ADD COLUMN organization_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE audit_events ADD COLUMN result TEXT NOT NULL DEFAULT 'accepted';
+ALTER TABLE audit_events ADD COLUMN request_id TEXT NOT NULL DEFAULT '';
+ALTER TABLE audit_events ADD COLUMN upstream_operation_id TEXT NOT NULL DEFAULT '';
+CREATE INDEX IF NOT EXISTS idx_audit_events_org_created ON audit_events (organization_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_events_upstream_operation ON audit_events (upstream_operation_id);
 `,
 	},
 }
@@ -335,7 +418,7 @@ func (s *Store) ListCustomers() ([]contracts.CustomerSummary, error) {
 
 func (s *Store) ListAuditEvents() ([]contracts.AuditEvent, error) {
 	rows, err := s.db.Query(`
-SELECT id, actor, action, target, created_at
+SELECT id, actor, actor_kind, action, target, organization_id, result, request_id, upstream_operation_id, created_at
 FROM audit_events
 ORDER BY created_at DESC, id DESC
 LIMIT 100`)
@@ -347,7 +430,7 @@ LIMIT 100`)
 	events := []contracts.AuditEvent{}
 	for rows.Next() {
 		var event contracts.AuditEvent
-		if err := rows.Scan(&event.ID, &event.Actor, &event.Action, &event.Target, &event.CreatedAt); err != nil {
+		if err := rows.Scan(&event.ID, &event.Actor, &event.ActorKind, &event.Action, &event.Target, &event.OrganizationID, &event.Result, &event.RequestID, &event.UpstreamOperationID, &event.CreatedAt); err != nil {
 			return nil, err
 		}
 		events = append(events, event)
@@ -357,16 +440,35 @@ LIMIT 100`)
 
 func (s *Store) insertAuditEvent(tx *sql.Tx, actor, action, target, createdAt string) error {
 	_, err := tx.Exec(`
-INSERT INTO audit_events (actor, action, target, created_at)
-VALUES (?, ?, ?, ?)`, actor, action, target, createdAt)
+INSERT INTO audit_events (actor, actor_kind, action, target, organization_id, result, request_id, upstream_operation_id, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, actor, "demo", action, target, "", "accepted", "", "", createdAt)
 	return err
 }
 
 func (s *Store) CreateAuditEvent(actor, action, target string) error {
-	now := time.Now().UTC().Format(time.RFC3339)
+	return s.CreateAuditEventWithMetadata(AuditEventInput{
+		Actor:     actor,
+		ActorKind: "operator",
+		Action:    action,
+		Target:    target,
+		Result:    "accepted",
+	})
+}
+
+func (s *Store) CreateAuditEventWithMetadata(input AuditEventInput) error {
+	if input.ActorKind == "" {
+		input.ActorKind = "operator"
+	}
+	if input.Result == "" {
+		input.Result = "accepted"
+	}
+	if input.CreatedAt == "" {
+		input.CreatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
 	_, err := s.db.Exec(`
-INSERT INTO audit_events (actor, action, target, created_at)
-VALUES (?, ?, ?, ?)`, actor, action, target, now)
+INSERT INTO audit_events (actor, actor_kind, action, target, organization_id, result, request_id, upstream_operation_id, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		input.Actor, input.ActorKind, input.Action, input.Target, input.OrganizationID, input.Result, input.RequestID, input.UpstreamOperationID, input.CreatedAt)
 	return err
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -92,6 +93,66 @@ func TestMigrateTracksVersionsAndIsIdempotent(t *testing.T) {
 	if len(versions) != len(migrations) {
 		t.Fatalf("versions = %#v, want %d migrations", versions, len(migrations))
 	}
+	for _, table := range []string{
+		"upstream_organizations",
+		"upstream_devices",
+		"upstream_operations",
+		"readiness_facts",
+		"integration_settings",
+	} {
+		assertTableExists(t, st, table)
+	}
+	assertColumnExists(t, st, "audit_events", "actor_kind")
+	assertColumnExists(t, st, "audit_events", "organization_id")
+	assertColumnExists(t, st, "audit_events", "result")
+	assertColumnExists(t, st, "audit_events", "request_id")
+	assertColumnExists(t, st, "audit_events", "upstream_operation_id")
+}
+
+func TestMigrateUpgradesVersionTwoSchemaWithoutDataLoss(t *testing.T) {
+	t.Parallel()
+
+	st, err := Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+
+	applyMigrationFixture(t, st, migrations[0])
+	applyMigrationFixture(t, st, migrations[1])
+	if _, err := st.db.Exec(`
+INSERT INTO devices (id, organization_id, organization, name, category, model, serial_number, video_cloud_devid, status, readiness, last_seen_at, updated_at)
+VALUES ('dev-upgrade', 'org-upgrade', 'Upgrade Org', 'camera-upgrade', 'ip_camera', 'RTK-CAM', 'SERIAL-1', 'video-upgrade', 'online', 'online', '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z');
+INSERT INTO audit_events (actor, action, target, created_at)
+VALUES ('operator@example.com', 'DeviceProvisionRequested', 'dev-upgrade', '2026-05-01T00:00:00Z');
+`); err != nil {
+		t.Fatalf("seed v2 fixture: %v", err)
+	}
+
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+
+	var deviceCount int
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM devices WHERE id = 'dev-upgrade'`).Scan(&deviceCount); err != nil {
+		t.Fatalf("count upgraded devices: %v", err)
+	}
+	if deviceCount != 1 {
+		t.Fatalf("device count = %d, want 1", deviceCount)
+	}
+
+	auditEvents, err := st.ListAuditEvents()
+	if err != nil {
+		t.Fatalf("ListAuditEvents returned error: %v", err)
+	}
+	if len(auditEvents) != 1 {
+		t.Fatalf("audit event count = %d, want 1", len(auditEvents))
+	}
+	if auditEvents[0].ActorKind != "operator" || auditEvents[0].Result != "accepted" {
+		t.Fatalf("audit defaults after upgrade = %#v", auditEvents[0])
+	}
+	assertTableExists(t, st, "upstream_devices")
+	assertTableExists(t, st, "readiness_facts")
 }
 
 func TestPlatformAdminAndSessions(t *testing.T) {
@@ -191,4 +252,110 @@ func TestCreateLifecycleOperationUpdatesDeviceReadiness(t *testing.T) {
 	if auditEvents[0].Target != "dev-002" {
 		t.Fatalf("audit target = %q, want dev-002", auditEvents[0].Target)
 	}
+	if auditEvents[0].ActorKind != "demo" {
+		t.Fatalf("audit actor kind = %q, want demo", auditEvents[0].ActorKind)
+	}
+	if auditEvents[0].Result != "accepted" {
+		t.Fatalf("audit result = %q, want accepted", auditEvents[0].Result)
+	}
+}
+
+func TestCreateAuditEventWithMetadata(t *testing.T) {
+	t.Parallel()
+
+	st, err := Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+
+	err = st.CreateAuditEventWithMetadata(AuditEventInput{
+		Actor:               "admin@example.com",
+		ActorKind:           "platform_admin",
+		Action:              "DeviceProvisionRequested.completed",
+		Target:              "dev-001",
+		OrganizationID:      "org-acme",
+		Result:              "accepted",
+		RequestID:           "req-001",
+		UpstreamOperationID: "op-upstream-001",
+		CreatedAt:           "2026-05-01T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("CreateAuditEventWithMetadata returned error: %v", err)
+	}
+
+	events, err := st.ListAuditEvents()
+	if err != nil {
+		t.Fatalf("ListAuditEvents returned error: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("audit event count = %d, want 1", len(events))
+	}
+	event := events[0]
+	if event.ActorKind != "platform_admin" || event.OrganizationID != "org-acme" || event.Result != "accepted" || event.RequestID != "req-001" || event.UpstreamOperationID != "op-upstream-001" {
+		t.Fatalf("audit metadata = %#v", event)
+	}
+}
+
+func applyMigrationFixture(t *testing.T, st *Store, migration migration) {
+	t.Helper()
+
+	if _, err := st.db.Exec(`
+CREATE TABLE IF NOT EXISTS schema_migrations (
+	version INTEGER PRIMARY KEY,
+	name TEXT NOT NULL,
+	applied_at TEXT NOT NULL
+);`); err != nil {
+		t.Fatalf("create schema_migrations: %v", err)
+	}
+	if _, err := st.db.Exec(migration.sql); err != nil {
+		t.Fatalf("apply migration %d fixture: %v", migration.version, err)
+	}
+	if _, err := st.db.Exec(`INSERT INTO schema_migrations (version, name, applied_at) VALUES (?, ?, ?)`, migration.version, migration.name, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		t.Fatalf("record migration %d fixture: %v", migration.version, err)
+	}
+}
+
+func assertTableExists(t *testing.T, st *Store, table string) {
+	t.Helper()
+
+	var count int
+	if err := st.db.QueryRow(`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table).Scan(&count); err != nil {
+		t.Fatalf("lookup table %s: %v", table, err)
+	}
+	if count != 1 {
+		t.Fatalf("table %s count = %d, want 1", table, count)
+	}
+}
+
+func assertColumnExists(t *testing.T, st *Store, table, column string) {
+	t.Helper()
+
+	rows, err := st.db.Query(fmt.Sprintf(`PRAGMA table_info(%s)`, table))
+	if err != nil {
+		t.Fatalf("pragma table_info(%s): %v", table, err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var cid int
+		var name, dataType string
+		var notNull int
+		var defaultValue any
+		var pk int
+		if err := rows.Scan(&cid, &name, &dataType, &notNull, &defaultValue, &pk); err != nil {
+			t.Fatalf("scan table_info(%s): %v", table, err)
+		}
+		if name == column {
+			return
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("table_info(%s) rows: %v", table, err)
+	}
+	t.Fatalf("column %s.%s not found", table, column)
 }

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -452,6 +452,7 @@ function AuditLog({ audit, compact = false }) {
               <div>
                 <strong>{event.action}</strong>
                 <span>{event.actor} / {event.target}</span>
+                <small>{[event.actor_kind, event.organization_id, event.result, event.upstream_operation_id].filter(Boolean).join(' / ')}</small>
               </div>
               <time>{event.created_at}</time>
             </article>


### PR DESCRIPTION
Refs #8

Summary:
- add v3 SQLite migrations for upstream organization/device/operation/readiness cache tables and integration settings
- expand audit rows with actor kind, organization id, result, request id, and upstream operation id while keeping existing audit writes compatible
- record richer upstream lifecycle audit metadata and surface it in the audit list
- document non-authoritative cache ownership and migration behavior

Validation:
- go test ./internal/store ./internal/app ./internal/contracts
- go test ./...
- go build ./cmd/server
- npm run build (web)