### PR TITLE
Add admin console table controls

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import './styles.css';
 
+const DEFAULT_PAGE_SIZE = 8;
+
 const navItems = [
   { id: 'console', label: 'Customer Fleet', path: '/console' },
   { id: 'customers', label: 'Customers', path: '/console/customers' },
@@ -20,7 +22,6 @@ function App() {
   const [operations, setOperations] = useState([]);
   const [health, setHealth] = useState([]);
   const [audit, setAudit] = useState([]);
-  const [query, setQuery] = useState('');
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
   const [error, setError] = useState('');
 
@@ -108,21 +109,10 @@ function App() {
     loadData();
   }
 
-  const filteredDevices = useMemo(() => {
-    const needle = query.trim().toLowerCase();
-    if (!needle) return devices;
-    return devices.filter((device) =>
-      [device.name, device.organization, device.model, device.serial_number, device.readiness]
-        .join(' ')
-        .toLowerCase()
-        .includes(needle),
-    );
-  }, [devices, query]);
-
   const selectedDevice = useMemo(() => {
     if (!devices.length) return null;
-    return devices.find((device) => device.id === selectedDeviceId) || filteredDevices[0] || devices[0];
-  }, [devices, filteredDevices, selectedDeviceId]);
+    return devices.find((device) => device.id === selectedDeviceId) || devices[0];
+  }, [devices, selectedDeviceId]);
 
   return (
     <div className="app-shell">
@@ -167,10 +157,8 @@ function App() {
         {active === 'customers' ? <Customers customers={customers} /> : null}
         {active === 'devices' ? (
           <Devices
-            devices={filteredDevices}
-            query={query}
+            devices={devices}
             selectedDevice={selectedDevice}
-            setQuery={setQuery}
             setSelectedDeviceId={selectDevice}
             onAction={runDeviceAction}
           />
@@ -231,7 +219,48 @@ function MetricGrid({ summary }) {
   );
 }
 
-function Devices({ devices, query, selectedDevice, setQuery, setSelectedDeviceId, onAction }) {
+function Devices({ devices, selectedDevice, setSelectedDeviceId, onAction }) {
+  const columns = useMemo(() => [
+    {
+      key: 'name',
+      label: 'Device',
+      value: (device) => device.name,
+      render: (device) => (
+        <>
+          <strong>{device.name}</strong>
+          <small>{device.serial_number}</small>
+        </>
+      ),
+    },
+    { key: 'organization', label: 'Customer', value: (device) => device.organization },
+    { key: 'model', label: 'Model', value: (device) => device.model },
+    { key: 'video_cloud_devid', label: 'Video ID', value: (device) => device.video_cloud_devid },
+    {
+      key: 'readiness',
+      label: 'Readiness',
+      value: (device) => device.readiness,
+      render: (device) => <StatusBadge value={device.readiness} />,
+    },
+    {
+      key: 'last_seen_at',
+      label: 'Last seen',
+      value: (device) => device.last_seen_at,
+      render: (device) => device.last_seen_at || 'No transport evidence',
+    },
+    {
+      key: 'actions',
+      label: 'Actions',
+      sortable: false,
+      value: () => '',
+      render: (device) => (
+        <div className="row-actions">
+          <button onClick={(event) => runRowAction(event, onAction, device.id, 'provision')}>Provision</button>
+          <button onClick={(event) => runRowAction(event, onAction, device.id, 'deactivate')}>Deactivate</button>
+        </div>
+      ),
+    },
+  ], [onAction]);
+
   return (
     <section className="device-workspace">
       <div className="panel device-table-panel">
@@ -240,46 +269,17 @@ function Devices({ devices, query, selectedDevice, setQuery, setSelectedDeviceId
             <h2>Device fleet</h2>
             <p>Registry, video identity, readiness, and last known status.</p>
           </div>
-          <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search devices" />
         </div>
-        <table>
-          <thead>
-            <tr>
-              <th>Device</th>
-              <th>Customer</th>
-              <th>Model</th>
-              <th>Video ID</th>
-              <th>Readiness</th>
-              <th>Last seen</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {devices.map((device) => (
-              <tr
-                key={device.id}
-                className={selectedDevice?.id === device.id ? 'selected-row' : ''}
-                onClick={() => setSelectedDeviceId(device.id)}
-              >
-                <td>
-                  <strong>{device.name}</strong>
-                  <small>{device.serial_number}</small>
-                </td>
-                <td>{device.organization}</td>
-                <td>{device.model}</td>
-                <td>{device.video_cloud_devid}</td>
-                <td><StatusBadge value={device.readiness} /></td>
-                <td>{device.last_seen_at || 'No transport evidence'}</td>
-                <td>
-                  <div className="row-actions">
-                    <button onClick={(event) => runRowAction(event, onAction, device.id, 'provision')}>Provision</button>
-                    <button onClick={(event) => runRowAction(event, onAction, device.id, 'deactivate')}>Deactivate</button>
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <DataTable
+          columns={columns}
+          rows={devices}
+          rowKey={(device) => device.id}
+          initialSortKey="name"
+          searchPlaceholder="Search devices"
+          emptyLabel="No devices match the current filter."
+          rowClassName={(device) => selectedDevice?.id === device.id ? 'selected-row' : ''}
+          onRowClick={(device) => setSelectedDeviceId(device.id)}
+        />
       </div>
       <DeviceDetail device={selectedDevice} onAction={onAction} />
     </section>
@@ -287,6 +287,31 @@ function Devices({ devices, query, selectedDevice, setQuery, setSelectedDeviceId
 }
 
 function Customers({ customers }) {
+  const columns = useMemo(() => [
+    {
+      key: 'organization',
+      label: 'Customer',
+      value: (customer) => customer.organization,
+      render: (customer) => (
+        <>
+          <strong>{customer.organization}</strong>
+          <small>{customer.organization_id}</small>
+        </>
+      ),
+    },
+    { key: 'total_devices', label: 'Total', value: (customer) => customer.total_devices },
+    { key: 'online_devices', label: 'Online', value: (customer) => customer.online_devices },
+    { key: 'activated_devices', label: 'Activated', value: (customer) => customer.activated_devices },
+    { key: 'pending_devices', label: 'Pending', value: (customer) => customer.pending_devices },
+    { key: 'failed_devices', label: 'Failed', value: (customer) => customer.failed_devices },
+    {
+      key: 'last_seen_at',
+      label: 'Last seen',
+      value: (customer) => customer.last_seen_at,
+      render: (customer) => customer.last_seen_at || 'No activity',
+    },
+  ], []);
+
   return (
     <section className="panel">
       <div className="panel-head">
@@ -295,35 +320,15 @@ function Customers({ customers }) {
           <p>Organization-level fleet health aggregated from cached device projections.</p>
         </div>
       </div>
-      <table className="customers-table">
-        <thead>
-          <tr>
-            <th>Customer</th>
-            <th>Total</th>
-            <th>Online</th>
-            <th>Activated</th>
-            <th>Pending</th>
-            <th>Failed</th>
-            <th>Last seen</th>
-          </tr>
-        </thead>
-        <tbody>
-          {customers.map((customer) => (
-            <tr key={customer.organization_id}>
-              <td>
-                <strong>{customer.organization}</strong>
-                <small>{customer.organization_id}</small>
-              </td>
-              <td>{customer.total_devices}</td>
-              <td>{customer.online_devices}</td>
-              <td>{customer.activated_devices}</td>
-              <td>{customer.pending_devices}</td>
-              <td>{customer.failed_devices}</td>
-              <td>{customer.last_seen_at || 'No activity'}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <DataTable
+        columns={columns}
+        rows={customers}
+        rowKey={(customer) => customer.organization_id}
+        initialSortKey="organization"
+        searchPlaceholder="Search customers"
+        emptyLabel="No customers match the current filter."
+        tableClassName="customers-table"
+      />
     </section>
   );
 }
@@ -383,6 +388,20 @@ function DeviceDetail({ device, onAction }) {
 }
 
 function Operations({ operations }) {
+  const columns = useMemo(() => [
+    { key: 'type', label: 'Type', value: (operation) => operation.type },
+    { key: 'organization', label: 'Customer', value: (operation) => operation.organization },
+    { key: 'device_name', label: 'Device', value: (operation) => operation.device_name },
+    {
+      key: 'state',
+      label: 'State',
+      value: (operation) => operation.state,
+      render: (operation) => <StatusBadge value={operation.state} />,
+    },
+    { key: 'updated_at', label: 'Updated', value: (operation) => operation.updated_at },
+    { key: 'message', label: 'Message', value: (operation) => operation.message },
+  ], []);
+
   return (
     <section className="panel">
       <div className="panel-head">
@@ -391,7 +410,16 @@ function Operations({ operations }) {
           <p>Provisioning and deactivation commands projected from account/video contracts.</p>
         </div>
       </div>
-      <OperationList operations={operations} detailed />
+      <DataTable
+        columns={columns}
+        rows={operations}
+        rowKey={(operation) => operation.id}
+        initialSortKey="updated_at"
+        initialDirection="desc"
+        searchPlaceholder="Search operations"
+        emptyLabel="No operations match the current filter."
+        tableClassName="operations-table"
+      />
     </section>
   );
 }
@@ -437,6 +465,13 @@ function PlatformAdmin({ summary, health, devices, customers, audit, me, onLogin
 }
 
 function AuditLog({ audit, compact = false }) {
+  const columns = useMemo(() => [
+    { key: 'action', label: 'Action', value: (event) => event.action },
+    { key: 'actor', label: 'Actor', value: (event) => event.actor },
+    { key: 'target', label: 'Target', value: (event) => event.target },
+    { key: 'created_at', label: 'Created', value: (event) => event.created_at },
+  ], []);
+
   return (
     <section className="panel">
       <div className="panel-head">
@@ -445,7 +480,7 @@ function AuditLog({ audit, compact = false }) {
           <p>Local operator actions captured by the Go BFF.</p>
         </div>
       </div>
-      {audit.length ? (
+      {compact && audit.length ? (
         <div className="audit-list">
           {audit.map((event) => (
             <article className="audit-event" key={event.id}>
@@ -457,11 +492,159 @@ function AuditLog({ audit, compact = false }) {
             </article>
           ))}
         </div>
-      ) : (
+      ) : compact ? (
         <p>No audit events yet.</p>
+      ) : (
+        <DataTable
+          columns={columns}
+          rows={audit}
+          rowKey={(event) => event.id}
+          initialSortKey="created_at"
+          initialDirection="desc"
+          searchPlaceholder="Search audit"
+          emptyLabel="No audit events match the current filter."
+          tableClassName="audit-table"
+        />
       )}
     </section>
   );
+}
+
+function DataTable({
+  columns,
+  rows,
+  rowKey,
+  initialSortKey,
+  initialDirection = 'asc',
+  searchPlaceholder,
+  emptyLabel,
+  rowClassName,
+  onRowClick,
+  tableClassName = '',
+  pageSize = DEFAULT_PAGE_SIZE,
+}) {
+  const {
+    filter,
+    setFilter,
+    sort,
+    requestSort,
+    visibleRows,
+    totalRows,
+    page,
+    maxPage,
+    setPage,
+  } = useTableControls(rows, columns, initialSortKey, initialDirection, pageSize);
+
+  return (
+    <>
+      <div className="table-toolbar">
+        <input value={filter} onChange={(event) => setFilter(event.target.value)} placeholder={searchPlaceholder} />
+        <span>{totalRows} of {rows.length}</span>
+      </div>
+      <table className={tableClassName}>
+        <thead>
+          <tr>
+            {columns.map((column) => (
+              <th key={column.key}>
+                {column.sortable === false ? (
+                  column.label
+                ) : (
+                  <button className="sort-button" onClick={() => requestSort(column.key)}>
+                    <span>{column.label}</span>
+                    <span aria-hidden="true">{sort.key === column.key ? (sort.direction === 'asc' ? '^' : 'v') : '-'}</span>
+                  </button>
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {visibleRows.map((row) => (
+            <tr
+              key={rowKey(row)}
+              className={[onRowClick ? 'clickable-row' : '', rowClassName ? rowClassName(row) : ''].filter(Boolean).join(' ')}
+              onClick={onRowClick ? () => onRowClick(row) : undefined}
+            >
+              {columns.map((column) => (
+                <td key={column.key}>{column.render ? column.render(row) : displayValue(column.value(row))}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {!visibleRows.length ? <p className="empty-table">{emptyLabel}</p> : null}
+      <div className="pagination">
+        <button disabled={page <= 1} onClick={() => setPage(page - 1)}>Previous</button>
+        <span>Page {page} of {maxPage}</span>
+        <button disabled={page >= maxPage} onClick={() => setPage(page + 1)}>Next</button>
+      </div>
+    </>
+  );
+}
+
+function useTableControls(rows, columns, initialSortKey, initialDirection, pageSize) {
+  const [filter, setFilter] = useState('');
+  const [sort, setSort] = useState({ key: initialSortKey, direction: initialDirection });
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    setPage(1);
+  }, [filter, rows]);
+
+  const filteredRows = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) return rows;
+    return rows.filter((row) =>
+      columns.some((column) => String(column.value(row) ?? '').toLowerCase().includes(needle)),
+    );
+  }, [columns, filter, rows]);
+
+  const sortedRows = useMemo(() => {
+    const column = columns.find((candidate) => candidate.key === sort.key) || columns[0];
+    const direction = sort.direction === 'desc' ? -1 : 1;
+    return [...filteredRows].sort((left, right) => compareValues(column.value(left), column.value(right)) * direction);
+  }, [columns, filteredRows, sort]);
+
+  const maxPage = Math.max(1, Math.ceil(sortedRows.length / pageSize));
+  const safePage = Math.min(page, maxPage);
+  const start = (safePage - 1) * pageSize;
+  const visibleRows = sortedRows.slice(start, start + pageSize);
+
+  useEffect(() => {
+    if (page !== safePage) setPage(safePage);
+  }, [page, safePage]);
+
+  function requestSort(key) {
+    setSort((current) => ({
+      key,
+      direction: current.key === key && current.direction === 'asc' ? 'desc' : 'asc',
+    }));
+  }
+
+  return {
+    filter,
+    setFilter,
+    sort,
+    requestSort,
+    visibleRows,
+    totalRows: sortedRows.length,
+    page: safePage,
+    maxPage,
+    setPage,
+  };
+}
+
+function compareValues(left, right) {
+  if (left === right) return 0;
+  if (left === null || left === undefined || left === '') return 1;
+  if (right === null || right === undefined || right === '') return -1;
+  if (typeof left === 'number' && typeof right === 'number') return left - right;
+  return String(left).localeCompare(String(right), undefined, { numeric: true, sensitivity: 'base' });
+}
+
+function displayValue(value) {
+  if (value === null || value === undefined || value === '') return '-';
+  return value;
 }
 
 function ServiceHealth({ health, compact = false }) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -461,14 +461,33 @@ input:focus {
   outline: none;
 }
 
+.table-toolbar {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  margin: 14px 0;
+}
+
+.table-toolbar span {
+  color: var(--muted);
+  flex: 0 0 auto;
+  font-size: 13px;
+}
+
 table {
   border-collapse: collapse;
   min-width: 980px;
   width: 100%;
 }
 
-.customers-table {
+.customers-table,
+.audit-table {
   min-width: 760px;
+}
+
+.operations-table {
+  min-width: 900px;
 }
 
 th,
@@ -479,7 +498,7 @@ td {
   vertical-align: top;
 }
 
-tbody tr {
+tbody tr.clickable-row {
   cursor: pointer;
 }
 
@@ -492,6 +511,63 @@ th {
   color: var(--muted);
   font-size: 12px;
   text-transform: uppercase;
+}
+
+.sort-button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  font: inherit;
+  gap: 6px;
+  padding: 0;
+  text-align: left;
+  text-transform: inherit;
+}
+
+.sort-button:hover {
+  color: var(--brand-dark);
+}
+
+.sort-button span:last-child {
+  color: var(--brand);
+  font-size: 11px;
+  min-width: 10px;
+}
+
+.empty-table {
+  margin: 14px 0 0;
+}
+
+.pagination {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+  margin-top: 14px;
+}
+
+.pagination button {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--brand-dark);
+  cursor: pointer;
+  min-height: 34px;
+  padding: 6px 12px;
+}
+
+.pagination button:disabled {
+  color: var(--muted);
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.pagination span {
+  color: var(--muted);
+  font-size: 13px;
 }
 
 .operation-list {
@@ -644,5 +720,12 @@ th {
 
   input {
     min-width: 100%;
+  }
+
+  .table-toolbar,
+  .pagination {
+    align-items: stretch;
+    display: grid;
+    justify-content: stretch;
   }
 }


### PR DESCRIPTION
Refs #7

Summary:
- add reusable React table controls for search, sortable columns, result counts, and pagination
- apply the table controls to customers, devices, operations, and full audit views
- preserve URL-selected device detail behavior while moving device filtering into the table itself

Validation:
- npm ci
- npm run build
- go test ./...
- go build ./cmd/server
- live smoke: /healthz, /api/devices, and /console/devices?device=dev-001 on PORT=18087