### PR TITLE
Persist upstream lifecycle operations and deduplicate requests

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -503,10 +503,27 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 	}
 	deviceID := r.PathValue("id")
 	operationType := "DeviceProvisionRequested"
+	if existing, ok, err := s.store.GetOpenLifecycleOperation(deviceID, operationType); err == nil && ok {
+		_ = s.store.CreateAuditEvent(session.Email, operationType+".idempotent", deviceID)
+		writeJSON(w, existing)
+		return true
+	} else if err != nil {
+		writeError(w, err)
+		return true
+	}
+
 	var op accountclient.Operation
 	var err error
 	if action == "deactivate" {
 		operationType = "DeviceDeactivateRequested"
+		if existing, ok, err := s.store.GetOpenLifecycleOperation(deviceID, operationType); err == nil && ok {
+			_ = s.store.CreateAuditEvent(session.Email, operationType+".idempotent", deviceID)
+			writeJSON(w, existing)
+			return true
+		} else if err != nil {
+			writeError(w, err)
+			return true
+		}
 		op, err = s.accountClient.Deactivate(r.Context(), session.AccessToken, session.ActiveOrgID, deviceID)
 	} else {
 		op, err = s.accountClient.Provision(r.Context(), session.AccessToken, session.ActiveOrgID, deviceID)
@@ -514,18 +531,32 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 	_ = s.store.CreateAuditEvent(session.Email, operationType+".attempted", deviceID)
 	if err != nil {
 		_ = s.store.CreateAuditEvent(session.Email, operationType+".failed", deviceID)
+		_, _ = s.store.CreateFailedUpstreamLifecycleOperation(deviceID, operationType, session.Email, err.Error())
+		if strings.Contains(err.Error(), "returned 409") {
+			if existing, ok, lookupErr := s.store.GetOpenLifecycleOperation(deviceID, operationType); lookupErr == nil && ok {
+				_ = s.store.CreateAuditEvent(session.Email, operationType+".idempotent", deviceID)
+				writeJSON(w, existing)
+				return true
+			}
+		}
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return true
 	}
-	_ = s.store.CreateAuditEvent(session.Email, operationType+".completed", deviceID)
-	writeJSON(w, contracts.Operation{
-		ID:        fallback(op.ID, fmt.Sprintf("op-%d", time.Now().UTC().UnixNano())),
-		DeviceID:  deviceID,
-		Type:      operationType,
-		State:     mapOperationState(op.State),
-		Message:   fallback(op.Message, "Accepted by Account Manager."),
-		UpdatedAt: fallback(op.UpdatedAt, time.Now().UTC().Format(time.RFC3339)),
-	})
+
+	operationState := mapOperationState(op.State)
+	upstreamID := fallback(op.ID, fmt.Sprintf("op-%d", time.Now().UTC().UnixNano()))
+	upstreamMessage := fallback(op.Message, "Accepted by Account Manager.")
+	recorded, err := s.store.CreateUpstreamLifecycleOperation(deviceID, operationType, session.Email, upstreamID, string(operationState), upstreamMessage)
+	if err != nil {
+		writeError(w, err)
+		return true
+	}
+	if recorded.Message == "" {
+		recorded.Message = upstreamMessage
+	}
+	recorded.Message = upstreamMessage
+	recorded.UpdatedAt = fallback(op.UpdatedAt, recorded.UpdatedAt)
+	writeJSON(w, recorded)
 	return true
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,13 +4,12 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
-	"testing"
-
 	"rtk_cloud_admin/internal/accountclient"
 	"rtk_cloud_admin/internal/config"
 	"rtk_cloud_admin/internal/contracts"
 	"rtk_cloud_admin/internal/store"
+	"strings"
+	"testing"
 )
 
 func TestServerHealthAndHomeRedirect(t *testing.T) {
@@ -111,8 +110,10 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 		case "/v1/orgs":
 			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
 		case "/v1/orgs/org-up/devices":
-			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-up","name":"edge-01","model":"RTK-CAM-X","serial_number":"UP-1","readiness":"online","status":"online","metadata":{"video_cloud_devid":"video-up"}}]}`))
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"activated","status":"offline","metadata":{"video_cloud_devid":"device-2"}}]}`))
 		case "/v1/orgs/org-up/devices/dev-up/provision":
+			fallthrough
+		case "/v1/orgs/org-up/devices/dev-002/provision":
 			_, _ = w.Write([]byte(`{"operation":{"id":"op-up","state":"published","message":"accepted"}}`))
 		default:
 			http.NotFound(w, r)
@@ -164,6 +165,187 @@ func TestCustomerLoginAndUpstreamProxyMode(t *testing.T) {
 	if !strings.Contains(provision.Body.String(), "op-up") {
 		t.Fatalf("provision body = %s", provision.Body.String())
 	}
+}
+
+func TestCustomerUpstreamLifecycleIsIdempotentAndDurable(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/login":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs":
+			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs/org-up/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"activated","status":"offline","metadata":{"video_cloud_devid":"device-2"}}]}`))
+		case "/v1/orgs/org-up/devices/dev-up/provision":
+			fallthrough
+		case "/v1/orgs/org-up/devices/dev-002/provision":
+			callCount++
+			_, _ = w.Write([]byte(`{"operation":{"id":"op-up","state":"published","message":"accepted"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	login := httptest.NewRecorder()
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	if login.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
+	}
+	cookie := login.Result().Cookies()[0]
+
+	first := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/provision", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(first, req)
+	if first.Code != http.StatusOK {
+		t.Fatalf("first provision status = %d, body=%s", first.Code, first.Body.String())
+	}
+
+	second := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/provision", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(second, req)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second provision status = %d, body=%s", second.Code, second.Body.String())
+	}
+	if callCount != 1 {
+		t.Fatalf("provision upstream call count = %d, want 1", callCount)
+	}
+
+	var firstOp contracts.Operation
+	if err := json.NewDecoder(first.Body).Decode(&firstOp); err != nil {
+		t.Fatalf("decode first op: %v", err)
+	}
+	var secondOp contracts.Operation
+	if err := json.NewDecoder(second.Body).Decode(&secondOp); err != nil {
+		t.Fatalf("decode second op: %v", err)
+	}
+	if firstOp.UpstreamOperationID != "op-up" {
+		t.Fatalf("first upstream id = %q, want op-up", firstOp.UpstreamOperationID)
+	}
+	if secondOp.ID != firstOp.ID {
+		t.Fatalf("expected idempotent operation id=%q, got %q", firstOp.ID, secondOp.ID)
+	}
+
+	ops := httptest.NewRecorder()
+	srv.ServeHTTP(ops, httptest.NewRequest(http.MethodGet, "/api/operations", nil))
+	var list []contracts.Operation
+	if err := json.NewDecoder(ops.Body).Decode(&list); err != nil {
+		t.Fatalf("decode operations: %v", err)
+	}
+	if len(list) == 0 {
+		t.Fatalf("operations list should not be empty")
+	}
+}
+
+func TestCustomerUpstreamLifecycleFailurePersistsFailedOperation(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/login":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs":
+			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs/org-up/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"activated","status":"offline","metadata":{"video_cloud_devid":"device-2"}}]}`))
+		case "/v1/orgs/org-up/devices/dev-up/provision":
+			fallthrough
+		case "/v1/orgs/org-up/devices/dev-002/provision":
+			http.Error(w, "downstream failure", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	login := httptest.NewRecorder()
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	if login.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
+	}
+	cookie := login.Result().Cookies()[0]
+
+	provision := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/provision", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(provision, req)
+	if provision.Code != http.StatusBadGateway {
+		t.Fatalf("provision status = %d, body=%s", provision.Code, provision.Body.String())
+	}
+
+	ops := httptest.NewRecorder()
+	srv.ServeHTTP(ops, httptest.NewRequest(http.MethodGet, "/api/operations", nil))
+	var operations []contracts.Operation
+	if err := json.NewDecoder(ops.Body).Decode(&operations); err != nil {
+		t.Fatalf("decode operations: %v", err)
+	}
+	hasFailed := false
+	for _, op := range operations {
+		if op.Type == "DeviceProvisionRequested" && op.State == contracts.OperationFailed {
+			hasFailed = true
+		}
+	}
+	if !hasFailed {
+		t.Fatalf("expected failed operation projection after upstream failure")
+	}
+
+	audit := httptest.NewRecorder()
+	srv.ServeHTTP(audit, httptest.NewRequest(http.MethodGet, "/api/audit", nil))
+	var events []contracts.AuditEvent
+	if err := json.NewDecoder(audit.Body).Decode(&events); err != nil {
+		t.Fatalf("decode audit events: %v", err)
+	}
+	hasFailedAudit := false
+	for _, event := range events {
+		if event.Action == "DeviceProvisionRequested.failed" {
+			hasFailedAudit = true
+		}
+	}
+	if !hasFailedAudit {
+		t.Fatalf("expected DeviceProvisionRequested.failed audit event")
+	}
+
 }
 
 func TestPlatformAdminLogin(t *testing.T) {

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -52,14 +52,16 @@ type SourceFact struct {
 }
 
 type Operation struct {
-	ID           string         `json:"id"`
-	DeviceID     string         `json:"device_id"`
-	DeviceName   string         `json:"device_name"`
-	Organization string         `json:"organization"`
-	Type         string         `json:"type"`
-	State        OperationState `json:"state"`
-	Message      string         `json:"message"`
-	UpdatedAt    string         `json:"updated_at"`
+	ID                  string         `json:"id"`
+	DeviceID            string         `json:"device_id"`
+	DeviceName          string         `json:"device_name"`
+	Organization        string         `json:"organization"`
+	Type                string         `json:"type"`
+	State               OperationState `json:"state"`
+	UpstreamOperationID string         `json:"upstream_operation_id,omitempty"`
+	UpstreamState       string         `json:"upstream_state,omitempty"`
+	Message             string         `json:"message"`
+	UpdatedAt           string         `json:"updated_at"`
 }
 
 type Summary struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -151,8 +151,16 @@ CREATE TABLE IF NOT EXISTS sessions (
 	active_org_id TEXT NOT NULL,
 	expires_at TEXT NOT NULL,
 	created_at TEXT NOT NULL
-);
-`,
+	);
+	`,
+	},
+	{
+		version: 3,
+		name:    "operations_upstream_projection",
+		sql: `
+	ALTER TABLE operations ADD COLUMN upstream_operation_id TEXT;
+	ALTER TABLE operations ADD COLUMN upstream_state TEXT;
+	`,
 	},
 }
 
