### PR TITLE
feat: split navigation into customer and platform views

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -96,12 +96,18 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /assets/", s.assets)
 	s.mux.HandleFunc("GET /", s.home)
 	s.mux.HandleFunc("GET /console", s.shell)
+	s.mux.HandleFunc("GET /console/overview", s.shell)
 	s.mux.HandleFunc("GET /console/devices", s.shell)
-	s.mux.HandleFunc("GET /admin", s.shell)
-	s.mux.HandleFunc("GET /admin/operations", s.shell)
 	s.mux.HandleFunc("GET /console/customers", s.shell)
 	s.mux.HandleFunc("GET /console/operations", s.shell)
 	s.mux.HandleFunc("GET /console/audit", s.shell)
+	s.mux.HandleFunc("GET /console/firmware-ota", s.shell)
+	s.mux.HandleFunc("GET /console/stream-health", s.shell)
+	s.mux.HandleFunc("GET /console/groups", s.shell)
+	s.mux.HandleFunc("GET /admin", s.shell)
+	s.mux.HandleFunc("GET /admin/ops", s.shell)
+	s.mux.HandleFunc("GET /admin/audit", s.shell)
+	s.mux.HandleFunc("GET /admin/operations", s.shell)
 }
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1179,8 +1179,14 @@ func TestConsoleAndAdminPagesRenderSeedData(t *testing.T) {
 		want string
 	}{
 		{path: "/console", want: "Customer Fleet"},
+		{path: "/console/overview", want: "Customer Fleet"},
 		{path: "/console/devices", want: "cam-a-001"},
+		{path: "/console/firmware-ota", want: "Customer Fleet"},
+		{path: "/console/stream-health", want: "Customer Fleet"},
+		{path: "/console/groups", want: "Customer Fleet"},
 		{path: "/admin", want: "Platform Operations"},
+		{path: "/admin/ops", want: "DeviceProvisionRequested"},
+		{path: "/admin/audit", want: "Platform Operations"},
 		{path: "/admin/operations", want: "DeviceProvisionRequested"},
 	}
 

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,7 @@
 {
   "scripts": {
     "dev": "vite --host 127.0.0.1",
+    "test": "node --test src/routes.test.mjs",
     "build": "vite build",
     "preview": "vite preview --host 127.0.0.1"
   },
@@ -12,4 +13,3 @@
   },
   "devDependencies": {}
 }
