### PR TITLE
feat: Video Cloud activation and transport facts integration (issue 5)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"rtk_cloud_admin/internal/accountclient"
@@ -573,9 +574,11 @@ func (s *Server) customerDevices(ctx context.Context, session store.Session) ([]
 	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
 		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 	}
+	vcFacts := s.videoCloudFacts(ctx, devices)
 	out := make([]contracts.Device, 0, len(devices))
 	for _, device := range devices {
-		out = append(out, mapUpstreamDevice(org, device))
+		vid := fallback(device.VideoCloudDevID, metadataString(device.Metadata, "video_cloud_devid", ""))
+		out = append(out, mapUpstreamDevice(org, device, vcFacts[vid]))
 	}
 	return out, nil
 }
@@ -958,7 +961,7 @@ func (s *Server) upstreamCustomers(w http.ResponseWriter, r *http.Request) ([]co
 			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 		}
 		for _, device := range devices {
-			mapped := mapUpstreamDevice(org, device)
+			mapped := mapUpstreamDevice(org, device, nil)
 			customer.TotalDevices++
 			switch mapped.Readiness {
 			case contracts.ReadinessOnline:
@@ -1021,8 +1024,10 @@ func (s *Server) upstreamDevices(w http.ResponseWriter, r *http.Request) ([]cont
 		if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
 			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 		}
+		vcFacts := s.videoCloudFacts(r.Context(), devices)
 		for _, device := range devices {
-			out = append(out, mapUpstreamDevice(org, device))
+			vid := fallback(device.VideoCloudDevID, metadataString(device.Metadata, "video_cloud_devid", ""))
+			out = append(out, mapUpstreamDevice(org, device, vcFacts[vid]))
 		}
 	}
 	return out, true
@@ -1156,7 +1161,7 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 	return true
 }
 
-func mapUpstreamDevice(org accountclient.Organization, device accountclient.Device) contracts.Device {
+func mapUpstreamDevice(org accountclient.Organization, device accountclient.Device, vcFacts *readinessfacts.VideoCloudFacts) contracts.Device {
 	now := time.Now().UTC().Format(time.RFC3339)
 	readiness := contracts.ReadinessState(fallback(device.Readiness, metadataString(device.Metadata, "readiness", string(contracts.ReadinessRegistered))))
 	status := fallback(device.Status, metadataString(device.Metadata, "status", "unknown"))
@@ -1176,7 +1181,7 @@ func mapUpstreamDevice(org accountclient.Organization, device accountclient.Devi
 		LastSeenAt:      fallback(device.LastSeenAt, metadataString(device.Metadata, "last_seen_at", "")),
 		UpdatedAt:       updatedAt,
 	}
-	mapped.SourceFacts = readinessfacts.Build(mapped, upstreamOperationFromMetadata(device, updatedAt))
+	mapped.SourceFacts = readinessfacts.Build(mapped, upstreamOperationFromMetadata(device, updatedAt), vcFacts)
 	return mapped
 }
 
@@ -1260,4 +1265,80 @@ func (s *Server) upstreamHealth(ctx context.Context, name, baseURL string, check
 		detail = err.Error()
 	}
 	return contracts.ServiceHealth{Name: name, Status: status, Detail: detail, LatencyMillis: time.Since(start).Milliseconds(), LastCheckedAt: time.Now().UTC().Format(time.RFC3339)}
+}
+
+// videoCloudFacts queries Video Cloud for activation and transport facts for a
+// batch of Account Manager devices. Returns a map keyed by VideoCloudDevID.
+// Non-nil facts are only present for devices that have a VideoCloudDevID.
+// Errors are logged and silently ignored — Video Cloud is best-effort.
+func (s *Server) videoCloudFacts(ctx context.Context, devices []accountclient.Device) map[string]*readinessfacts.VideoCloudFacts {
+	if !s.videoClient.Enabled() || s.cfg.VideoCloudAdminToken == "" {
+		return nil
+	}
+
+	// Collect device IDs that have a VideoCloudDevID.
+	var vcIDs []string
+	idToVC := make(map[string]string) // accountclient device ID → video_cloud_devid
+	for _, d := range devices {
+		vid := fallback(d.VideoCloudDevID, metadataString(d.Metadata, "video_cloud_devid", ""))
+		if vid != "" {
+			vcIDs = append(vcIDs, vid)
+			idToVC[d.ID] = vid
+		}
+	}
+	if len(vcIDs) == 0 {
+		return nil
+	}
+
+	qCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	activated, err := s.videoClient.QueryActivation(qCtx, s.cfg.VideoCloudAdminToken, vcIDs)
+	if err != nil {
+		return nil
+	}
+
+	updatedAt := time.Now().UTC().Format(time.RFC3339)
+
+	// Fan out GetCameraInfo for activated devices concurrently.
+	type transportResult struct {
+		vcID      string
+		transport string
+	}
+	resultsCh := make(chan transportResult, len(vcIDs))
+	var wg sync.WaitGroup
+	for _, vcID := range vcIDs {
+		if !activated[vcID] {
+			continue
+		}
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			tCtx, tCancel := context.WithTimeout(ctx, 4*time.Second)
+			defer tCancel()
+			transport, err := s.videoClient.GetCameraInfo(tCtx, s.cfg.VideoCloudAdminToken, id)
+			if err != nil {
+				resultsCh <- transportResult{vcID: id}
+				return
+			}
+			resultsCh <- transportResult{vcID: id, transport: transport}
+		}(vcID)
+	}
+	wg.Wait()
+	close(resultsCh)
+
+	transports := make(map[string]string, len(vcIDs))
+	for r := range resultsCh {
+		transports[r.vcID] = r.transport
+	}
+
+	out := make(map[string]*readinessfacts.VideoCloudFacts, len(vcIDs))
+	for _, vcID := range vcIDs {
+		out[vcID] = &readinessfacts.VideoCloudFacts{
+			Activated: activated[vcID],
+			Transport: transports[vcID],
+			UpdatedAt: updatedAt,
+		}
+	}
+	return out
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	DatabasePath           string
 	AccountManagerBaseURL  string
 	VideoCloudBaseURL      string
