### PR TITLE
docs: add ROLES.md and align admin dashboard redesign spec to role taxonomy

### DIFF
--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -1,0 +1,187 @@
+# RTK Cloud Admin — Role Definitions
+
+Status: draft.
+
+Author: Kevin Huang
+
+Audience:
+
+- rtk_cloud_admin frontend and backend developers
+- rtk_account_manager backend developers
+- rtk_video_cloud backend developers (telemetry, firmware, and stream APIs must
+  honor the field-level visibility rules below when surfacing data per role)
+- PM / QA
+
+---
+
+## Three-Tier Architecture
+
+RTK Cloud is structured as a three-tier business hierarchy, analogous to a
+shopping mall: Realtek owns the platform (the landlord), brand operators
+license it to ship their own branded IoT products (tenants renting storefronts),
+and end users own the devices (the consumers walking in).
+
+```
+Tier 1 — Realtek (platform owner / landlord)
+    └── Tier 2 — Brand Operators (licensed tenants)
+            └── Tier 3 — End Users (device owners)
+```
+
+Each tier has distinct roles with different visibility and permission scopes
+within the admin console.
+
+### Tier Relationships
+
+- A Tier 2 brand operator licenses the platform from Realtek and operates one
+  or more organizations. Each organization is the unit of isolation for devices,
+  users, and operations.
+- A Tier 3 end user owns one or more devices. Each device is bound to exactly
+  one Tier 2 organization, which is responsible for its lifecycle (provisioning,
+  firmware, deactivation). The Tier 3 user's identity is managed inside the
+  Tier 2 org's user namespace.
+- Tier 1 has cross-tenant visibility for platform operations and support;
+  Tier 2 sees only their own org.
+
+### Why Tier 3 Appears In This Document
+
+Tier 3 end users do not use this admin console — they use the Realtek Connect+
+consumer app. Tier 3 is documented here only to make the org/device ownership
+chain explicit, because Tier 1 Platform Admins and Tier 2 Fleet Managers
+frequently answer questions on behalf of Tier 3 users (e.g., "the end user says
+their camera is offline").
+
+The remainder of this document covers only Tier 1 and Tier 2 roles.
+
+---
+
+## Tier 1 — Realtek Internal Roles
+
+These roles belong to Realtek employees operating the platform. Tier 1
+authenticates via the `/admin` login endpoint (bootstrapped by
+`ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` on first run; subsequent
+admins are managed via SQLite). The session cookie is `rtk_admin_session` with
+session kind `platform_admin`. Passwords are stored as bcrypt hashes.
+
+### Platform Admin
+
+**Responsibilities:** Overall platform operations, infrastructure health,
+cross-tenant oversight, compliance, and support investigations on behalf of
+Tier 2 customers.
+
+**Visible scope:** All tenants, all devices, all operations.
+
+**Console surfaces used:**
+- Platform View — Service Health (Account Manager, Video Cloud, SQLite status)
+- Platform View — Operations Log (all lifecycle operation types across tenants)
+- Platform View — Audit Log (all actor/action/target records)
+
+**Can execute:**
+- Platform-side admin actions: customer session refresh and invalidation (existing in `internal/app/app.go`).
+- Tenant lifecycle actions (provisioning, deactivation, firmware campaign control on behalf of a tenant): not supported. Tenant-side write actions remain with Tier 2 Fleet Managers.
+
+**Known gap:** There is no cross-tenant device-detail surface today. Operations
+Log shows lifecycle operation history and Audit Log shows actor/action/target
+records, but neither exposes a tenant's current device fleet (health, RSSI,
+firmware version). A Platform Admin investigating "what is the current state of
+this customer's devices?" cannot answer it from the console today and must
+either read SQLite directly or contact the tenant.
+
+**Future capabilities (deferred):** Read-only impersonation of any tenant's
+Customer View will close this gap.
+
+---
+
+## Tier 2 — Brand Operator Roles
+
+These roles belong to the licensed tenant operating their own branded IoT
+product. Tier 2 sessions are org-scoped — users can only see and act on devices
+within their own organization.
+
+Tier 2 authenticates via the customer login endpoint (backed by Account Manager
+when `ACCOUNT_MANAGER_BASE_URL` is set, or local SQLite seed data in demo mode).
+The session cookie is `rtk_admin_session`; the session row carries the upstream
+Bearer / refresh token pair when in proxy mode. Plaintext credentials are never
+persisted.
+
+### Fleet Manager
+
+**Responsibilities:** Day-to-day fleet operations — device provisioning,
+deactivation, health monitoring, OTA tracking, stream health.
+
+**Visible scope:** Own org only.
+
+**Console surfaces used:**
+- Customer View — all sections (Fleet Health Overview, Devices, Firmware & OTA,
+  Stream Health)
+- Device Detail Drawer — full detail
+
+**Can execute:** Provision, Deactivate.
+
+---
+
+### Read-only Observer
+
+**Responsibilities:** Monitoring fleet health and reviewing reports without
+making operational changes. Typical role for IT managers or customer success
+staff within a tenant org.
+
+**Visible scope:** Own org only.
+
+**Console surfaces used:**
+- Customer View — all sections, read-only
+- Device Detail Drawer — full detail, read-only
+
+**Cannot execute:** No provision, deactivate, or any write actions.
+
+**Current implementation:** Read-only Observer is not yet a distinct session
+type — all Tier 2 users currently share the same customer session and have
+Fleet Manager privileges. A read-only role is deferred.
+
+---
+
+## Role-to-View Mapping Summary
+
+| Role | Customer View | Platform View | Can Write |
+|---|---|---|---|
+| Platform Admin (T1) | — (impersonation deferred) | Full | Platform-side only (session control); no tenant lifecycle actions |
+| Fleet Manager (T2) | Full (own org) | — | Yes (provision, deactivate) |
+| Read-only Observer (T2) | Full read-only (own org) | — | No |
+
+---
+
+## Field-Level Visibility Rules
+
+Page-level access is described per role above. This section defines the
+field-level rules that apply *within* shared concepts (devices, operations,
+events) when the same data surface is shown to different tiers.
+
+Backend handlers and frontend components must enforce these rules consistently.
+Source of truth — when a section in `admin-dashboard-redesign.md` mentions a
+visibility constraint on a specific field, it must align with the table below.
+
+| Field / Concept | Tier 2 (Fleet Manager, Read-only Observer) | Tier 1 (Platform Admin) |
+|---|---|---|
+| `video_cloud_devid` | hidden | visible |
+| Account Manager device ID (e.g. `acct-dev-1`) | visible (used as device row key) | visible |
+| Internal operation type names (e.g. `DeviceProvisionRequested`, `cloud_activation_pending`) | hidden — Friendly Summary only | visible as secondary text alongside Friendly Summary |
+| Operation `dead_lettered` state | hidden | visible (filter chip available in Operations Log) |
+| Operation IDs | hidden | visible |
+| Raw upstream error payloads | hidden — surface as user-facing message only | visible in Operations Log detail |
+| Audit log (`audit_events` table) | hidden | visible (cross-tenant) |
+| Service Health (Account Manager / Video Cloud / SQLite status) | hidden | visible |
+| Demo Mode banner | hidden | visible |
+| Cross-tenant device list / per-tenant fleet view | not applicable (org-scoped session) | not directly available today; cross-tenant inspection happens via Operations Log and Audit Log only. Direct cross-tenant device drill-down requires the deferred impersonation capability. |
+| Bearer / refresh tokens | never exposed in UI | never exposed in UI |
+
+Read-only Observer (T2) sees exactly the same fields as Fleet Manager (T2);
+the distinction is write actions only, not field visibility.
+
+---
+
+## Out Of Scope For This Version
+
+The following role-related features are intentionally deferred:
+
+- Read-only Observer as a distinct Tier 2 session type
+- Tenant impersonation for Tier 1 Platform Admin
+- Role assignment UI