-

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -32,6 +32,7 @@ function App() {
   const [refreshTick, setRefreshTick] = useState(0);
   const isPlatformView = active.startsWith('platform');
   const visibleNavItems = isPlatformView ? platformNavItems : customerNavItems;
+  const needsPlatformAccess = isPlatformView && me?.kind !== 'platform_admin';
 
   useEffect(() => {
     let alive = true;
@@ -240,8 +241,9 @@ function App() {
 
         {error ? <div className="error">{error}</div> : null}
 
-        {active === 'overview' ? <Overview summary={summary} me={me} onLogin={handleLogin} /> : null}
-        {active === 'devices' ? (
+        {needsPlatformAccess ? <PlatformAccessGate active={active} onLogin={handleLogin} /> : null}
+        {!needsPlatformAccess && active === 'overview' ? <Overview summary={summary} me={me} onLogin={handleLogin} /> : null}
+        {!needsPlatformAccess && active === 'devices' ? (
           <Devices
             devices={devices}
             selectedDevice={selectedDevice}
@@ -249,12 +251,12 @@ function App() {
             onAction={runDeviceAction}
           />
         ) : null}
-        {active === 'firmware-ota' ? <FirmwareOTAPage /> : null}
-        {active === 'stream-health' ? <StreamHealthPage /> : null}
-        {active === 'groups' ? <GroupsPage /> : null}
-        {active === 'platform-health' ? <PlatformHealth summary={summary} health={health} me={me} onLogin={handleLogin} /> : null}
-        {active === 'platform-operations' ? <Operations operations={operations} /> : null}
-        {active === 'platform-audit' ? <AuditLog audit={audit} /> : null}
+        {!needsPlatformAccess && active === 'firmware-ota' ? <FirmwareOTAPage /> : null}
+        {!needsPlatformAccess && active === 'stream-health' ? <StreamHealthPage /> : null}
+        {!needsPlatformAccess && active === 'groups' ? <GroupsPage /> : null}
+        {!needsPlatformAccess && active === 'platform-health' ? <PlatformHealth summary={summary} health={health} /> : null}
+        {!needsPlatformAccess && active === 'platform-operations' ? <Operations operations={operations} /> : null}
+        {!needsPlatformAccess && active === 'platform-audit' ? <AuditLog audit={audit} /> : null}
       </main>
     </div>
   );
@@ -318,11 +320,24 @@ function GroupsPage() {
   );
 }
 
-function PlatformHealth({ summary, health, me, onLogin }) {
+function PlatformAccessGate({ active, onLogin }) {
+  return (
+    <>
+      <LoginPanel mode="platform" title="Platform admin login" onLogin={onLogin} />
+      <section className="panel split-panel">
+        <div>
+          <h2>Platform access required</h2>
+          <p>Sign in with a platform admin session to open {titleFor(active)}.</p>
+        </div>
+      </section>
+    </>
+  );
+}
+
+function PlatformHealth({ summary, health }) {
   const customerCount = summary?.customers ?? '-';
   return (
     <>
-      {me?.kind !== 'platform_admin' ? <LoginPanel mode="platform" title="Platform admin login" onLogin={onLogin} /> : null}
       <section className="panel split-panel">
         <div>
           <h2>Platform Operations</h2>

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -4,13 +4,18 @@ import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
 
-const navItems = [
-  { id: 'console', label: 'Customer Fleet', path: '/console' },
-  { id: 'customers', label: 'Customers', path: '/console/customers' },
+const customerNavItems = [
+  { id: 'overview', label: 'Overview', path: '/console/overview' },
   { id: 'devices', label: 'Devices', path: '/console/devices' },
-  { id: 'operations', label: 'Provisioning', path: '/console/operations' },
-  { id: 'admin', label: 'Platform Admin', path: '/admin' },
-  { id: 'audit', label: 'Audit', path: '/console/audit' },
+  { id: 'firmware-ota', label: 'Firmware & OTA', path: '/console/firmware-ota' },
+  { id: 'stream-health', label: 'Stream Health', path: '/console/stream-health' },
+  { id: 'groups', label: 'Groups', path: '/console/groups' },
+];
+
+const platformNavItems = [
+  { id: 'platform-health', label: 'Service Health', path: '/admin' },
+  { id: 'platform-operations', label: 'Operations Log', path: '/admin/ops' },
+  { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
 ];
 
 function App() {
@@ -25,6 +30,8 @@ function App() {
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
   const [error, setError] = useState('');
   const [refreshTick, setRefreshTick] = useState(0);
+  const isPlatformView = active.startsWith('platform');
+  const visibleNavItems = isPlatformView ? platformNavItems : customerNavItems;
 
   useEffect(() => {
     let alive = true;
@@ -35,8 +42,8 @@ function App() {
         if (!alive) return;
         setMe(nextMe);
 
-        const useAdminApi = active === 'admin' && nextMe.kind === 'platform_admin';
-        if (active === 'admin' && nextMe.kind !== 'platform_admin') {
+        const useAdminApi = isPlatformView && nextMe.kind === 'platform_admin';
+        if (isPlatformView && nextMe.kind !== 'platform_admin') {
           setSummary(null);
           setCustomers([]);
           setDevices([]);
@@ -102,6 +109,11 @@ function App() {
     setActive(item.id);
   }
 
+  function switchView(targetActive) {
+    const target = targetActive === 'platform' ? platformNavItems[0] : customerNavItems[0];
+    navigate(target);
+  }
+
   function selectDevice(deviceId) {
     setSelectedDeviceId(deviceId);
     const path = '/console/devices';
@@ -117,8 +129,8 @@ function App() {
       return;
     }
     setRefreshTick((tick) => tick + 1);
-    window.history.pushState({}, '', '/console/operations');
-    setActive('operations');
+    window.history.pushState({}, '', '/admin/ops');
+    setActive('platform-operations');
   }
 
   async function handleLogin(kind, credentials) {
@@ -177,8 +189,19 @@ function App() {
             <small>Admin Console</small>
           </div>
         </div>
+        <div className="view-switcher">
+          <small>Workspace</small>
+          <div className="view-switcher-buttons">
+            <button className={!isPlatformView ? 'active' : ''} onClick={() => switchView('customer')}>
+              Customer View
+            </button>
+            <button className={isPlatformView ? 'active' : ''} onClick={() => switchView('platform')}>
+              Platform View
+            </button>
+          </div>
+        </div>
         <nav>
-          {navItems.map((item) => (
+          {visibleNavItems.map((item) => (
             <button
               key={item.id}
               className={active === item.id ? 'active' : ''}
@@ -217,8 +240,7 @@ function App() {
 
         {error ? <div className="error">{error}</div> : null}
 
-        {active === 'console' ? <Dashboard summary={summary} health={health} operations={operations} me={me} onLogin={handleLogin} /> : null}
-        {active === 'customers' ? <Customers customers={customers} /> : null}
+        {active === 'overview' ? <Overview summary={summary} me={me} onLogin={handleLogin} /> : null}
         {active === 'devices' ? (
           <Devices
             devices={devices}
@@ -227,36 +249,91 @@ function App() {
             onAction={runDeviceAction}
           />
         ) : null}
-        {active === 'operations' ? <Operations operations={operations} /> : null}
-        {active === 'admin' ? <PlatformAdmin summary={summary} health={health} devices={devices} customers={customers} operations={operations} audit={audit} me={me} onLogin={handleLogin} /> : null}
-        {active === 'audit' ? <AuditLog audit={audit} /> : null}
+        {active === 'firmware-ota' ? <FirmwareOTAPage /> : null}
+        {active === 'stream-health' ? <StreamHealthPage /> : null}
+        {active === 'groups' ? <GroupsPage /> : null}
+        {active === 'platform-health' ? <PlatformHealth summary={summary} health={health} me={me} onLogin={handleLogin} /> : null}
+        {active === 'platform-operations' ? <Operations operations={operations} /> : null}
+        {active === 'platform-audit' ? <AuditLog audit={audit} /> : null}
       </main>
     </div>
   );
 }
 
-function Dashboard({ summary, health, operations, me, onLogin }) {
+function Overview({ summary, me, onLogin }) {
   return (
     <>
       <MetricGrid summary={summary} />
       {!me?.authenticated ? <LoginPanel mode="customer" title="Customer Account Manager login" onLogin={onLogin} /> : null}
       <section className="panel split-panel">
         <div>
-          <h2>Lifecycle focus</h2>
-          <p>Provisioning and readiness use the shared contract vocabulary.</p>
-          <div className="timeline">
-            <span>registered</span>
-            <span>cloud_activation_pending</span>
-            <span>activated</span>
-            <span>online</span>
-          </div>
-        </div>
-        <div>
-          <h2>Recent operations</h2>
-          <OperationList operations={operations.slice(0, 3)} />
+          <h2>Customer overview</h2>
+          <p>Monitor fleet key metrics and access fleet management pages.</p>
+          <p>Use the Devices page to perform read and lifecycle actions for your own organization.</p>
         </div>
       </section>
-      <ServiceHealth health={health} />
+    </>
+  );
+}
+
+function FirmwareOTAPage() {
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <div>
+          <h2>Firmware &amp; OTA</h2>
+          <p>Firmware policy and rollout staging is in progress and will be added in this section.</p>
+        </div>
+      </div>
+      <p className="placeholder-subtitle">This section is a temporary placeholder while the OTA workflow is being integrated.</p>
+    </section>
+  );
+}
+
+function StreamHealthPage() {
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <div>
+          <h2>Stream Health</h2>
+          <p>Stream diagnostics and quality summaries will be available in the next milestone.</p>
+        </div>
+      </div>
+      <p className="placeholder-subtitle">Placeholder area for customer-facing stream observability insights.</p>
+    </section>
+  );
+}
+
+function GroupsPage() {
+  return (
+    <section className="panel">
+      <div className="panel-head">
+        <div>
+          <h2>Groups</h2>
+          <p>Customer group management and membership assignment will be added here.</p>
+        </div>
+      </div>
+      <p className="placeholder-subtitle">Placeholder area for customer group workspace.</p>
+    </section>
+  );
+}
+
+function PlatformHealth({ summary, health, me, onLogin }) {
+  const customerCount = summary?.customers ?? '-';
+  return (
+    <>
+      {me?.kind !== 'platform_admin' ? <LoginPanel mode="platform" title="Platform admin login" onLogin={onLogin} /> : null}
+      <section className="panel split-panel">
+        <div>
+          <h2>Platform Operations</h2>
+          <p>Cross-customer view for service and operations support teams.</p>
+          <div className="admin-kpis">
+            <div><strong>{customerCount}</strong><span>Customers</span></div>
+            <div><strong>{health.length}</strong><span>Service checks</span></div>
+          </div>
+        </div>
+        <ServiceHealth health={health} compact />
+      </section>
     </>
   );
 }
@@ -882,23 +959,29 @@ function toTitleCase(value) {
 
 function titleFor(active) {
   return {
-    console: 'Customer Fleet',
-    customers: 'Customers',
+    overview: 'Customer Overview',
     devices: 'Devices',
-    operations: 'Provisioning',
-    admin: 'Platform Operations',
-    audit: 'Audit',
+    'firmware-ota': 'Firmware & OTA',
+    'stream-health': 'Stream Health',
+    groups: 'Groups',
+    'platform-health': 'Service Health',
+    'platform-operations': 'Operations',
+    'platform-audit': 'Audit Log',
   }[active];
 }
 
 function routeFromLocation() {
   const path = window.location.pathname;
-  if (path === '/admin' || path.startsWith('/admin/')) return 'admin';
-  if (path === '/console/customers') return 'customers';
-  if (path === '/console/devices') return 'devices';
-  if (path === '/console/operations') return 'operations';
-  if (path === '/console/audit') return 'audit';
-  return 'console';
+  if (path === '/admin' || path === '/admin/') return 'platform-health';
+  if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
+  if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';
+  if (path === '/console' || path === '/console/' || path === '/console/overview' || path.startsWith('/console/overview/')) return 'overview';
+  if (path === '/console/devices' || path.startsWith('/console/devices/')) return 'devices';
+  if (path === '/console/firmware-ota' || path.startsWith('/console/firmware-ota/')) return 'firmware-ota';
+  if (path === '/console/stream-health' || path.startsWith('/console/stream-health/')) return 'stream-health';
+  if (path === '/console/groups' || path.startsWith('/console/groups/')) return 'groups';
+  if (path === '/console/customers' || path === '/console/operations' || path === '/console/audit') return 'overview';
+  return 'overview';
 }
 
 class AuthError extends Error {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,22 +1,9 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { customerNavItems, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
-
-const customerNavItems = [
-  { id: 'overview', label: 'Overview', path: '/console/overview' },
-  { id: 'devices', label: 'Devices', path: '/console/devices' },
-  { id: 'firmware-ota', label: 'Firmware & OTA', path: '/console/firmware-ota' },
-  { id: 'stream-health', label: 'Stream Health', path: '/console/stream-health' },
-  { id: 'groups', label: 'Groups', path: '/console/groups' },
-];
-
-const platformNavItems = [
-  { id: 'platform-health', label: 'Service Health', path: '/admin' },
-  { id: 'platform-operations', label: 'Operations Log', path: '/admin/ops' },
-  { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
-];
 
 function App() {
   const [active, setActive] = useState(routeFromLocation());
@@ -970,33 +957,6 @@ function toTitleCase(value) {
     .filter(Boolean)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
     .join(' ');
-}
-
-function titleFor(active) {
-  return {
-    overview: 'Customer Overview',
-    devices: 'Devices',
-    'firmware-ota': 'Firmware & OTA',
-    'stream-health': 'Stream Health',
-    groups: 'Groups',
-    'platform-health': 'Service Health',
-    'platform-operations': 'Operations',
-    'platform-audit': 'Audit Log',
-  }[active];
-}
-
-function routeFromLocation() {
-  const path = window.location.pathname;
-  if (path === '/admin' || path === '/admin/') return 'platform-health';
-  if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
-  if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';
-  if (path === '/console' || path === '/console/' || path === '/console/overview' || path.startsWith('/console/overview/')) return 'overview';
-  if (path === '/console/devices' || path.startsWith('/console/devices/')) return 'devices';
-  if (path === '/console/firmware-ota' || path.startsWith('/console/firmware-ota/')) return 'firmware-ota';
-  if (path === '/console/stream-health' || path.startsWith('/console/stream-health/')) return 'stream-health';
-  if (path === '/console/groups' || path.startsWith('/console/groups/')) return 'groups';
-  if (path === '/console/customers' || path === '/console/operations' || path === '/console/audit') return 'overview';
-  return 'overview';
 }
 
 class AuthError extends Error {

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -1,0 +1,44 @@
+export const customerNavItems = [
+  { id: 'overview', label: 'Overview', path: '/console/overview' },
+  { id: 'devices', label: 'Devices', path: '/console/devices' },
+  { id: 'firmware-ota', label: 'Firmware & OTA', path: '/console/firmware-ota' },
+  { id: 'stream-health', label: 'Stream Health', path: '/console/stream-health' },
+  { id: 'groups', label: 'Groups', path: '/console/groups' },
+];
+
+export const platformNavItems = [
+  { id: 'platform-health', label: 'Service Health', path: '/admin' },
+  { id: 'platform-operations', label: 'Operations Log', path: '/admin/ops' },
+  { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
+];
+
+export function titleFor(active) {
+  return {
+    overview: 'Customer Overview',
+    devices: 'Devices',
+    'firmware-ota': 'Firmware & OTA',
+    'stream-health': 'Stream Health',
+    groups: 'Groups',
+    'platform-health': 'Service Health',
+    'platform-operations': 'Operations',
+    'platform-audit': 'Audit Log',
+  }[active];
+}
+
+export function routeFromPath(path) {
+  if (path === '/admin' || path === '/admin/') return 'platform-health';
+  if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
+  if (path === '/admin/operations' || path.startsWith('/admin/operations/')) return 'platform-operations';
+  if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';
+  if (path === '/console' || path === '/console/' || path === '/console/overview' || path.startsWith('/console/overview/')) return 'overview';
+  if (path === '/console/devices' || path.startsWith('/console/devices/')) return 'devices';
+  if (path === '/console/firmware-ota' || path.startsWith('/console/firmware-ota/')) return 'firmware-ota';
+  if (path === '/console/stream-health' || path.startsWith('/console/stream-health/')) return 'stream-health';
+  if (path === '/console/groups' || path.startsWith('/console/groups/')) return 'groups';
+  if (path === '/console/customers' || path === '/console/operations' || path === '/console/audit') return 'overview';
+  return 'overview';
+}
+
+export function routeFromLocation() {
+  return routeFromPath(window.location.pathname);
+}

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { routeFromPath } from './routes.mjs';
+
+test('maps platform shell paths to platform routes', () => {
+  assert.equal(routeFromPath('/admin'), 'platform-health');
+  assert.equal(routeFromPath('/admin/ops'), 'platform-operations');
+  assert.equal(routeFromPath('/admin/operations'), 'platform-operations');
+  assert.equal(routeFromPath('/admin/audit'), 'platform-audit');
+});
+
+test('maps customer shell paths to customer routes', () => {
+  assert.equal(routeFromPath('/console'), 'overview');
+  assert.equal(routeFromPath('/console/overview'), 'overview');
+  assert.equal(routeFromPath('/console/devices'), 'devices');
+  assert.equal(routeFromPath('/console/firmware-ota'), 'firmware-ota');
+  assert.equal(routeFromPath('/console/stream-health'), 'stream-health');
+  assert.equal(routeFromPath('/console/groups'), 'groups');
+});

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -75,6 +75,29 @@ input {
   width: 96px;
 }
 
+.view-switcher {
+  margin-bottom: 16px;
+}
+
+.view-switcher small {
+  color: rgba(255, 255, 255, 0.72);
+  display: block;
+  font-size: 12px;
+  margin-bottom: 8px;
+}
+
+.view-switcher-buttons {
+  display: grid;
+  gap: 6px;
+}
+
+.view-switcher-buttons button,
+.view-switcher-buttons button:hover,
+.view-switcher-buttons button.active {
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+}
+
 .brand small,
 td small {
   display: block;
@@ -418,6 +441,10 @@ dd {
   border-radius: 8px;
   min-height: 38px;
   padding: 8px 10px;
+}
+
+.placeholder-subtitle {
+  color: var(--muted);
 }
 
 .login-panel button {


### PR DESCRIPTION
## Summary
- Restructure sidebar and routing into two view modes: Customer View and Platform View.
- Add Customer routes: Overview, Devices, Firmware & OTA, Stream Health, Groups.
- Add Platform routes: Service Health (/admin), Operations (/admin/ops), Audit Log (/admin/audit).
- Remove customer dashboard internal timeline and service health from customer-facing pages.
- Keep platform actions and ops log navigation behavior after device action.

Closes #24