+	VideoCloudAdminToken   string
 	AdminBootstrapEmail    string
 	AdminBootstrapPassword string
 }
@@ -20,6 +21,7 @@ func FromEnv() Config {
 		DatabasePath:           getenv("DATABASE_PATH", filepath.Join("data", "rtk-cloud-admin.db")),
 		AccountManagerBaseURL:  os.Getenv("ACCOUNT_MANAGER_BASE_URL"),
 		VideoCloudBaseURL:      os.Getenv("VIDEO_CLOUD_BASE_URL"),
+		VideoCloudAdminToken:   os.Getenv("VIDEO_CLOUD_ADMIN_TOKEN"),
 		AdminBootstrapEmail:    os.Getenv("ADMIN_BOOTSTRAP_EMAIL"),
 		AdminBootstrapPassword: os.Getenv("ADMIN_BOOTSTRAP_PASSWORD"),
 	}

--- a/internal/readinessfacts/facts.go
+++ b/internal/readinessfacts/facts.go
@@ -7,7 +7,15 @@ import (
 	"rtk_cloud_admin/internal/contracts"
 )
 
-func Build(device contracts.Device, latestOp *contracts.Operation) []contracts.SourceFact {
+// VideoCloudFacts holds ground-truth data retrieved directly from Video Cloud.
+// When non-nil it overrides inferred activation and transport state.
+type VideoCloudFacts struct {
+	Activated bool
+	Transport string // e.g. "websocket"; empty if unknown
+	UpdatedAt string
+}
+
+func Build(device contracts.Device, latestOp *contracts.Operation, vcFacts *VideoCloudFacts) []contracts.SourceFact {
 	updatedAt := device.UpdatedAt
 	if updatedAt == "" && latestOp != nil {
 		updatedAt = latestOp.UpdatedAt
@@ -20,12 +28,12 @@ func Build(device contracts.Device, latestOp *contracts.Operation) []contracts.S
 			Detail:    "Device exists in the registry projection.",
 			UpdatedAt: updatedAt,
 		},
-		cloudActivationFact(device, latestOp, updatedAt),
-		transportOnlineFact(device, updatedAt),
+		cloudActivationFact(device, latestOp, updatedAt, vcFacts),
+		transportOnlineFact(device, updatedAt, vcFacts),
 	}
 }
 
