### PR TITLE
Add Video Cloud health client

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,6 +16,7 @@ import (
 	"rtk_cloud_admin/internal/config"
 	"rtk_cloud_admin/internal/contracts"
 	"rtk_cloud_admin/internal/store"
+	"rtk_cloud_admin/internal/videoclient"
 )
 
 type Server struct {
@@ -23,11 +24,13 @@ type Server struct {
 	mux           *http.ServeMux
 	cfg           config.Config
 	accountClient *accountclient.Client
+	videoClient   *videoclient.Client
 }
 
 type Options struct {
 	Config        config.Config
 	AccountClient *accountclient.Client
+	VideoClient   *videoclient.Client
 }
 
 func NewTestServer(dbPath string) (*Server, error) {
@@ -54,7 +57,10 @@ func NewWithOptions(st *store.Store, opts Options) *Server {
 	if opts.AccountClient == nil && opts.Config.AccountManagerBaseURL != "" {
 		opts.AccountClient = accountclient.New(opts.Config.AccountManagerBaseURL)
 	}
-	s := &Server{store: st, mux: http.NewServeMux(), cfg: opts.Config, accountClient: opts.AccountClient}
+	if opts.VideoClient == nil && opts.Config.VideoCloudBaseURL != "" {
+		opts.VideoClient = videoclient.New(opts.Config.VideoCloudBaseURL)
+	}
+	s := &Server{store: st, mux: http.NewServeMux(), cfg: opts.Config, accountClient: opts.AccountClient, videoClient: opts.VideoClient}
 	s.routes()
 	return s
 }
@@ -348,7 +354,12 @@ func (s *Server) apiServiceHealth(w http.ResponseWriter, r *http.Request) {
 			}
 			return s.accountClient.Health(ctx)
 		}),
-		s.httpHealth(r.Context(), "Video Cloud", s.cfg.VideoCloudBaseURL),
+		s.upstreamHealth(r.Context(), "Video Cloud", s.cfg.VideoCloudBaseURL, func(ctx context.Context) error {
+			if !s.videoClient.Enabled() {
+				return nil
+			}
+			return s.videoClient.Health(ctx)
+		}),
 		{Name: "SQLite", Status: "ok", Detail: "Local console cache is available.", LastCheckedAt: time.Now().UTC().Format(time.RFC3339)},
 	})
 }
@@ -607,22 +618,4 @@ func (s *Server) upstreamHealth(ctx context.Context, name, baseURL string, check
 		detail = err.Error()
 	}
 	return contracts.ServiceHealth{Name: name, Status: status, Detail: detail, LatencyMillis: time.Since(start).Milliseconds(), LastCheckedAt: time.Now().UTC().Format(time.RFC3339)}
-}
-
-func (s *Server) httpHealth(ctx context.Context, name, baseURL string) contracts.ServiceHealth {
-	return s.upstreamHealth(ctx, name, baseURL, func(ctx context.Context) error {
-		req, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(baseURL, "/")+"/healthz", nil)
-		if err != nil {
-			return err
-		}
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return err
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-			return fmt.Errorf("status %d", resp.StatusCode)
-		}
-		return nil
-	})
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -96,6 +97,52 @@ func TestCustomersAPI(t *testing.T) {
 	}
 }
 