@@ -196,9 +204,9 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 	}
 	for _, op := range operations {
 		if _, err := s.db.Exec(`
-INSERT OR IGNORE INTO operations (id, device_id, device_name, organization, type, state, message, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-			op.ID, op.DeviceID, op.DeviceName, op.Organization, op.Type, string(op.State), op.Message, op.UpdatedAt); err != nil {
+	INSERT OR IGNORE INTO operations (id, device_id, device_name, organization, type, state, message, updated_at, upstream_operation_id, upstream_state)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			op.ID, op.DeviceID, op.DeviceName, op.Organization, op.Type, string(op.State), op.Message, op.UpdatedAt, "", ""); err != nil {
 			return err
 		}
 	}
@@ -237,9 +245,9 @@ WHERE id = ?`, id).Scan(&d.ID, &d.OrganizationID, &d.Organization, &d.Name, &d.C
 
 func (s *Store) ListOperations() ([]contracts.Operation, error) {
 	rows, err := s.db.Query(`
-SELECT id, device_id, device_name, organization, type, state, message, updated_at
-FROM operations
-ORDER BY updated_at DESC, id`)
+	SELECT id, device_id, device_name, organization, type, state, message, updated_at, upstream_operation_id, upstream_state
+	FROM operations
+	ORDER BY updated_at DESC, id`)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +256,7 @@ ORDER BY updated_at DESC, id`)
 	var ops []contracts.Operation
 	for rows.Next() {
 		var op contracts.Operation
-		if err := rows.Scan(&op.ID, &op.DeviceID, &op.DeviceName, &op.Organization, &op.Type, &op.State, &op.Message, &op.UpdatedAt); err != nil {
+		if err := rows.Scan(&op.ID, &op.DeviceID, &op.DeviceName, &op.Organization, &op.Type, &op.State, &op.Message, &op.UpdatedAt, &op.UpstreamOperationID, &op.UpstreamState); err != nil {
 			return nil, err
 		}
 		ops = append(ops, op)
@@ -470,6 +478,37 @@ func randomHex(bytesLen int) string {
 }
 
 func (s *Store) CreateLifecycleOperation(deviceID, operationType string) (contracts.Operation, error) {
+	return s.createLifecycleOperation(deviceID, operationType, "demo-platform-operator", operationType, "", "", "Published lifecycle command to account.video.commands demo queue", true)
+}
+
+func (s *Store) CreateUpstreamLifecycleOperation(deviceID, operationType, actor, upstreamOperationID, upstreamState, message string) (contracts.Operation, error) {
+	return s.createLifecycleOperation(deviceID, operationType, actor, operationType+".completed", upstreamOperationID, upstreamState, message, true)
+}
+
+func (s *Store) CreateFailedUpstreamLifecycleOperation(deviceID, operationType, actor, message string) (contracts.Operation, error) {
+	return s.createLifecycleOperation(deviceID, operationType, actor, operationType+".failed", "", string(contracts.OperationFailed), message, false)
+}
+
+func (s *Store) GetOpenLifecycleOperation(deviceID, operationType string) (contracts.Operation, bool, error) {
+	var op contracts.Operation
+	err := s.db.QueryRow(`
+	SELECT id, device_id, device_name, organization, type, state, message, updated_at, upstream_operation_id, upstream_state
+	FROM operations
+	WHERE device_id = ? AND type = ? AND state != ?
+	ORDER BY updated_at DESC, id DESC
+	LIMIT 1`, deviceID, operationType, string(contracts.OperationSucceeded)).Scan(
+		&op.ID, &op.DeviceID, &op.DeviceName, &op.Organization, &op.Type, &op.State, &op.Message, &op.UpdatedAt, &op.UpstreamOperationID, &op.UpstreamState,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return contracts.Operation{}, false, nil
+		}
+		return contracts.Operation{}, false, err
+	}
+	return op, true, nil
+}
+
+func (s *Store) createLifecycleOperation(deviceID, operationType, actor, auditAction, upstreamOperationID, upstreamState, message string, updateReadiness bool) (contracts.Operation, error) {
 	device, err := s.GetDevice(deviceID)
 	if err != nil {
 		return contracts.Operation{}, err
@@ -477,21 +516,46 @@ func (s *Store) CreateLifecycleOperation(deviceID, operationType string) (contra
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	nextReadiness := contracts.ReadinessCloudActivationPending
-	message := "Published lifecycle command to account.video.commands demo queue"
+	operationState := mapOperationState(upstreamState)
 	if operationType == "DeviceDeactivateRequested" {
 		nextReadiness = contracts.ReadinessDeactivationPending
-		message = "Published deactivation command to account.video.commands demo queue"
+	}
+	if message == "" {
+		message = "Accepted by Account Manager."
+	}
+	if operationState == contracts.OperationFailed {
+		updateReadiness = false
+	}
+	if operationType == "DeviceProvisionRequested" && operationState == contracts.OperationSucceeded {
+		nextReadiness = contracts.ReadinessActivated
+	}
+	if operationType == "DeviceDeactivateRequested" && operationState == contracts.OperationSucceeded {
+		nextReadiness = contracts.ReadinessDeactivated
 	}
 
 	op := contracts.Operation{
-		ID:           fmt.Sprintf("op-%d", time.Now().UTC().UnixNano()),
-		DeviceID:     device.ID,
-		DeviceName:   device.Name,
-		Organization: device.Organization,
-		Type:         operationType,
-		State:        contracts.OperationPublished,
-		Message:      message,
-		UpdatedAt:    now,
+		ID:                  fallback(fmt.Sprintf("op-%d", time.Now().UTC().UnixNano()), ""),
+		DeviceID:            device.ID,
+		DeviceName:          device.Name,
+		Organization:        device.Organization,
+		Type:                operationType,
+		State:               operationState,
+		Message:             message,
+		UpstreamOperationID: upstreamOperationID,
+		UpstreamState:       upstreamState,
+		UpdatedAt:           now,
+	}
+	if op.ID == "" {
+		op.ID = fmt.Sprintf("op-%d", time.Now().UTC().UnixNano())
+	}
+	if upstreamOperationID != "" {
+		op.ID = upstreamOperationID
+	}
+	if op.State == "" {
+		op.State = contracts.OperationPublished
+	}
+	if op.UpdatedAt == "" {
+		op.UpdatedAt = now
 	}
 
 	tx, err := s.db.Begin()
@@ -501,19 +565,39 @@ func (s *Store) CreateLifecycleOperation(deviceID, operationType string) (contra
 	defer tx.Rollback()
 
 	if _, err := tx.Exec(`
-INSERT INTO operations (id, device_id, device_name, organization, type, state, message, updated_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		op.ID, op.DeviceID, op.DeviceName, op.Organization, op.Type, string(op.State), op.Message, op.UpdatedAt); err != nil {
+	INSERT INTO operations (id, device_id, device_name, organization, type, state, message, updated_at, upstream_operation_id, upstream_state)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		op.ID, op.DeviceID, op.DeviceName, op.Organization, op.Type, string(op.State), op.Message, op.UpdatedAt, op.UpstreamOperationID, op.UpstreamState); err != nil {
 		return contracts.Operation{}, err
 	}
-	if _, err := tx.Exec(`UPDATE devices SET readiness = ?, updated_at = ? WHERE id = ?`, string(nextReadiness), now, device.ID); err != nil {
-		return contracts.Operation{}, err
+	if updateReadiness {
+		if _, err := tx.Exec(`UPDATE devices SET readiness = ?, updated_at = ? WHERE id = ?`, string(nextReadiness), now, device.ID); err != nil {
+			return contracts.Operation{}, err
+		}
 	}
-	if err := s.insertAuditEvent(tx, "demo-platform-operator", operationType, device.ID, now); err != nil {
-		return contracts.Operation{}, err
+	if actor != "" {
+		if err := s.insertAuditEvent(tx, actor, auditAction, device.ID, now); err != nil {
+			return contracts.Operation{}, err
+		}
 	}
 	if err := tx.Commit(); err != nil {
 		return contracts.Operation{}, err
 	}
 	return op, nil
+}
+
+func mapOperationState(state string) contracts.OperationState {
+	switch contracts.OperationState(state) {
+	case contracts.OperationPending, contracts.OperationPublished, contracts.OperationSucceeded, contracts.OperationFailed, contracts.OperationRetrying, contracts.OperationDeadLettered:
+		return contracts.OperationState(state)
+	default:
+		return contracts.OperationPublished
+	}
+}
+
+func fallback(value, fallbackValue string) string {
+	if value != "" {
+		return value
+	}
+	return fallbackValue
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"strings"
 	"testing"
 	"time"
 )
@@ -190,5 +191,74 @@ func TestCreateLifecycleOperationUpdatesDeviceReadiness(t *testing.T) {
 	}
 	if auditEvents[0].Target != "dev-002" {
 		t.Fatalf("audit target = %q, want dev-002", auditEvents[0].Target)
+	}
+}
+
+func TestGetOpenLifecycleOperation(t *testing.T) {
+	t.Parallel()
+
+	st, err := Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	op, found, err := st.GetOpenLifecycleOperation("dev-004", "DeviceProvisionRequested")
+	if err != nil {
+		t.Fatalf("GetOpenLifecycleOperation returned error: %v", err)
+	}
+	if !found {
+		t.Fatalf("expected open operation for dev-004")
+	}
+	if op.UpstreamState != "" {
+		t.Fatalf("upstream state = %q, want empty", op.UpstreamState)
+	}
+}
+
+func TestCreateUpstreamLifecycleOperationPersistsProjection(t *testing.T) {
+	t.Parallel()
+
+	st, err := Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	recorded, err := st.CreateUpstreamLifecycleOperation("dev-002", "DeviceProvisionRequested", "user@example.com", "up-op-1", "published", "accepted")
+	if err != nil {
+		t.Fatalf("CreateUpstreamLifecycleOperation returned error: %v", err)
+	}
+	if recorded.ID != "up-op-1" {
+		t.Fatalf("recorded id = %q, want up-op-1", recorded.ID)
+	}
+	if recorded.UpstreamOperationID != "up-op-1" {
+		t.Fatalf("upstream id = %q, want up-op-1", recorded.UpstreamOperationID)
+	}
+	if recorded.UpstreamState != "published" {
+		t.Fatalf("upstream state = %q, want published", recorded.UpstreamState)
+	}
+
+	open, found, err := st.GetOpenLifecycleOperation("dev-002", "DeviceProvisionRequested")
+	if err != nil {
+		t.Fatalf("GetOpenLifecycleOperation returned error: %v", err)
+	}
+	if !found || open.ID != recorded.ID {
+		t.Fatalf("expected open operation to match recorded, found=%v open=%#v", found, open)
+	}
+
+	if !strings.Contains(recorded.Message, "accepted") {
+		t.Fatalf("message = %q", recorded.Message)
 	}
 }


### PR DESCRIPTION
## Summary
- Added upstream operation projection columns on SQLite operations table (migration v3).
- Extended \/api\/operations payload with upstream_operation_id/upstream_state.
- Added Store helpers to retrieve open lifecycle operations and create durable upstream failed/success projections.
- Updated upstream lifecycle handler to be idempotent (repeat calls reuse open operation), always write audit + failed operation projection on upstream errors.
- Added tests for upstream idempotency and failure persistence, plus store coverage for new projection methods.

## Issue
- closes #6