--- a/docs/admin-dashboard-redesign.md
+++ b/docs/admin-dashboard-redesign.md
@@ -13,6 +13,7 @@ Audience:
 
 Related contracts:
 
+- [ROLES.md](ROLES.md) — three-tier role definitions (read this first)
 - [TELEMETRY_INSIGHTS.md](../rtk_cloud_contracts_doc/TELEMETRY_INSIGHTS.md)
 - [FIRMWARE_CAMPAIGN.md](../rtk_cloud_contracts_doc/FIRMWARE_CAMPAIGN.md)
 - [FRONTEND_STYLE.md](../rtk_cloud_contracts_doc/FRONTEND_STYLE.md)
@@ -22,30 +23,36 @@ Related contracts:
 
 ## Background And Motivation
 
+RTK Cloud is a three-tier platform (see [ROLES.md](ROLES.md)). Two of those
+tiers use this admin console: Tier 2 Brand Operators (Fleet Managers and
+Read-only Observers managing their own device fleet) and Tier 1 Realtek
+Platform Admins (operating the platform across all tenants). Tier 3 end users
+do not use this console.
+
 The current admin dashboard was designed from a system-implementation perspective.
 It surfaces internal operational vocabulary (`cloud_activation_pending`,
 `dead_lettered`, `video_cloud_devid`) and exposes service-health indicators that
