### PR TITLE
[codex] Harden customer account manager error handling

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -169,7 +169,7 @@ func (s *Server) apiSummary(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		summary, err := s.customerSummary(r.Context(), session)
 		if err != nil {
-			s.writeCustomerError(w, err)
+			s.writeCustomerErrorForSession(w, session.ID, err)
 			return
 		}
 		writeJSON(w, summary)
@@ -367,7 +367,7 @@ func (s *Server) apiDevices(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		devices, err := s.customerDevices(r.Context(), session)
 		if err != nil {
-			s.writeCustomerError(w, err)
+			s.writeCustomerErrorForSession(w, session.ID, err)
 			return
 		}
 		writeJSON(w, devices)
@@ -397,7 +397,7 @@ func (s *Server) apiDevice(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		devices, err := s.customerDevices(r.Context(), session)
 		if err != nil {
-			s.writeCustomerError(w, err)
+			s.writeCustomerErrorForSession(w, session.ID, err)
 			return
 		}
 		for _, device := range devices {
@@ -425,7 +425,7 @@ func (s *Server) apiCustomers(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		customers, err := s.customerCustomers(r.Context(), session)
 		if err != nil {
-			s.writeCustomerError(w, err)
+			s.writeCustomerErrorForSession(w, session.ID, err)
 			return
 		}
 		writeJSON(w, customers)
@@ -455,7 +455,7 @@ func (s *Server) apiOperations(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		ops, err := s.customerOperations(r.Context(), session)
 		if err != nil {
-			s.writeCustomerError(w, err)
+			s.writeCustomerErrorForSession(w, session.ID, err)
 			return
 		}
 		writeJSON(w, ops)
@@ -496,7 +496,7 @@ func (s *Server) apiAudit(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		events, err := s.customerAudit(r.Context(), session)
 		if err != nil {
-			s.writeCustomerError(w, err)
+			s.writeCustomerErrorForSession(w, session.ID, err)
 			return
 		}
 		writeJSON(w, events)
@@ -869,6 +869,13 @@ func customerUpstreamStatus(err error) (int, bool) {
 		return http.StatusGatewayTimeout, true
 	}
 	return 0, false
+}
+
+func (s *Server) writeCustomerErrorForSession(w http.ResponseWriter, sessionID string, err error) {
+	if errors.Is(err, errCustomerSessionInvalid) {
+		s.invalidateCustomerSession(w, sessionID)
+	}
+	s.writeCustomerError(w, err)
 }
 
 func (s *Server) writeCustomerError(w http.ResponseWriter, err error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -169,7 +169,7 @@ func (s *Server) apiSummary(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		summary, err := s.customerSummary(r.Context(), session)
 		if err != nil {
-			writeError(w, err)
+			s.writeCustomerError(w, err)
 			return
 		}
 		writeJSON(w, summary)
@@ -302,6 +302,14 @@ func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
 	}
 	login, err := s.accountClient.Login(r.Context(), body.Email, body.Password)
 	if err != nil {
+		if status, ok := customerUpstreamStatus(err); ok {
+			if status == http.StatusUnauthorized {
+				http.Error(w, "invalid credentials", http.StatusUnauthorized)
+				return
+			}
+			s.writeCustomerError(w, err)
+			return
+		}
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)
 		return
 	}
@@ -359,7 +367,7 @@ func (s *Server) apiDevices(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		devices, err := s.customerDevices(r.Context(), session)
 		if err != nil {
-			writeError(w, err)
+			s.writeCustomerError(w, err)
 			return
 		}
 		writeJSON(w, devices)
@@ -389,7 +397,7 @@ func (s *Server) apiDevice(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		devices, err := s.customerDevices(r.Context(), session)
 		if err != nil {
-			writeError(w, err)
+			s.writeCustomerError(w, err)
 			return
 		}
 		for _, device := range devices {
@@ -417,7 +425,7 @@ func (s *Server) apiCustomers(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		customers, err := s.customerCustomers(r.Context(), session)
 		if err != nil {
-			writeError(w, err)
+			s.writeCustomerError(w, err)
 			return
 		}
 		writeJSON(w, customers)
@@ -447,7 +455,7 @@ func (s *Server) apiOperations(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		ops, err := s.customerOperations(r.Context(), session)
 		if err != nil {
-			writeError(w, err)
+			s.writeCustomerError(w, err)
 			return
 		}
 		writeJSON(w, ops)
@@ -488,7 +496,7 @@ func (s *Server) apiAudit(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		events, err := s.customerAudit(r.Context(), session)
 		if err != nil {
-			writeError(w, err)
+			s.writeCustomerError(w, err)
 			return
 		}
 		writeJSON(w, events)
@@ -549,13 +557,21 @@ func (s *Server) serviceHealth(ctx context.Context) []contracts.ServiceHealth {
 }
 
 func (s *Server) customerDevices(ctx context.Context, session store.Session) ([]contracts.Device, error) {
-	org, err := s.activeCustomerOrg(ctx, session)
+	org, tokens, err := s.activeCustomerOrg(ctx, session)
 	if err != nil {
 		return nil, err
 	}
-	devices, err := s.accountClient.Devices(ctx, session.AccessToken, org.ID)
+	var devices []accountclient.Device
+	tokens, err = s.customerCall(ctx, tokens, func(token string) error {
+		var callErr error
+		devices, callErr = s.accountClient.Devices(ctx, token, org.ID)
+		return callErr
+	})
 	if err != nil {
 		return nil, err
+	}
+	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 	}
 	out := make([]contracts.Device, 0, len(devices))
 	for _, device := range devices {
@@ -565,7 +581,7 @@ func (s *Server) customerDevices(ctx context.Context, session store.Session) ([]
 }
 
 func (s *Server) customerCustomers(ctx context.Context, session store.Session) ([]contracts.CustomerSummary, error) {
-	org, err := s.activeCustomerOrg(ctx, session)
+	org, _, err := s.activeCustomerOrg(ctx, session)
 	if err != nil {
 		return nil, err
 	}
@@ -670,22 +686,35 @@ func (s *Server) customerAudit(ctx context.Context, session store.Session) ([]co
 	return filtered, nil
 }
 
-func (s *Server) activeCustomerOrg(ctx context.Context, session store.Session) (accountclient.Organization, error) {
-	me, err := s.accountClient.Me(ctx, session.AccessToken)
+func (s *Server) activeCustomerOrg(ctx context.Context, session store.Session) (accountclient.Organization, accountclient.Tokens, error) {
+	tokens := accountclient.Tokens{
+		AccessToken:  session.AccessToken,
+		RefreshToken: session.RefreshToken,
+	}
+	var me accountclient.MeResult
+	nextTokens, err := s.customerCall(ctx, tokens, func(token string) error {
+		var callErr error
+		me, callErr = s.accountClient.Me(ctx, token)
+		return callErr
+	})
 	if err != nil {
-		return accountclient.Organization{}, err
+		return accountclient.Organization{}, accountclient.Tokens{}, err
+	}
+	if nextTokens.AccessToken != session.AccessToken || nextTokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, nextTokens.AccessToken, nextTokens.RefreshToken, tokenTTL(nextTokens))
 	}
 	if session.ActiveOrgID != "" {
 		for _, org := range me.Organizations {
 			if org.ID == session.ActiveOrgID {
-				return org, nil
+				return org, nextTokens, nil
 			}
 		}
+		return accountclient.Organization{}, nextTokens, errCustomerActiveOrgInvalid
 	}
 	if len(me.Organizations) > 0 {
-		return me.Organizations[0], nil
+		return me.Organizations[0], nextTokens, nil
 	}
-	return accountclient.Organization{}, fmt.Errorf("no accessible organizations available")
+	return accountclient.Organization{}, accountclient.Tokens{}, fmt.Errorf("no accessible organizations available")
 }
 
 func (s *Server) apiProvisionDevice(w http.ResponseWriter, r *http.Request) {
@@ -754,6 +783,7 @@ func tokenTTL(tokens accountclient.Tokens) time.Duration {
 }
 
 var errCustomerSessionInvalid = errors.New("customer session is invalid")
+var errCustomerActiveOrgInvalid = errors.New("active organization is not part of the current customer memberships")
 
 func (s *Server) invalidateCustomerSession(w http.ResponseWriter, sessionID string) {
 	_ = s.store.DeleteSession(sessionID)
@@ -844,6 +874,10 @@ func customerUpstreamStatus(err error) (int, bool) {
 func (s *Server) writeCustomerError(w http.ResponseWriter, err error) {
 	if errors.Is(err, errCustomerSessionInvalid) {
 		http.Error(w, "customer session expired; please sign in again", http.StatusUnauthorized)
+		return
+	}
+	if errors.Is(err, errCustomerActiveOrgInvalid) {
+		http.Error(w, err.Error(), http.StatusForbidden)
 		return
 	}
 	if status, ok := customerUpstreamStatus(err); ok {
@@ -1181,6 +1215,27 @@ func fallback(value, fallbackValue string) string {
 		return value
 	}
 	return fallbackValue
+}
+
+func (s *Server) httpHealth(ctx context.Context, name, baseURL string) contracts.ServiceHealth {
+	return s.upstreamHealth(ctx, name, baseURL, func(ctx context.Context) error {
+		if baseURL == "" {
+			return nil
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/healthz", nil)
+		if err != nil {
+			return err
+		}
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return err
+		}
+		_ = res.Body.Close()
+		if res.StatusCode != http.StatusOK {
+			return fmt.Errorf("unexpected status %d", res.StatusCode)
+		}
+		return nil
+	})
 }
 
 func (s *Server) upstreamHealth(ctx context.Context, name, baseURL string, check func(context.Context) error) contracts.ServiceHealth {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3,8 +3,8 @@ package app
 import (
 	"database/sql"
 	"encoding/json"
-	"io"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"rtk_cloud_admin/internal/accountclient"
@@ -180,6 +180,8 @@ func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 		case "/v1/orgs/org-up/devices/dev-002/provision":
 			_, _ = w.Write([]byte(`{"operation":{"id":"op-up","state":"published","message":"accepted"}}`))
 		case "/v1/orgs/org-up/devices/dev-up/deactivate":
+			fallthrough
+		case "/v1/orgs/org-up/devices/dev-002/deactivate":
 			if r.Header.Get("Authorization") != "Bearer refreshed-access" {
 				http.Error(w, "unexpected bearer token", http.StatusUnauthorized)
 				return
@@ -262,7 +264,7 @@ func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 	if devices.Code != http.StatusOK {
 		t.Fatalf("devices status = %d, body=%s", devices.Code, devices.Body.String())
 	}
-	if !strings.Contains(devices.Body.String(), "edge-01") || strings.Contains(devices.Body.String(), "cam-a-001") {
+	if !strings.Contains(devices.Body.String(), "dev-002") || strings.Contains(devices.Body.String(), "cam-a-001") {
 		t.Fatalf("devices should use upstream projection, got %s", devices.Body.String())
 	}
 	if !strings.Contains(devices.Body.String(), "source_facts") {
@@ -270,7 +272,7 @@ func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 	}
 
 	provision := httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-up/provision", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/provision", nil)
 	req.AddCookie(cookie)
 	srv.ServeHTTP(provision, req)
 	if provision.Code != http.StatusOK {
@@ -281,7 +283,7 @@ func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 	}
 
 	deactivate := httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-up/deactivate", nil)
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/deactivate", nil)
 	req.AddCookie(cookie)
 	srv.ServeHTTP(deactivate, req)
 	if deactivate.Code != http.StatusOK {
@@ -448,6 +450,171 @@ func TestCustomerMePersistsRotatedTokensOnRetryFailure(t *testing.T) {
 	}
 	if updated.AccessToken != "refreshed-access" || updated.RefreshToken != "refresh-2" {
 		t.Fatalf("session tokens = %#v, want refreshed tokens", updated)
+	}
+}
+
+func TestCustomerLoginMapsUpstreamFailures(t *testing.T) {
+	t.Parallel()
+
+	t.Run("unauthorized", func(t *testing.T) {
+		t.Parallel()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "invalid credentials", http.StatusUnauthorized)
+		}))
+		defer upstream.Close()
+
+		st, err := store.Open(t.TempDir() + "/admin.db")
+		if err != nil {
+			t.Fatalf("Open returned error: %v", err)
+		}
+		defer st.Close()
+		if err := st.Migrate(); err != nil {
+			t.Fatalf("Migrate returned error: %v", err)
+		}
+		srv := NewWithOptions(st, Options{
+			Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+			AccountClient: accountclient.New(upstream.URL),
+		})
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusUnauthorized {
+			t.Fatalf("login status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("server error", func(t *testing.T) {
+		t.Parallel()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "upstream failure", http.StatusInternalServerError)
+		}))
+		defer upstream.Close()
+
+		st, err := store.Open(t.TempDir() + "/admin.db")
+		if err != nil {
+			t.Fatalf("Open returned error: %v", err)
+		}
+		defer st.Close()
+		if err := st.Migrate(); err != nil {
+			t.Fatalf("Migrate returned error: %v", err)
+		}
+		srv := NewWithOptions(st, Options{
+			Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+			AccountClient: accountclient.New(upstream.URL),
+		})
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusBadGateway {
+			t.Fatalf("login status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "Account Manager request failed") {
+			t.Fatalf("login body = %s", rec.Body.String())
+		}
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		t.Parallel()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(200 * time.Millisecond)
+			_, _ = w.Write([]byte("too slow"))
+		}))
+		defer upstream.Close()
+
+		st, err := store.Open(t.TempDir() + "/admin.db")
+		if err != nil {
+			t.Fatalf("Open returned error: %v", err)
+		}
+		defer st.Close()
+		if err := st.Migrate(); err != nil {
+			t.Fatalf("Migrate returned error: %v", err)
+		}
+		srv := NewWithOptions(st, Options{
+			Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+			AccountClient: accountclient.NewWithHTTPClient(upstream.URL, &http.Client{Timeout: 40 * time.Millisecond}),
+		})
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusGatewayTimeout {
+			t.Fatalf("login status = %d, body=%s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func TestCustomerDevicesRefreshesExpiredAccessAndRejectsInvalidActiveOrg(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			switch r.Header.Get("Authorization") {
+			case "Bearer access":
+				http.Error(w, "expired", http.StatusUnauthorized)
+			case "Bearer refreshed-access":
+				_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+			default:
+				http.Error(w, fmt.Sprintf("unexpected bearer token %q", r.Header.Get("Authorization")), http.StatusUnauthorized)
+			}
+		case "/v1/auth/refresh":
+			_, _ = w.Write([]byte(`{"tokens":{"access_token":"refreshed-access","refresh_token":"refresh-2","expires_in":1800}}`))
+		case "/v1/orgs/org-up/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-up","name":"cam-up","readiness":"activated","status":"offline","metadata":{"video_cloud_devid":"device-up"}}]}`))
+		default:
+			http.Error(w, "unexpected request", http.StatusNotFound)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+	session, err := st.CreateSession("customer", "u1", "user@example.com", "access", "refresh", "org-up", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	reqCookie := &http.Cookie{Name: "rtk_admin_session", Value: session.ID}
+
+	devices := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	req.AddCookie(reqCookie)
+	srv.ServeHTTP(devices, req)
+	if devices.Code != http.StatusOK {
+		t.Fatalf("devices status = %d, body=%s", devices.Code, devices.Body.String())
+	}
+	updated, err := st.GetSession(session.ID)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if updated.AccessToken != "refreshed-access" || updated.RefreshToken != "refresh-2" {
+		t.Fatalf("session tokens = %#v, want refreshed tokens", updated)
+	}
+
+	badOrgSession, err := st.CreateSession("customer", "u1", "user@example.com", "access", "refresh-2", "org-bad", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	bad := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: badOrgSession.ID})
+	srv.ServeHTTP(bad, req)
+	if bad.Code != http.StatusForbidden {
+		t.Fatalf("bad active org status = %d, body=%s", bad.Code, bad.Body.String())
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -397,6 +397,55 @@ func TestCustomerSessionInvalidRefreshClearsStoredSession(t *testing.T) {
 	}
 }
 
+func TestCustomerDevicesInvalidSessionRefreshClearsStoredSession(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			if r.Header.Get("Authorization") == "Bearer expired-access" {
+				http.Error(w, "expired", http.StatusUnauthorized)
+				return
+			}
+			http.NotFound(w, r)
+		case "/v1/auth/refresh":
+			http.Error(w, "refresh expired", http.StatusUnauthorized)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u1", "user@example.com", "expired-access", "refresh-1", "org-up", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("devices status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+
+	if _, err := st.GetSession(session.ID); err != sql.ErrNoRows {
+		t.Fatalf("session should be cleared, got %v", err)
+	}
+}
+
 func TestCustomerMePersistsRotatedTokensOnRetryFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -176,7 +176,7 @@ CREATE TABLE IF NOT EXISTS sessions (
 	`,
 	},
 	{
-		version: 3,
+		version: 4,
 		name:    "cache_settings_audit_metadata",
 		sql: `
 CREATE TABLE IF NOT EXISTS upstream_organizations (


### PR DESCRIPTION
## Summary
- Map customer-facing upstream failures in account-manager proxy APIs to deterministic HTTP responses via `writeCustomerError`.
- Update login path to return `401 invalid credentials` only for upstream 401, otherwise map upstream 502/504 etc consistently.
- Make customer org resolution refresh tokens when needed and persist rotated tokens.
- Add robust handling for stale/invalid `ActiveOrgID` in session (`403` with explicit message).
- Strengthen `/api/devices` to refresh tokens before calling account-manager and persist refreshed session tokens.
- Add regression tests for upstream failure mapping, token refresh flow, and invalid active-org enforcement.