-func cloudActivationFact(device contracts.Device, latestOp *contracts.Operation, fallbackUpdatedAt string) contracts.SourceFact {
+func cloudActivationFact(device contracts.Device, latestOp *contracts.Operation, fallbackUpdatedAt string, vcFacts *VideoCloudFacts) contracts.SourceFact {
 	fact := contracts.SourceFact{
 		Layer:     "cloud_activation",
 		UpdatedAt: fallbackUpdatedAt,
@@ -56,48 +64,75 @@ func cloudActivationFact(device contracts.Device, latestOp *contracts.Operation,
 		fact.Detail = "Video Cloud device identity is present."
 	}
 
-	if latestOp == nil {
-		return fact
-	}
-
-	fact.OperationID = latestOp.ID
-	if latestOp.UpdatedAt != "" {
-		fact.UpdatedAt = latestOp.UpdatedAt
-	}
-
-	switch latestOp.State {
-	case contracts.OperationPending, contracts.OperationPublished, contracts.OperationRetrying:
-		fact.State = "pending"
-		if latestOp.Message != "" {
-			fact.Detail = latestOp.Message
+	if latestOp != nil {
+		fact.OperationID = latestOp.ID
+		if latestOp.UpdatedAt != "" {
+			fact.UpdatedAt = latestOp.UpdatedAt
 		}
-	case contracts.OperationSucceeded:
-		if fact.State != "failed" {
+
+		switch latestOp.State {
+		case contracts.OperationPending, contracts.OperationPublished, contracts.OperationRetrying:
+			fact.State = "pending"
+			if latestOp.Message != "" {
+				fact.Detail = latestOp.Message
+			}
+		case contracts.OperationSucceeded:
+			if fact.State != "failed" {
+				fact.State = "present"
+			}
+			if latestOp.Message != "" {
+				fact.Detail = latestOp.Message
+			}
+		case contracts.OperationFailed, contracts.OperationDeadLettered:
+			fact.State = "failed"
+			if latestOp.Message != "" {
+				fact.Detail = latestOp.Message
+				fact.ErrorCode = normalizeErrorCode(latestOp.Message)
+				fact.Retryable = retryableFromMessage(latestOp.Message)
+			}
+		default:
+			if latestOp.Message != "" && fact.Detail == "" {
+				fact.Detail = latestOp.Message
+			}
+		}
+	}
+
+	// Video Cloud ground truth overrides inferred state when present.
+	if vcFacts != nil {
+		ts := fallbackUpdatedAt
+		if vcFacts.UpdatedAt != "" {
+			ts = vcFacts.UpdatedAt
+		}
+		if vcFacts.Activated {
 			fact.State = "present"
+			fact.Detail = "Video Cloud confirms device activation."
+		} else {
+			fact.State = "stale"
+			fact.Detail = "Video Cloud reports device is not activated."
+			fact.Retryable = true
 		}
-		if latestOp.Message != "" {
-			fact.Detail = latestOp.Message
-		}
-	case contracts.OperationFailed, contracts.OperationDeadLettered:
-		fact.State = "failed"
-		if latestOp.Message != "" {
-			fact.Detail = latestOp.Message
-			fact.ErrorCode = normalizeErrorCode(latestOp.Message)
-			fact.Retryable = retryableFromMessage(latestOp.Message)
-		}
-	default:
-		if latestOp.Message != "" && fact.Detail == "" {
-			fact.Detail = latestOp.Message
-		}
+		fact.UpdatedAt = ts
 	}
 
 	return fact
 }
 
-func transportOnlineFact(device contracts.Device, fallbackUpdatedAt string) contracts.SourceFact {
+func transportOnlineFact(device contracts.Device, fallbackUpdatedAt string, vcFacts *VideoCloudFacts) contracts.SourceFact {
 	fact := contracts.SourceFact{
 		Layer:     "transport_online",
 		UpdatedAt: fallbackUpdatedAt,
+	}
+
+	// Video Cloud transport is authoritative; use it regardless of LastSeenAt.
+	if vcFacts != nil && vcFacts.Transport != "" {
+		ts := fallbackUpdatedAt
+		if vcFacts.UpdatedAt != "" {
+			ts = vcFacts.UpdatedAt
+		}
+		fact.State = "present"
+		fact.Detail = "Video Cloud transport: " + vcFacts.Transport + "."
+		fact.UpdatedAt = ts
+		return fact
 	}
 
 	if device.LastSeenAt == "" {

--- a/internal/readinessfacts/facts_test.go
+++ b/internal/readinessfacts/facts_test.go
@@ -13,6 +13,7 @@ func TestBuildSourceFacts(t *testing.T) {
 		name            string
 		device          contracts.Device
 		latestOp        *contracts.Operation
+		vcFacts         *VideoCloudFacts
 		wantStates      []string
 		wantErrorCode   string
 		wantRetryable   bool
@@ -101,6 +102,57 @@ func TestBuildSourceFacts(t *testing.T) {
 			},
 			wantStates: []string{"present", "present", "stale"},
 		},
+		{
+			name: "vc_activated_with_transport",
+			device: contracts.Device{
+				ID:              "dev-7",
+				VideoCloudDevID: "video-7",
+				Status:          "offline",
+				Readiness:       contracts.ReadinessCloudActivationPending,
+				UpdatedAt:       "2026-05-01T10:00:00Z",
+			},
+			vcFacts: &VideoCloudFacts{
+				Activated: true,
+				Transport: "websocket",
+				UpdatedAt: "2026-05-01T10:05:00Z",
+			},
+			wantStates: []string{"present", "present", "present"},
+		},
+		{
+			name: "vc_not_activated",
+			device: contracts.Device{
+				ID:              "dev-8",
+				VideoCloudDevID: "video-8",
+				Status:          "online",
+				Readiness:       contracts.ReadinessOnline,
+				LastSeenAt:      "2026-05-01T10:00:00Z",
+				UpdatedAt:       "2026-05-01T10:00:00Z",
+			},
+			vcFacts: &VideoCloudFacts{
+				Activated: false,
+				UpdatedAt: "2026-05-01T10:05:00Z",
+			},
+			wantStates:    []string{"present", "stale", "present"},
+			wantRetryable: true,
+		},
+		{
+			name: "vc_activated_no_transport",
+			device: contracts.Device{
+				ID:              "dev-9",
+				VideoCloudDevID: "video-9",
+				Status:          "offline",
+				Readiness:       contracts.ReadinessActivated,
+				LastSeenAt:      "2026-05-01T10:00:00Z",
+				UpdatedAt:       "2026-05-01T10:00:00Z",
+			},
+			vcFacts: &VideoCloudFacts{
+				Activated: true,
+				Transport: "",
+				UpdatedAt: "2026-05-01T10:05:00Z",
+			},
+			// transport falls back to inferred "stale" (status=offline, no VC transport)
+			wantStates: []string{"present", "present", "stale"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -108,7 +160,7 @@ func TestBuildSourceFacts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			facts := Build(tt.device, tt.latestOp)
+			facts := Build(tt.device, tt.latestOp, tt.vcFacts)
 			if len(facts) != 3 {
 				t.Fatalf("facts len = %d, want 3", len(facts))
 			}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -730,7 +730,7 @@ func (s *Store) sourceFactsForDevice(device contracts.Device) ([]contracts.Sourc
 	if err != nil {
 		return nil, err
 	}
-	return readinessfacts.Build(device, latest), nil
+	return readinessfacts.Build(device, latest, nil), nil
 }
 
 func (s *Store) latestOperationForDevice(deviceID string) (*contracts.Operation, error) {

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -1,8 +1,11 @@
 package videoclient
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -44,4 +47,89 @@ func (c *Client) Health(ctx context.Context) error {
 		return fmt.Errorf("status %d", resp.StatusCode)
 	}
 	return nil
+}
+
+// QueryActivation returns a map from device ID to whether it is activated in
+// Video Cloud. devids must be non-empty. Any device ID not present in the
+// response is treated as not activated.
+func (c *Client) QueryActivation(ctx context.Context, adminToken string, devids []string) (map[string]bool, error) {
+	if !c.Enabled() {
+		return nil, fmt.Errorf("video cloud base URL is not configured")
+	}
+	body, err := json.Marshal(map[string]any{"devices": devids})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/query_camera_activate", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("query_camera_activate status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, err
+	}
+	var result struct {
+		Status  string   `json:"status"`
+		Devices []string `json:"devices"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("query_camera_activate parse: %w", err)
+	}
+	out := make(map[string]bool, len(devids))
+	for i, id := range devids {
+		if i < len(result.Devices) {
+			out[id] = result.Devices[i] == "1"
+		}
+	}
+	return out, nil
+}
+
+// GetCameraInfo returns the current transport type for a single device.
+// Returns an empty string if the transport is unknown.
+func (c *Client) GetCameraInfo(ctx context.Context, adminToken, devid string) (string, error) {
+	if !c.Enabled() {
+		return "", fmt.Errorf("video cloud base URL is not configured")
+	}
+	body, err := json.Marshal(map[string]string{"devid": devid})
+	if err != nil {
+		return "", err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/get_camera_info", bytes.NewReader(body))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", fmt.Errorf("get_camera_info status %d", resp.StatusCode)
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		Status string `json:"status"`
+		Info   struct {
+			CurrentTransport string `json:"current_transport"`
+		} `json:"info"`
+	}
+	if err := json.Unmarshal(data, &result); err != nil {
+		return "", fmt.Errorf("get_camera_info parse: %w", err)
+	}
+	return result.Info.CurrentTransport, nil
 }

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -2,6 +2,7 @@ package videoclient
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -66,5 +67,112 @@ func TestDisabledClient(t *testing.T) {
 	}
 	if err := client.Health(t.Context()); err == nil {
 		t.Fatal("expected disabled health error")
+	}
+	if _, err := client.QueryActivation(t.Context(), "tok", []string{"d1"}); err == nil {
+		t.Fatal("expected disabled QueryActivation error")
+	}
+	if _, err := client.GetCameraInfo(t.Context(), "tok", "d1"); err == nil {
+		t.Fatal("expected disabled GetCameraInfo error")
+	}
+}
+
+func TestQueryActivation(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/query_camera_activate" {
+			t.Fatalf("path = %q, want /query_camera_activate", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q, want Bearer secret", got)
+		}
+		var body struct {
+			Devices []string `json:"devices"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if len(body.Devices) != 2 {
+			t.Fatalf("devices len = %d, want 2", len(body.Devices))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":  "ok",
+			"devices": []string{"1", "0"},
+		})
+	}))
+	defer upstream.Close()
+
+	result, err := New(upstream.URL).QueryActivation(t.Context(), "secret", []string{"dev-a", "dev-b"})
+	if err != nil {
+		t.Fatalf("QueryActivation error: %v", err)
+	}
+	if !result["dev-a"] {
+		t.Fatalf("dev-a should be activated")
+	}
+	if result["dev-b"] {
+		t.Fatalf("dev-b should not be activated")
+	}
+}
+
+func TestQueryActivationUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+	}))
+	defer upstream.Close()
+
+	if _, err := New(upstream.URL).QueryActivation(t.Context(), "tok", []string{"d1"}); err == nil {
+		t.Fatal("expected error on 5xx response")
+	}
+}
+
+func TestGetCameraInfo(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/get_camera_info" {
+			t.Fatalf("path = %q, want /get_camera_info", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q, want Bearer secret", got)
+		}
+		var body struct {
+			DevID string `json:"devid"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.DevID != "cam-1" {
+			t.Fatalf("devid = %q, want cam-1", body.DevID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok",
+			"info":   map[string]string{"current_transport": "websocket"},
+		})
+	}))
+	defer upstream.Close()
+
+	transport, err := New(upstream.URL).GetCameraInfo(t.Context(), "secret", "cam-1")
+	if err != nil {
+		t.Fatalf("GetCameraInfo error: %v", err)
+	}
+	if transport != "websocket" {
+		t.Fatalf("transport = %q, want websocket", transport)
+	}
+}
+
+func TestGetCameraInfoUpstreamError(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer upstream.Close()
+
+	if _, err := New(upstream.URL).GetCameraInfo(t.Context(), "tok", "cam-1"); err == nil {
+		t.Fatal("expected error on 4xx response")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `VIDEO_CLOUD_ADMIN_TOKEN` config field wired to the `videoclient` package
- Extends `videoclient.Client` with `QueryActivation` (batch) and `GetCameraInfo` (per-device) methods backed by `POST /query_camera_activate` and `POST /get_camera_info`
- Introduces `readinessfacts.VideoCloudFacts` struct and updates `Build()` to accept it as an optional third arg; when non-nil, Video Cloud ground truth overrides the inferred `cloud_activation` and `transport_online` source facts
- Customer device list endpoints batch-query Video Cloud activation then fan out `GetCameraInfo` concurrently for activated devices; errors degrade gracefully (VC unavailable → inferred facts used)
- `store.go` and admin summary callers pass `nil` (no VC enrichment needed for summary counts)

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go build ./...` — clean build
- [x] `npm run build` — frontend builds
- [x] `readinessfacts` table-driven tests cover: no-VC (existing 6 cases), VC activated + transport, VC not activated, VC activated no transport
- [x] `videoclient` tests cover: `QueryActivation` happy path, 5xx error, `GetCameraInfo` happy path, 4xx error, disabled client rejects all methods

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)