-are meaningful only to platform engineers. Customer operators — the primary
-users — cannot derive actionable answers to their everyday questions from the
-current UI.
+are meaningful only to Tier 1 platform engineers. Tier 2 Fleet Managers — the
+primary daily users — cannot derive actionable answers to their everyday
+questions from the current UI.
 
-Typical customer operator questions the current dashboard cannot answer:
+Typical Tier 2 Fleet Manager questions the current dashboard cannot answer:
 
 - Which of my devices have been unreliable this week?
 - How many devices still run the old firmware, and how is the OTA rollout going?
 - Is my fleet's signal quality degrading?
 - How often are streams actually working?
 
-This spec defines the redesign required to make the dashboard customer-useful
-while preserving an operator/internal view for platform teams.
+This spec defines the redesign required to make the dashboard useful for Tier 2
+operators while preserving a clean internal view for Tier 1 roles.
 
 ---
 
 ## Goals
 
-1. Surface the data customer operators actually need to manage their fleet.
-2. Remove internal implementation details from the customer-facing view.
-3. Separate customer views from platform/operator views cleanly.
+1. Surface the data Tier 2 operators actually need to manage their fleet.
+2. Remove internal implementation vocabulary (`cloud_activation_pending`, `dead_lettered`, `video_cloud_devid`, etc.) from Customer View routes.
+3. Ensure no Customer View route exposes Platform View data, and no Platform View route is reachable from Customer View navigation.
 4. Ground all new data surfaces in existing contracts (TELEMETRY_INSIGHTS,
    FIRMWARE_CAMPAIGN) to avoid inventing new vocabulary.
 
@@ -64,7 +71,7 @@ Platform Admin   →  customer count + service health
 
 ### Proposed Navigation (2 top-level views)
 
-**Customer View** — default landing for org operators:
+**Customer View** — default landing for Tier 2 roles (Fleet Manager, Read-only Observer):
 
 ```
 Overview         →  fleet health summary (new)
@@ -74,7 +81,7 @@ Stream Health    →  new section
 Groups           →  new section (depends on device-group feature)
 ```
 
-**Platform View** — separate top-level context for internal operators:
+**Platform View** — Tier 1 Platform Admin only:
 
 ```
 Service Health   →  moved from customer view
@@ -83,18 +90,20 @@ Audit Log        →  new section (uses existing audit_events table)
 ```
 
 The two views should have clearly differentiated entry points. A nav switcher
-or separate route prefix (`/admin/ops`) is acceptable. Do not intermix customer
-and platform content on the same page.
+or separate route prefix (`/admin/ops`) is acceptable. Do not intermix Tier 2
+customer content and Tier 1 platform content on the same page.
 
 ---
 
 ## Section 1: Fleet Health Overview (new)
 
+Primary users: Tier 2 Fleet Manager, Read-only Observer.
+
 This replaces the current Customer Fleet Dashboard.
 
 ### Purpose
 
-Give the customer operator a single-glance answer to: "Is my fleet healthy right
+Give the Tier 2 operator a single-glance answer to: "Is my fleet healthy right
 now, and has it been healthy recently?"
 
 ### KPI Strip (top of page)
