### PR TITLE
fix: deactivate idempotency bug, frontend org switcher, and 401/403 auth reset

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1057,6 +1057,9 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 	}
 	deviceID := r.PathValue("id")
 	operationType := "DeviceProvisionRequested"
+	if action == "deactivate" {
+		operationType = "DeviceDeactivateRequested"
+	}
 	if existing, ok, err := s.store.GetOpenLifecycleOperation(deviceID, operationType); err == nil && ok {
 		_ = s.store.CreateAuditEvent(session.Email, operationType+".idempotent", deviceID)
 		writeJSON(w, existing)
@@ -1068,15 +1071,6 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 
 	var op accountclient.Operation
 	if action == "deactivate" {
-		operationType = "DeviceDeactivateRequested"
-		if existing, ok, err := s.store.GetOpenLifecycleOperation(deviceID, operationType); err == nil && ok {
-			_ = s.store.CreateAuditEvent(session.Email, operationType+".idempotent", deviceID)
-			writeJSON(w, existing)
-			return true
-		} else if err != nil {
-			writeError(w, err)
-			return true
-		}
 		tokens, err = s.customerCall(r.Context(), tokens, func(token string) error {
 			var callErr error
 			op, callErr = s.accountClient.Deactivate(r.Context(), token, session.ActiveOrgID, deviceID)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -969,6 +969,78 @@ func TestCustomerUpstreamLifecycleIsIdempotentAndDurable(t *testing.T) {
 	}
 }
 
+func TestDeactivateDoesNotReturnOpenProvisionOperation(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/login":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs":
+			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs/org-up/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"activated","status":"offline"}]}`))
+		case "/v1/orgs/org-up/devices/dev-002/provision":
+			_, _ = w.Write([]byte(`{"operation":{"id":"op-prov","state":"published","message":"accepted"}}`))
+		case "/v1/orgs/org-up/devices/dev-002/deactivate":
+			_, _ = w.Write([]byte(`{"operation":{"id":"op-deact","state":"published","message":"deactivation accepted"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	login := httptest.NewRecorder()
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	if login.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
+	}
+	cookie := login.Result().Cookies()[0]
+
+	provision := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/provision", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(provision, req)
+	if provision.Code != http.StatusOK {
+		t.Fatalf("provision status = %d, body=%s", provision.Code, provision.Body.String())
+	}
+	if !strings.Contains(provision.Body.String(), "op-prov") {
+		t.Fatalf("provision body missing op-prov: %s", provision.Body.String())
+	}
+
+	deactivate := httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/deactivate", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(deactivate, req)
+	if deactivate.Code != http.StatusOK {
+		t.Fatalf("deactivate status = %d, body=%s", deactivate.Code, deactivate.Body.String())
+	}
+	if strings.Contains(deactivate.Body.String(), "op-prov") {
+		t.Fatalf("deactivate returned provision operation instead of deactivate operation: %s", deactivate.Body.String())
+	}
+	if !strings.Contains(deactivate.Body.String(), "op-deact") {
+		t.Fatalf("deactivate body missing op-deact: %s", deactivate.Body.String())
+	}
+}
+
 func TestCustomerUpstreamLifecycleFailurePersistsFailedOperation(t *testing.T) {
 	t.Parallel()
 

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -63,6 +63,19 @@ function App() {
         setHealth(nextHealth);
         setAudit(nextAudit);
       } catch (err) {
+        if (!alive) return;
+        if (err.isAuthError) {
+          try {
+            const freshMe = await fetch('/api/me').then((r) => r.json());
+            if (alive) setMe(freshMe);
+          } catch (_) {}
+          setSummary(null);
+          setCustomers([]);
+          setDevices([]);
+          setOperations([]);
+          setHealth([]);
+          setAudit([]);
+        }
         if (alive) setError(err.message);
       }
     }
@@ -123,6 +136,20 @@ function App() {
     setRefreshTick((tick) => tick + 1);
   }
 
+  async function handleSwitchOrg(orgId) {
+    setError('');
+    const response = await fetch('/api/me/active-org', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ organization_id: orgId }),
+    });
+    if (!response.ok) {
+      setError(`org switch failed with ${response.status}`);
+      return;
+    }
+    setRefreshTick((tick) => tick + 1);
+  }
+
   async function handleLogout() {
     setError('');
     const response = await fetch('/api/auth/logout', { method: 'POST' });
@@ -171,7 +198,19 @@ function App() {
           </div>
           <div className="session-strip">
             <span>{me?.authenticated ? `${me.email} / ${me.kind}` : 'Demo mode'}</span>
-            <span>{me?.active_org_id || 'all orgs'}</span>
+            {me?.kind === 'customer' && (me?.memberships?.length ?? 0) > 1 ? (
+              <select
+                className="org-switcher"
+                value={me.active_org_id || ''}
+                onChange={(e) => handleSwitchOrg(e.target.value)}
+              >
+                {(me.memberships || []).map((m) => (
+                  <option key={m.organization_id} value={m.organization_id}>{m.organization}</option>
+                ))}
+              </select>
+            ) : (
+              <span>{me?.active_org_id || 'all orgs'}</span>
+            )}
             {me?.authenticated ? <button onClick={handleLogout}>Logout</button> : null}
           </div>
         </header>
@@ -747,8 +786,18 @@ function routeFromLocation() {
   return 'console';
 }
 
+class AuthError extends Error {
+  constructor(status, message) {
+    super(message);
+    this.status = status;
+    this.isAuthError = true;
+  }
+}
+
 async function fetchJSON(url) {
   const response = await fetch(url);
+  if (response.status === 401) throw new AuthError(401, 'Session expired; please sign in again.');
+  if (response.status === 403) throw new AuthError(403, 'Access denied.');
   if (!response.ok) throw new Error(`${url} failed with ${response.status}`);
   return response.json();
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -196,6 +196,17 @@ p {
   font-weight: 700;
 }
 
+.org-switcher {
+  font-size: 13px;
+  color: var(--brand-dark);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 2px 6px;
+  cursor: pointer;
+  max-width: 160px;
+}
+
 .metrics {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));


### PR DESCRIPTION
## Summary

- **Bug fix**: `tryUpstreamLifecycle` was checking for an open `DeviceProvisionRequested` operation before branching on `action`, so a deactivate request would incorrectly return an existing provision operation. Fixed by setting `operationType` from `action` upfront and removing the now-redundant inner check.
- **Org switcher**: Customers with multiple organization memberships now get a `<select>` dropdown in the topbar. Selecting an org POSTs to `/api/me/active-org` and reloads all scoped data.
- **401/403 auth reset**: `fetchJSON` now throws a typed `AuthError` on 401/403. On auth failure, the frontend re-fetches `/api/me` (which returns demo state after session invalidation) and clears all cached data before showing a user-facing message.

Closes #3, closes #7

## Test plan

- [ ] `go test ./...` passes (new `TestDeactivateDoesNotReturnOpenProvisionOperation` covers the bug)
- [ ] `npm run build` in `web/` succeeds
- [ ] Login as customer with multiple orgs → topbar shows org selector; switch org → data reloads
- [ ] With expired session cookie → any API call shows "Session expired; please sign in again" and UI reverts to demo mode
- [ ] Platform admin login/logout → 401 on admin API returns to unauthenticated state

🤖 Generated with [Claude Code](https://claude.com/claude-code)