### PR TITLE
[codex] Improve CI smoke readiness and runner recovery hygiene

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,11 +39,21 @@ jobs:
         run: npm run build
 
       - name: Docker build
-        run: docker build -t rtk-cloud-admin:ci .
+        id: docker_build
+        run: |
+          image_tag="rtk-cloud-admin:${GITHUB_SHA}"
+          docker build -t "${image_tag}" -t rtk-cloud-admin:ci .
+          echo "ci_image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Container smoke
         run: |
           set -euo pipefail
+
+          ci_image_tag="${{ steps.docker_build.outputs.ci_image_tag }}"
+          if [ -z "${ci_image_tag}" ]; then
+            ci_image_tag="rtk-cloud-admin:ci"
+          fi
+          container_name="rtk-cloud-admin-ci-smoke-${GITHUB_RUN_ID}"
           smoke_dir="$(mktemp -d)"
           chmod 0777 "$smoke_dir"
           container_id=""
@@ -51,19 +61,22 @@ jobs:
             if [ -n "$container_id" ]; then
               docker rm -f "$container_id" >/dev/null 2>&1 || true
             fi
+            docker rm -f "$container_name" >/dev/null 2>&1 || true
             rm -rf "$smoke_dir"
           }
           trap cleanup EXIT
 
           container_id="$(docker run -d \
-            --name rtk-cloud-admin-ci-smoke \
+            --name "$container_name" \
             -e PORT=8080 \
             -e DATABASE_PATH=/data/ci.db \
             -v "$smoke_dir:/data" \
-            rtk-cloud-admin:ci)"
+            "$ci_image_tag")"
 
+          ready=0
           for _ in $(seq 1 30); do
             if docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'; then
+              ready=1
               break
             fi
             if ! docker inspect -f '{{.State.Running}}' "$container_id" >/dev/null 2>&1; then
@@ -72,6 +85,11 @@ jobs:
             fi
             sleep 1
           done
+          if [ "$ready" -ne 1 ]; then
+            docker logs "$container_id" >&2 || true
+            echo "timeout: service did not become ready within 30s" >&2
+            exit 1
+          fi
 
           docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'
           docker exec "$container_id" wget -qO- http://127.0.0.1:8080/api/summary | grep -q '"total_devices"'
@@ -80,5 +98,6 @@ jobs:
       - name: Docker cleanup
         if: always()
         run: |
-          docker image rm rtk-cloud-admin:ci >/dev/null 2>&1 || true
+          docker image rm rtk-cloud-admin:ci "${{ steps.docker_build.outputs.ci_image_tag }}" >/dev/null 2>&1 || true
+          docker image prune -af >/dev/null 2>&1 || true
           docker builder prune -af >/dev/null 2>&1 || true

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -30,6 +30,19 @@ docker info
 If the runner gets stuck or disk usage climbs too high:
 
 1. Restart the runner service on `cloud-admin-ci.local`.
-2. Prune the Docker build cache with `docker builder prune -af`.
-3. Remove any stale local CI image with `docker image rm rtk-cloud-admin:ci`.
-4. Rerun the workflow from GitHub.
+2. Check current runner/container state:
+   - `docker ps -a`
+   - `docker images | head`
+   - `docker system df`
+3. Prune stale local CI artifacts:
+   - `docker image rm rtk-cloud-admin:ci`
+   - `docker image prune -af`
+   - `docker builder prune -af`
+4. Prune and restart the runner service if needed:
+   - `sudo systemctl restart actions.runner.hkt999rtk-rtk-cloud-admin-ci-1.service`
+5. Rerun the workflow from GitHub.
+6. If smoke checks fail again, reproduce locally:
+   - `docker run --rm -p 18080:8080 -e DATABASE_PATH=/tmp/ci.db rtk-cloud-admin:ci`
+   - `curl http://127.0.0.1:18080/healthz`
+   - `curl http://127.0.0.1:18080/api/summary`
+   - `curl http://127.0.0.1:18080/console`


### PR DESCRIPTION
## Summary
- Make container smoke checks more deterministic by using a run-specific container name and explicit image tag from Docker build output.
- Add readiness timeout failure diagnostics to avoid silent container-start hangs in CI.
- Improve CI cleanup to remove both `rtk-cloud-admin:ci` and run-specific tagged image, plus image-level pruning.
- Update CI runner documentation with concrete recovery and local smoke reproduction steps.

## Why
Current CI path had weak timeout handling and cleanup coverage for self-hosted runner cache pressure scenarios.

## Impact
- Faster diagnosis when container readiness fails in self-hosted runner.
- Less risk of stale container/image accumulation on dedicated CI host.
- Clearer operator recovery workflow for CI runner stability.