@@ -145,12 +154,15 @@ Data source: `device.health.summary` latest event per device per org.
 | Signal | `low_rssi` / `recent_crash` / `offline_risk` etc., from TELEMETRY_INSIGHTS |
 | Health | resulting health state |
 
-No service-internal fields. No operation type codes. Customer-readable signal
-names only.
+Field visibility for this table follows the rules in
+[ROLES.md — Field-Level Visibility Rules](ROLES.md#field-level-visibility-rules).
+Use Customer-readable signal names from TELEMETRY_INSIGHTS.md only.
 
 ---
 
 ## Section 2: Devices Table (improved)
+
+Primary users: Tier 2 Fleet Manager, Read-only Observer.
 
 ### Columns
 
@@ -210,12 +222,14 @@ When clicking a device row, open a side drawer or detail page showing:
 - Recent events (last 10 telemetry events from this device)
 - Active stream status (is there currently an open session?)
 
-This panel should not expose video_cloud_devid or internal operation IDs to
-non-platform users.
+Field visibility follows
+[ROLES.md — Field-Level Visibility Rules](ROLES.md#field-level-visibility-rules).
 
 ---
 
 ## Section 3: Firmware & OTA (new)
+
+Primary users: Tier 2 Fleet Manager, Read-only Observer.
 
 ### Purpose
 
@@ -276,6 +290,8 @@ and `/query_firmware_rollout` existing route.
 
 ## Section 4: Stream Health (new)
 
+Primary users: Tier 2 Fleet Manager, Read-only Observer.
+
 ### Purpose
 
 Answer: "Are my devices' video streams actually working for end users?"
@@ -328,26 +344,30 @@ When available, the Groups section provides:
 
 ## Section 6: Platform View — Retained And Refined
 
+Primary users: Tier 1 Platform Admin. Not visible to any Tier 2 role.
+
 ### Service Health (moved from Customer View)
 
-The Account Manager, Video Cloud, and SQLite health indicators remain. Move
-them entirely out of the customer-facing view. They belong in the Platform View
-only.
+The Account Manager, Video Cloud, and SQLite health indicators remain, but
+move out of Customer View into Platform View.
 
-When a service is in `demo` mode, add a visible "Demo Mode" banner to the
-Platform View page, not to any customer-facing page.
+When a service is in `demo` mode, the "Demo Mode" banner appears in Platform
+View only.
 
 ### Operations Log (refined)
 
-The Operations page is retained for platform operators.
+The Operations page is retained for Tier 1 platform operators.
 
 Changes:
 
-- Add a `Friendly Summary` column that translates internal operation types into
-  readable sentences. Example:
-  - `DeviceProvisionRequested` → "Provisioning requested"
-  - `dead_lettered` → "Failed after retries — needs investigation"
-- Keep raw type and state values visible as secondary text for platform engineers.
+- Add a `Friendly Summary` column that combines the operation's `type` and
+  `state` into a single readable sentence. Mapping is composed from a `type`
+  phrase plus a `state` qualifier:
+  - `DeviceProvisionRequested` (type) + `pending` (state) → "Provisioning requested"
+  - `DeviceProvisionRequested` (type) + `succeeded` (state) → "Provisioning succeeded"
+  - `DeviceDeactivationRequested` (type) + `failed` (state) → "Deactivation failed"
+  - any type + `dead_lettered` (state) → "Failed after retries — needs investigation"
+- Show raw `type` and `state` values as secondary text beneath the Friendly Summary, per [ROLES.md — Field-Level Visibility Rules](ROLES.md#field-level-visibility-rules) (Tier 1 visibility).
 - Add filter by state: All / Pending / Succeeded / Failed / Dead Lettered.
 
 ### Audit Log (new, minimal)
@@ -355,6 +375,14 @@ Changes:
 Surface the existing `audit_events` table (actor, action, target, created_at)
 as a read-only table in Platform View. No new data model required; the table
 already exists in the store.
+
+**Write-side status:** `audit_events` is populated today by the device
+lifecycle handlers in `internal/app/app.go` (`CreateAuditEvent` /
+`CreateAuditEventWithMetadata` are called on provision and deactivate flows,
+including idempotent paths). Other actions (login, session invalidation,
+firmware campaign control) do not yet write audit rows. The Audit Log UI
+should expect populated data for device lifecycle actions only in the first
+release; expanding write coverage is a separate work item.
 
 ---
 
@@ -514,7 +542,9 @@ The following are intentionally deferred:
 - Alert notification rules and email/webhook delivery
 - Multi-org / platform-level fleet aggregation (single-org only for now)
 - Stream viewer / live preview
-- User roles and permission management
+- Read-only Observer as a distinct Tier 2 session type
+- Tenant impersonation for Tier 1 Platform Admin
+- Role assignment UI
 - Audit log export
 
 ---
@@ -551,8 +581,7 @@ audit log surface) can proceed immediately.
 
 For each new frontend section, the implementation must verify:
 
-- No internal IDs (`video_cloud_devid`, operation IDs) are exposed in
-  customer-facing views
+- All field visibility matches [ROLES.md — Field-Level Visibility Rules](ROLES.md#field-level-visibility-rules) (in particular: no `video_cloud_devid`, operation IDs, raw operation type names, or `dead_lettered` state in any Customer View route)
 - State labels use contract vocabulary (title-cased) from PRODUCT_READINESS.md
   and FIRMWARE_CAMPAIGN.md
 - Health signals use vocabulary from TELEMETRY_INSIGHTS.md
@@ -560,4 +589,5 @@ For each new frontend section, the implementation must verify:
 - Empty states are defined (e.g., "No campaigns active", "No stream data yet")
 - Tables show the most actionable items first (worst-performing devices at top)
 - Color usage follows FRONTEND_STYLE.md tokens
-- Platform View content does not appear in Customer View routes
+- Platform View content does not appear in any Customer View route, and no Customer View navigation links to a Platform View route
+- The backend route handler for each section returns 403 for any session whose role is not listed in that section's "Primary users" annotation (once role enforcement is implemented; until then, the annotation is descriptive — see ROLES.md current implementation notes)


### PR DESCRIPTION
## Summary

- Add [docs/ROLES.md](docs/ROLES.md) as the source of truth for the three-tier business architecture (Realtek platform owner / Brand Operators / End Users) and the roles within each tier that use this admin console.
- Document Tier 1 (Platform Admin) and Tier 2 (Fleet Manager, Read-only Observer) authentication paths, console surfaces, and write capabilities, grounded in the actual session/auth implementation in \`internal/app/app.go\`.
- Add a Field-Level Visibility Rules table covering \`video_cloud_devid\`, internal operation type names, \`dead_lettered\` state, audit log, service health, demo mode, cross-tenant access, and tokens — so backend handlers and frontend components have one place to look up what each tier may see.
- Update [docs/admin-dashboard-redesign.md](docs/admin-dashboard-redesign.md) to reference ROLES.md, annotate each section with primary users, replace scattered visibility rules with links to the central table, clarify the Friendly Summary as a \`type\` + \`state\` composition with concrete examples, and document the current write-side coverage of the \`audit_events\` table (today only the device lifecycle handlers populate it).

## Why

The original redesign spec was written for two implicit audiences ("customer operators" and "platform engineers") without naming the roles or the wider three-tier business hierarchy. This made it hard to answer downstream questions like "who actually sees this field?" and led to scattered, sometimes contradictory visibility statements across sections. ROLES.md makes the taxonomy explicit so subsequent specs (Groups, alerts, impersonation, etc.) can build on a shared definition.

## Test plan

- [ ] Reviewer confirms ROLES.md three-tier framing matches the business model
- [ ] Reviewer confirms the auth path descriptions match \`internal/app/app.go\` (session cookie name, bootstrap envs, demo/proxy mode split)
- [ ] Reviewer confirms the Field-Level Visibility table is complete enough to drive Tier 2 / Tier 1 routing in the backend
- [ ] Reviewer confirms the Friendly Summary mapping examples cover the cases that matter for the Operations Log redesign
- [ ] Reviewer confirms the Audit Log "Write-side status" note matches what \`CreateAuditEvent\` currently does

🤖 Generated with [Claude Code](https://claude.com/claude-code)