+func TestServiceHealthReportsVideoCloudOK(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			t.Fatalf("path = %q, want /healthz", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q, want empty", got)
+		}
+		_, _ = w.Write([]byte("ok\n"))
+	}))
+	defer upstream.Close()
+
+	srv := newSeededTestServer(t, config.Config{VideoCloudBaseURL: upstream.URL})
+	health := requestJSON[[]contracts.ServiceHealth](t, srv, http.MethodGet, "/api/service-health", nil)
+
+	video := findServiceHealth(t, health, "Video Cloud")
+	if video.Status != "ok" {
+		t.Fatalf("Video Cloud status = %q, want ok; detail=%s", video.Status, video.Detail)
+	}
+	if video.LastCheckedAt == "" {
+		t.Fatal("Video Cloud last_checked_at is empty")
+	}
+}
+
+func TestServiceHealthReportsVideoCloudDown(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "failed", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	srv := newSeededTestServer(t, config.Config{VideoCloudBaseURL: upstream.URL})
+	health := requestJSON[[]contracts.ServiceHealth](t, srv, http.MethodGet, "/api/service-health", nil)
+
+	video := findServiceHealth(t, health, "Video Cloud")
+	if video.Status != "down" {
+		t.Fatalf("Video Cloud status = %q, want down", video.Status)
+	}
+	if !strings.Contains(video.Detail, "status 500") {
+		t.Fatalf("Video Cloud detail = %q, want status 500", video.Detail)
+	}
+}
+
 func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	t.Parallel()
 
@@ -164,6 +211,50 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	if !strings.Contains(provision.Body.String(), "op-up") {
 		t.Fatalf("provision body = %s", provision.Body.String())
 	}
+}
+
+func newSeededTestServer(t *testing.T, cfg config.Config) *Server {
+	t.Helper()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	t.Cleanup(func() { _ = st.Close() })
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	return NewWithOptions(st, Options{Config: cfg})
+}
+
+func requestJSON[T any](t *testing.T, srv *Server, method string, path string, body io.Reader) T {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(method, path, body))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("%s %s status = %d, want %d; body=%s", method, path, rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var out T
+	if err := json.NewDecoder(rec.Body).Decode(&out); err != nil {
+		t.Fatalf("decode %s %s: %v", method, path, err)
+	}
+	return out
+}
+
+func findServiceHealth(t *testing.T, health []contracts.ServiceHealth, name string) contracts.ServiceHealth {
+	t.Helper()
+
+	for _, item := range health {
+		if item.Name == name {
+			return item
+		}
+	}
+	t.Fatalf("service health %q not found in %#v", name, health)
+	return contracts.ServiceHealth{}
 }
 
 func TestPlatformAdminLogin(t *testing.T) {

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -1,0 +1,47 @@
+package videoclient
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func New(baseURL string) *Client {
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Timeout: 6 * time.Second,
+		},
+	}
+}
+
+func (c *Client) Enabled() bool {
+	return c != nil && c.baseURL != ""
+}
+
+func (c *Client) Health(ctx context.Context) error {
+	if !c.Enabled() {
+		return fmt.Errorf("video cloud base URL is not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/healthz", nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json, text/plain")
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return nil
+}

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -1,0 +1,70 @@
+package videoclient
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHealthSucceedsWithoutBearerToken(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/healthz" {
+			t.Fatalf("path = %q, want /healthz", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q, want empty", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+	}))
+	defer upstream.Close()
+
+	if err := New(upstream.URL + "/").Health(t.Context()); err != nil {
+		t.Fatalf("Health returned error: %v", err)
+	}
+}
+
+func TestHealthRejectsUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "failed", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	if err := New(upstream.URL).Health(t.Context()); err == nil {
+		t.Fatal("expected health error")
+	}
+}
+
+func TestHealthHonorsContextTimeout(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+	defer cancel()
+	if err := New(upstream.URL).Health(ctx); err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+func TestDisabledClient(t *testing.T) {
+	t.Parallel()
+
+	client := New("")
+	if client.Enabled() {
+		t.Fatal("client should be disabled")
+	}
+	if err := client.Health(t.Context()); err == nil {
+		t.Fatal("expected disabled health error")
+	}
+}


### PR DESCRIPTION
Refs #5

Summary:
- add `internal/videoclient` as the first Video Cloud integration client
- wire the client into `/api/service-health` through app options instead of the generic HTTP helper
- add health tests for reachable, 500/down, timeout, disabled config, and no bearer-token leakage

Validation:
- go test ./internal/videoclient ./internal/app -count=1
- go test ./...
- go build ./cmd/server
- git diff --check

Notes:
- This is the first #5 slice for configured Video Cloud health. Readiness fact merging remains for a follow-up once the source-facts PR path is settled.