### PR TITLE
feat: add device telemetry endpoint

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -739,7 +739,7 @@ func telemetryUptime7D(samples []videoclient.DeviceTelemetryUptime) []contracts.
 			for _, value := range values {
 				sum += value
 			}
-			lastPct = sum / float64(len(values))
+			lastPct = telemetryOnlinePctFromUptimeSec(sum / float64(len(values)))
 		}
 		out = append(out, contracts.TelemetryUptimeSample{
 			Date:      date,
@@ -852,9 +852,10 @@ func demoTelemetryForDevice(device contracts.Device) contracts.DeviceTelemetry {
 			AvgDBM:  avg,
 			Quality: telemetryQualityFromDBM(avg),
 		})
+		uptimeSeconds := float64((96.0 + float64(i)/10.0) / 100.0 * telemetrySecondsPerDay)
 		uptime = append(uptime, contracts.TelemetryUptimeSample{
 			Date:      date,
-			OnlinePct: 96.0 + float64(i)/10.0,
+			OnlinePct: telemetryOnlinePctFromUptimeSec(uptimeSeconds),
 		})
 	}
 
@@ -1835,4 +1836,17 @@ func (s *Server) videoCloudFacts(ctx context.Context, devices []accountclient.De
 		}
 	}
 	return out
+}
+
+const telemetrySecondsPerDay = 24 * 60 * 60
+
+func telemetryOnlinePctFromUptimeSec(uptimeSec float64) float64 {
+	pct := uptimeSec / float64(telemetrySecondsPerDay) * 100
+	if pct < 0 {
+		pct = 0
+	}
+	if pct > 100 {
+		pct = 100
+	}
+	return math.Round(pct*10) / 10
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -431,14 +432,21 @@ func (s *Server) apiDeviceTelemetry(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "customer authentication required", http.StatusUnauthorized)
 		return
 	}
-	devices, err := s.customerDevices(r.Context(), session)
 	if s.accountClient.Enabled() {
+		devices, err := s.customerDevices(r.Context(), session)
 		if err != nil {
 			s.writeCustomerErrorForSession(w, session.ID, err)
 			return
 		}
 		for _, device := range devices {
 			if device.ID == r.PathValue("id") {
+				if telemetry, ok, err := s.proxyTelemetryForDevice(r.Context(), session, device); err != nil {
+					s.writeCustomerErrorForSession(w, session.ID, err)
+					return
+				} else if ok {
+					writeJSON(w, telemetry)
+					return
+				}
 				writeJSON(w, demoTelemetryForDevice(device))
 				return
 			}
@@ -459,7 +467,7 @@ func (s *Server) apiDeviceTelemetry(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	writeJSON(w, demoTelemetryForDevice(contracts.Device{
+	telemetryDevice := contracts.Device{
 		ID:              device.ID,
 		OrganizationID:  device.OrganizationID,
 		Organization:    device.Organization,
@@ -472,7 +480,341 @@ func (s *Server) apiDeviceTelemetry(w http.ResponseWriter, r *http.Request) {
 		Readiness:       device.Readiness,
 		LastSeenAt:      device.LastSeenAt,
 		UpdatedAt:       device.UpdatedAt,
-	}))
+	}
+	if telemetry, ok, err := s.proxyTelemetryForDevice(r.Context(), session, telemetryDevice); err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	} else if ok {
+		writeJSON(w, telemetry)
+		return
+	}
+	writeJSON(w, demoTelemetryForDevice(telemetryDevice))
+}
+
+func (s *Server) proxyTelemetryForDevice(ctx context.Context, session store.Session, device contracts.Device) (contracts.DeviceTelemetry, bool, error) {
+	if !s.videoClient.Enabled() || strings.TrimSpace(s.cfg.VideoCloudAdminToken) == "" || strings.TrimSpace(device.VideoCloudDevID) == "" {
+		return contracts.DeviceTelemetry{}, false, nil
+	}
+	upstream, err := s.videoClient.DeviceTelemetry(ctx, s.cfg.VideoCloudAdminToken, device.VideoCloudDevID, session.ActiveOrgID)
+	if err != nil {
+		return contracts.DeviceTelemetry{}, true, err
+	}
+	info, err := s.videoClient.GetDeviceInfo(ctx, s.cfg.VideoCloudAdminToken, device.VideoCloudDevID)
+	firmwareVersion := firmwareVersionFromDevice(device)
+	if err == nil && strings.TrimSpace(info.FirmwareVersion) != "" {
+		firmwareVersion = strings.TrimSpace(info.FirmwareVersion)
+	}
+	return telemetryFromVideoCloud(device.ID, firmwareVersion, upstream), true, nil
+}
+
+func telemetryFromVideoCloud(deviceID, firmwareVersion string, upstream videoclient.DeviceTelemetryResponse) contracts.DeviceTelemetry {
+	signals := telemetrySignalsFromUpstream(upstream.LatestHealth, upstream.RecentEvents)
+	health := telemetryHealthFromUpstream(upstream.LatestHealth, signals)
+	if strings.TrimSpace(firmwareVersion) == "" {
+		firmwareVersion = "unknown"
+	}
+	return contracts.DeviceTelemetry{
+		DeviceID:        deviceID,
+		Health:          health,
+		Signals:         signals,
+		FirmwareVersion: strings.TrimSpace(firmwareVersion),
+		RSSI7D:          telemetryRSSI7D(upstream.RSSIHistory),
+		Uptime7D:        telemetryUptime7D(upstream.UptimeHistory),
+		RecentEvents:    telemetryRecentEvents(upstream.RecentEvents, 10),
+	}
+}
+
+func telemetryHealthFromUpstream(latest *videoclient.DeviceTelemetryHealth, signals []string) string {
+	if latest != nil {
+		if health := canonicalTelemetryHealthState(latest.State); health != "" {
+			return health
+		}
+	}
+	if len(signals) > 0 {
+		for _, signal := range signals {
+			switch signal {
+			case "recent_crash", "offline_risk", "low_memory":
+				return "critical"
+			case "low_rssi", "recent_reboot":
+				return "warning"
+			}
+		}
+		return "warning"
+	}
+	return "unknown"
+}
+
+func canonicalTelemetryHealthState(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "healthy", "ok", "good", "normal":
+		return "healthy"
+	case "warning", "warn", "degraded", "fair":
+		return "warning"
+	case "critical", "crit", "bad", "error", "offline":
+		return "critical"
+	case "unknown":
+		return "unknown"
+	default:
+		return ""
+	}
+}
+
+func telemetrySignalsFromUpstream(latest *videoclient.DeviceTelemetryHealth, events []videoclient.DeviceTelemetryEvent) []string {
+	signals := make([]string, 0, 5)
+	seen := map[string]bool{}
+	add := func(signal string) {
+		if signal == "" || seen[signal] {
+			return
+		}
+		seen[signal] = true
+		signals = append(signals, signal)
+	}
+	if latest != nil {
+		addValidatedTelemetrySignals(&signals, seen, telemetrySignalsFromPayload(latest.Payload))
+	}
+	for _, event := range events {
+		switch event.EventType {
+		case "device.health.rssi_sample":
+			if quality := telemetryStringPayload(event.Payload, "quality"); quality == "poor" {
+				add("low_rssi")
+			}
+			if rssi := telemetryIntPayload(event.Payload, "rssi_dbm"); rssi != nil && *rssi <= -75 {
+				add("low_rssi")
+			}
+		case "device.reboot.reported":
+			add("recent_reboot")
+		case "device.crash.reported":
+			add("recent_crash")
+		case "device.health.memory_sample":
+			if telemetryBoolPayload(event.Payload, "low_memory") {
+				add("low_memory")
+			}
+		case "device.health.offline_risk":
+			add("offline_risk")
+		}
+	}
+	if len(signals) == 0 && latest != nil {
+		addValidatedTelemetrySignals(&signals, seen, telemetrySignalsFromPayload(latest.Payload))
+	}
+	return signals
+}
+
+func addValidatedTelemetrySignals(out *[]string, seen map[string]bool, signals []string) {
+	for _, signal := range signals {
+		switch signal {
+		case "low_rssi", "recent_reboot", "low_memory", "recent_crash", "offline_risk":
+			if seen[signal] {
+				continue
+			}
+			seen[signal] = true
+			*out = append(*out, signal)
+		}
+	}
+}
+
+func telemetrySignalsFromPayload(payload json.RawMessage) []string {
+	var decoded struct {
+		Signals []string `json:"signals"`
+	}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(decoded.Signals))
+	for _, signal := range decoded.Signals {
+		signal = strings.TrimSpace(signal)
+		switch signal {
+		case "low_rssi", "recent_reboot", "low_memory", "recent_crash", "offline_risk":
+			out = append(out, signal)
+		}
+	}
+	return out
+}
+
+func telemetryStringPayload(payload json.RawMessage, key string) string {
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return ""
+	}
+	if value, ok := decoded[key].(string); ok {
+		return strings.TrimSpace(value)
+	}
+	return ""
+}
+
+func telemetryBoolPayload(payload json.RawMessage, key string) bool {
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return false
+	}
+	value, ok := decoded[key]
+	if !ok {
+		return false
+	}
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		return strings.EqualFold(strings.TrimSpace(v), "true")
+	default:
+		return false
+	}
+}
+
+func telemetryIntPayload(payload json.RawMessage, key string) *int {
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return nil
+	}
+	value, ok := decoded[key]
+	if !ok {
+		return nil
+	}
+	switch v := value.(type) {
+	case float64:
+		if math.Trunc(v) != v {
+			return nil
+		}
+		out := int(v)
+		return &out
+	case string:
+		parsed, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil {
+			return nil
+		}
+		return &parsed
+	default:
+		return nil
+	}
+}
+
+func telemetryRSSI7D(samples []videoclient.DeviceTelemetryRSSI) []contracts.TelemetryRssiSample {
+	dates := telemetryLastSevenDates()
+	buckets := make(map[string][]int, len(dates))
+	for _, sample := range samples {
+		if sample.RSSIDBm == nil {
+			continue
+		}
+		date := sample.OccurredAt.UTC().Format("2006-01-02")
+		buckets[date] = append(buckets[date], *sample.RSSIDBm)
+	}
+	out := make([]contracts.TelemetryRssiSample, 0, len(dates))
+	lastAvg := -70
+	for _, date := range dates {
+		values := buckets[date]
+		if len(values) > 0 {
+			sum := 0
+			for _, value := range values {
+				sum += value
+			}
+			lastAvg = int(math.Round(float64(sum) / float64(len(values))))
+		}
+		out = append(out, contracts.TelemetryRssiSample{
+			Date:    date,
+			AvgDBM:  lastAvg,
+			Quality: telemetryQualityFromDBM(lastAvg),
+		})
+	}
+	return out
+}
+
+func telemetryUptime7D(samples []videoclient.DeviceTelemetryUptime) []contracts.TelemetryUptimeSample {
+	dates := telemetryLastSevenDates()
+	buckets := make(map[string][]float64, len(dates))
+	for _, sample := range samples {
+		date := sample.OccurredAt.UTC().Format("2006-01-02")
+		buckets[date] = append(buckets[date], float64(sample.UptimeSec))
+	}
+	out := make([]contracts.TelemetryUptimeSample, 0, len(dates))
+	lastPct := 96.0
+	for _, date := range dates {
+		values := buckets[date]
+		if len(values) > 0 {
+			sum := 0.0
+			for _, value := range values {
+				sum += value
+			}
+			lastPct = sum / float64(len(values))
+		}
+		out = append(out, contracts.TelemetryUptimeSample{
+			Date:      date,
+			OnlinePct: lastPct,
+		})
+	}
+	return out
+}
+
+func telemetryRecentEvents(events []videoclient.DeviceTelemetryEvent, limit int) []contracts.TelemetryEvent {
+	out := make([]contracts.TelemetryEvent, 0, len(events))
+	for _, event := range events {
+		out = append(out, contracts.TelemetryEvent{
+			OccurredAt: event.OccurredAt.UTC().Format(time.RFC3339),
+			EventType:  event.EventType,
+			Summary:    telemetryEventSummary(event),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		left, err := time.Parse(time.RFC3339, out[i].OccurredAt)
+		if err != nil {
+			return false
+		}
+		right, err := time.Parse(time.RFC3339, out[j].OccurredAt)
+		if err != nil {
+			return false
+		}
+		if !left.Equal(right) {
+			return left.After(right)
+		}
+		return out[i].EventType < out[j].EventType
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+func telemetryEventSummary(event videoclient.DeviceTelemetryEvent) string {
+	if summary := telemetryStringPayload(event.Payload, "summary"); summary != "" {
+		return summary
+	}
+	switch event.EventType {
+	case "device.health.rssi_sample":
+		rssi := telemetryIntPayload(event.Payload, "rssi_dbm")
+		quality := telemetryStringPayload(event.Payload, "quality")
+		if rssi != nil && quality != "" {
+			return fmt.Sprintf("Signal quality is %s at %d dBm", quality, *rssi)
+		}
+		if rssi != nil {
+			return fmt.Sprintf("Signal quality measured at %d dBm", *rssi)
+		}
+	case "device.reboot.reported":
+		if reason := telemetryStringPayload(event.Payload, "reason"); reason != "" {
+			return fmt.Sprintf("Device reboot reported: %s", reason)
+		}
+		return "Device reboot reported"
+	case "device.crash.reported":
+		if reason := telemetryStringPayload(event.Payload, "reason"); reason != "" {
+			return fmt.Sprintf("Crash reported: %s", reason)
+		}
+		return "Crash reported"
+	case "firmware.version.observed":
+		if version := telemetryStringPayload(event.Payload, "current_version"); version != "" {
+			return fmt.Sprintf("Firmware version observed: %s", version)
+		}
+		if version := telemetryStringPayload(event.Payload, "firmware_version"); version != "" {
+			return fmt.Sprintf("Firmware version observed: %s", version)
+		}
+		return "Firmware version observed"
+	}
+	return strings.ReplaceAll(event.EventType, ".", " ")
+}
+
+func telemetryLastSevenDates() []string {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	out := make([]string, 0, 7)
+	for i := 6; i >= 0; i-- {
+		out = append(out, today.AddDate(0, 0, -i).Format("2006-01-02"))
+	}
+	return out
 }
 
 func demoTelemetryForDevice(device contracts.Device) contracts.DeviceTelemetry {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -85,6 +87,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/devices", s.apiDevices)
 	s.mux.HandleFunc("GET /api/admin/devices", s.apiAdminDevices)
 	s.mux.HandleFunc("GET /api/devices/{id}", s.apiDevice)
+	s.mux.HandleFunc("GET /api/devices/{id}/telemetry", s.apiDeviceTelemetry)
 	s.mux.HandleFunc("GET /api/operations", s.apiOperations)
 	s.mux.HandleFunc("GET /api/admin/operations", s.apiAdminOperations)
 	s.mux.HandleFunc("GET /api/service-health", s.apiServiceHealth)
@@ -420,6 +423,155 @@ func (s *Server) apiDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, device)
+}
+
+func (s *Server) apiDeviceTelemetry(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requestSession(r)
+	if !ok || session.Kind != "customer" {
+		http.Error(w, "customer authentication required", http.StatusUnauthorized)
+		return
+	}
+	devices, err := s.customerDevices(r.Context(), session)
+	if s.accountClient.Enabled() {
+		if err != nil {
+			s.writeCustomerErrorForSession(w, session.ID, err)
+			return
+		}
+		for _, device := range devices {
+			if device.ID == r.PathValue("id") {
+				writeJSON(w, demoTelemetryForDevice(device))
+				return
+			}
+		}
+		http.NotFound(w, r)
+		return
+	}
+	if session.ActiveOrgID == "" {
+		http.Error(w, "customer authentication required", http.StatusUnauthorized)
+		return
+	}
+	device, err := s.store.GetDevice(r.PathValue("id"))
+	if err != nil {
+		http.NotFound(w, r)
+		return
+	}
+	if device.OrganizationID != session.ActiveOrgID {
+		http.NotFound(w, r)
+		return
+	}
+	writeJSON(w, demoTelemetryForDevice(contracts.Device{
+		ID:              device.ID,
+		OrganizationID:  device.OrganizationID,
+		Organization:    device.Organization,
+		Name:            device.Name,
+		Category:        device.Category,
+		Model:           device.Model,
+		SerialNumber:    device.SerialNumber,
+		VideoCloudDevID: device.VideoCloudDevID,
+		Status:          device.Status,
+		Readiness:       device.Readiness,
+		LastSeenAt:      device.LastSeenAt,
+		UpdatedAt:       device.UpdatedAt,
+	}))
+}
+
+func demoTelemetryForDevice(device contracts.Device) contracts.DeviceTelemetry {
+	health := "healthy"
+	signals := []string{}
+	switch device.Readiness {
+	case contracts.ReadinessFailed, contracts.ReadinessCloudActivationPending:
+		health = "critical"
+		signals = append(signals, "low_rssi", "offline_risk", "low_memory")
+	case contracts.ReadinessActivated:
+		health = "warning"
+		signals = append(signals, "low_rssi")
+	case contracts.ReadinessLocalOnboardingPending, contracts.ReadinessClaimPending, contracts.ReadinessDeactivationPending:
+		health = "warning"
+		signals = append(signals, "recent_reboot")
+	default:
+		health = "healthy"
+	}
+
+	rssi := make([]contracts.TelemetryRssiSample, 0, 7)
+	uptime := make([]contracts.TelemetryUptimeSample, 0, 7)
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	baseDBM := -64
+	for i := 6; i >= 0; i-- {
+		date := today.AddDate(0, 0, -i).Format("2006-01-02")
+		avg := baseDBM - (6-i)*2
+		rssi = append(rssi, contracts.TelemetryRssiSample{
+			Date:    date,
+			AvgDBM:  avg,
+			Quality: telemetryQualityFromDBM(avg),
+		})
+		uptime = append(uptime, contracts.TelemetryUptimeSample{
+			Date:      date,
+			OnlinePct: 96.0 + float64(i)/10.0,
+		})
+	}
+
+	recent := []contracts.TelemetryEvent{
+		{
+			OccurredAt: time.Now().UTC().Add(-1 * time.Hour).Format(time.RFC3339),
+			EventType:  "device.health.summary",
+			Summary:    "Health summary indicates elevated wifi variance",
+		},
+		{
+			OccurredAt: time.Now().UTC().Add(-3 * time.Hour).Format(time.RFC3339),
+			EventType:  "device.health.rssi_sample",
+			Summary:    "Signal quality dropped to fair due interference",
+		},
+		{
+			OccurredAt: time.Now().UTC().Add(-6 * time.Hour).Format(time.RFC3339),
+			EventType:  "device.reboot.reported",
+			Summary:    "Device reboot reported by endpoint",
+		},
+		{
+			OccurredAt: time.Now().UTC().Add(-10 * time.Hour).Format(time.RFC3339),
+			EventType:  "device.crash.reported",
+			Summary:    "Crash event recovered automatically",
+		},
+	}
+	sort.Slice(recent, func(i, j int) bool {
+		left, err := time.Parse(time.RFC3339, recent[i].OccurredAt)
+		if err != nil {
+			return false
+		}
+		right, err := time.Parse(time.RFC3339, recent[j].OccurredAt)
+		if err != nil {
+			return false
+		}
+		return left.After(right)
+	})
+
+	version := firmwareVersionFromDevice(device)
+	return contracts.DeviceTelemetry{
+		DeviceID:        device.ID,
+		Health:          health,
+		Signals:         signals,
+		FirmwareVersion: version,
+		RSSI7D:          rssi,
+		Uptime7D:        uptime,
+		RecentEvents:    recent,
+	}
+}
+
+func telemetryQualityFromDBM(avgDBM int) string {
+	if avgDBM >= -60 {
+		return "good"
+	}
+	if avgDBM >= -75 {
+		return "fair"
+	}
+	return "poor"
+}
+
+func firmwareVersionFromDevice(device contracts.Device) string {
+	suffix := strings.TrimPrefix(device.ID, "dev-")
+	if parsed, err := strconv.Atoi(suffix); err == nil {
+		return fmt.Sprintf("v1.2.%d", parsed)
+	}
+	return fmt.Sprintf("v1.2.%d", len(device.Model))
 }
 
 func (s *Server) apiCustomers(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -750,6 +750,154 @@ func TestDeviceAPIIncludesSourceFacts(t *testing.T) {
 	}
 }
 
+func TestDeviceTelemetryAPIRequiresCustomerSession(t *testing.T) {
+	t.Parallel()
+
+	srv, err := NewTestServer(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("NewTestServer returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/devices/dev-001/telemetry", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("telemetry status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestDeviceTelemetryDemoReturns404ForOutOfOrgDevice(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/dev-003/telemetry", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("out-of-org telemetry status = %d, want %d; body=%s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+}
+
+func TestDeviceTelemetryDemoPayload(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/dev-001/telemetry", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("telemetry status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "video_cloud_devid") {
+		t.Fatalf("telemetry response should not expose video_cloud_devid: %s", rec.Body.String())
+	}
+
+	var payload contracts.DeviceTelemetry
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode telemetry payload: %v", err)
+	}
+	if payload.DeviceID != "dev-001" {
+		t.Fatalf("device_id = %q, want %q", payload.DeviceID, "dev-001")
+	}
+	if payload.Health != "healthy" && payload.Health != "warning" && payload.Health != "critical" {
+		t.Fatalf("health = %q, want healthy|warning|critical", payload.Health)
+	}
+	if len(payload.RSSI7D) != 7 {
+		t.Fatalf("rssi_7d length = %d, want 7", len(payload.RSSI7D))
+	}
+	if len(payload.Uptime7D) != 7 {
+		t.Fatalf("uptime_7d length = %d, want 7", len(payload.Uptime7D))
+	}
+	validQuality := map[string]bool{"good": true, "fair": true, "poor": true}
+	for _, sample := range payload.RSSI7D {
+		if !validQuality[sample.Quality] {
+			t.Fatalf("invalid RSSI quality %q", sample.Quality)
+		}
+	}
+	if len(payload.RecentEvents) == 0 || len(payload.RecentEvents) > 10 {
+		t.Fatalf("recent_events length = %d, want 1..10", len(payload.RecentEvents))
+	}
+	prev, err := time.Parse(time.RFC3339, payload.RecentEvents[0].OccurredAt)
+	if err != nil {
+		t.Fatalf("parse first occurred_at %q: %v", payload.RecentEvents[0].OccurredAt, err)
+	}
+	for i := 1; i < len(payload.RecentEvents); i++ {
+		cur, err := time.Parse(time.RFC3339, payload.RecentEvents[i].OccurredAt)
+		if err != nil {
+			t.Fatalf("parse occurred_at %q: %v", payload.RecentEvents[i].OccurredAt, err)
+		}
+		if prev.Before(cur) {
+			t.Fatalf("recent_events not sorted desc: index=%d", i)
+		}
+		prev = cur
+	}
+	validSignals := map[string]bool{
+		"low_rssi":      true,
+		"recent_reboot":  true,
+		"low_memory":    true,
+		"recent_crash":  true,
+		"offline_risk":  true,
+	}
+	for _, signal := range payload.Signals {
+		if !validSignals[signal] {
+			t.Fatalf("invalid signal %q", signal)
+		}
+	}
+	validEventTypes := map[string]bool{
+		"device.health.summary":      true,
+		"device.health.rssi_sample":  true,
+		"device.reboot.reported":     true,
+		"device.crash.reported":      true,
+		"firmware.version.observed":  true,
+	}
+	for _, event := range payload.RecentEvents {
+		if !validEventTypes[event.EventType] {
+			t.Fatalf("invalid event type %q", event.EventType)
+		}
+		if strings.TrimSpace(event.Summary) == "" {
+			t.Fatalf("event summary is empty for %q", event.EventType)
+		}
+	}
+	if payload.FirmwareVersion == "" {
+		t.Fatalf("firmware_version is empty")
+	}
+}
+
 func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1072,6 +1072,19 @@ func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 	if len(payload.RSSI7D) != 7 || len(payload.Uptime7D) != 7 {
 		t.Fatalf("sparkline lengths = rssi:%d uptime:%d, want 7", len(payload.RSSI7D), len(payload.Uptime7D))
 	}
+	uptimeByDate := make(map[string]float64, len(payload.Uptime7D))
+	for _, sample := range payload.Uptime7D {
+		if sample.OnlinePct < 0 || sample.OnlinePct > 100 {
+			t.Fatalf("uptime sample %s has invalid online_pct %.1f", sample.Date, sample.OnlinePct)
+		}
+		uptimeByDate[sample.Date] = sample.OnlinePct
+	}
+	if got := uptimeByDate["2026-05-01"]; got != 4.2 {
+		t.Fatalf("online_pct for 2026-05-01 = %.1f, want 4.2", got)
+	}
+	if got := uptimeByDate["2026-05-02"]; got != 8.3 {
+		t.Fatalf("online_pct for 2026-05-02 = %.1f, want 8.3", got)
+	}
 	if len(payload.RecentEvents) != 2 || payload.RecentEvents[0].EventType != "device.reboot.reported" {
 		t.Fatalf("recent_events = %+v", payload.RecentEvents)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -11,6 +11,7 @@ import (
 	"rtk_cloud_admin/internal/config"
 	"rtk_cloud_admin/internal/contracts"
 	"rtk_cloud_admin/internal/store"
+	"rtk_cloud_admin/internal/videoclient"
 	"strings"
 	"testing"
 	"time"
@@ -895,6 +896,184 @@ func TestDeviceTelemetryDemoPayload(t *testing.T) {
 	}
 	if payload.FirmwareVersion == "" {
 		t.Fatalf("firmware_version is empty")
+	}
+}
+
+func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			if got := r.Header.Get("Authorization"); got != "Bearer access" {
+				t.Fatalf("account Authorization = %q, want Bearer access", got)
+			}
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"customer@example.com","name":"Customer"},"organizations":[{"id":"org-acme","name":"Acme Smart Camera","role":"owner"}]}`))
+		case "/v1/orgs/org-acme/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"activated","status":"online","video_cloud_devid":"device-2"}]}`))
+		default:
+			t.Fatalf("unexpected account path: %s", r.URL.Path)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/query_camera_activate":
+			if got := r.Header.Get("Authorization"); got != "Bearer vc-secret" {
+				t.Fatalf("query activation Authorization = %q, want Bearer vc-secret", got)
+			}
+			var body struct {
+				Devices []string `json:"devices"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode query activation body: %v", err)
+			}
+			if len(body.Devices) != 1 || body.Devices[0] != "device-2" {
+				t.Fatalf("query activation devices = %+v, want [device-2]", body.Devices)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":  "ok",
+				"devices": []string{"1"},
+			})
+		case "/api/devices/device-2/telemetry":
+			if got := r.URL.Query().Get("org_id"); got != "org-acme" {
+				t.Fatalf("telemetry org_id = %q, want org-acme", got)
+			}
+			if got := r.Header.Get("Authorization"); got != "Bearer vc-secret" {
+				t.Fatalf("telemetry Authorization = %q, want Bearer vc-secret", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":            "ok",
+				"org_id":            "org-acme",
+				"device_id":         "device-2",
+				"account_device_id": "dev-002",
+				"device_name":       "cam-a-002",
+				"latest_health": map[string]any{
+					"state":          "warning",
+					"occurred_at":    "2026-05-04T12:00:00Z",
+					"uptime_seconds": 7200,
+					"payload": map[string]any{
+						"health":  "warning",
+						"signals": []string{"low_rssi", "recent_reboot"},
+					},
+				},
+				"rssi_history": []map[string]any{
+					{"occurred_at": "2026-05-01T10:00:00Z", "rssi_dbm": -68, "quality": "fair"},
+					{"occurred_at": "2026-05-02T10:00:00Z", "rssi_dbm": -72, "quality": "fair"},
+				},
+				"uptime_history": []map[string]any{
+					{"occurred_at": "2026-05-01T10:00:00Z", "uptime_seconds": 3600},
+					{"occurred_at": "2026-05-02T10:00:00Z", "uptime_seconds": 7200},
+				},
+				"recent_events": []map[string]any{
+					{
+						"event_id":    "evt-2",
+						"event_type":  "device.reboot.reported",
+						"occurred_at": "2026-05-04T14:00:00Z",
+						"source":      "device",
+						"payload": map[string]any{
+							"reason":  "watchdog",
+							"summary": "Device reboot reported",
+						},
+					},
+					{
+						"event_id":    "evt-1",
+						"event_type":  "device.health.rssi_sample",
+						"occurred_at": "2026-05-04T13:00:00Z",
+						"source":      "device",
+						"payload": map[string]any{
+							"rssi_dbm": -72,
+							"quality":  "fair",
+							"summary":  "Signal quality dropped to fair",
+						},
+					},
+				},
+			})
+		case "/get_camera_info":
+			if got := r.Header.Get("Authorization"); got != "Bearer vc-secret" {
+				t.Fatalf("camera info Authorization = %q, want Bearer vc-secret", got)
+			}
+			var body struct {
+				DevID string `json:"devid"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode camera info body: %v", err)
+			}
+			if body.DevID != "device-2" {
+				t.Fatalf("camera info devid = %q, want device-2", body.DevID)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"info": map[string]any{
+					"firmware_version":  "v9.8.7",
+					"current_transport": "websocket",
+				},
+			})
+		default:
+			t.Fatalf("unexpected video path: %s", r.URL.Path)
+		}
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := NewWithOptions(st, Options{
+		Config: config.Config{
+			AccountManagerBaseURL: accountUpstream.URL,
+			VideoCloudBaseURL:     videoUpstream.URL,
+			VideoCloudAdminToken:  "vc-secret",
+		},
+		AccountClient: accountclient.New(accountUpstream.URL),
+		VideoClient:   videoclient.New(videoUpstream.URL),
+	})
+	session, err := st.CreateSession("customer", "u1", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/dev-002/telemetry", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("proxy telemetry status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "video_cloud_devid") {
+		t.Fatalf("proxy telemetry response should not expose video_cloud_devid: %s", rec.Body.String())
+	}
+
+	var payload contracts.DeviceTelemetry
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode proxy telemetry payload: %v", err)
+	}
+	if payload.DeviceID != "dev-002" {
+		t.Fatalf("device_id = %q, want dev-002", payload.DeviceID)
+	}
+	if payload.FirmwareVersion != "v9.8.7" {
+		t.Fatalf("firmware_version = %q, want v9.8.7", payload.FirmwareVersion)
+	}
+	if payload.Health != "warning" {
+		t.Fatalf("health = %q, want warning", payload.Health)
+	}
+	if len(payload.Signals) != 2 || payload.Signals[0] != "low_rssi" || payload.Signals[1] != "recent_reboot" {
+		t.Fatalf("signals = %+v, want [low_rssi recent_reboot]", payload.Signals)
+	}
+	if len(payload.RSSI7D) != 7 || len(payload.Uptime7D) != 7 {
+		t.Fatalf("sparkline lengths = rssi:%d uptime:%d, want 7", len(payload.RSSI7D), len(payload.Uptime7D))
+	}
+	if len(payload.RecentEvents) != 2 || payload.RecentEvents[0].EventType != "device.reboot.reported" {
+		t.Fatalf("recent_events = %+v", payload.RecentEvents)
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -868,7 +868,7 @@ func TestDeviceTelemetryDemoPayload(t *testing.T) {
 	}
 	validSignals := map[string]bool{
 		"low_rssi":      true,
-		"recent_reboot":  true,
+		"recent_reboot": true,
 		"low_memory":    true,
 		"recent_crash":  true,
 		"offline_risk":  true,
@@ -879,11 +879,11 @@ func TestDeviceTelemetryDemoPayload(t *testing.T) {
 		}
 	}
 	validEventTypes := map[string]bool{
-		"device.health.summary":      true,
-		"device.health.rssi_sample":  true,
-		"device.reboot.reported":     true,
-		"device.crash.reported":      true,
-		"firmware.version.observed":  true,
+		"device.health.summary":     true,
+		"device.health.rssi_sample": true,
+		"device.reboot.reported":    true,
+		"device.crash.reported":     true,
+		"firmware.version.observed": true,
 	}
 	for _, event := range payload.RecentEvents {
 		if !validEventTypes[event.EventType] {

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -122,3 +122,30 @@ type AuditEvent struct {
 	UpstreamOperationID string `json:"upstream_operation_id,omitempty"`
 	CreatedAt           string `json:"created_at"`
 }
+
+type TelemetryRssiSample struct {
+	Date     string `json:"date"`
+	AvgDBM   int    `json:"avg_dbm"`
+	Quality  string `json:"quality"`
+}
+
+type TelemetryUptimeSample struct {
+	Date      string  `json:"date"`
+	OnlinePct float64 `json:"online_pct"`
+}
+
+type TelemetryEvent struct {
+	OccurredAt string `json:"occurred_at"`
+	EventType string `json:"event_type"`
+	Summary   string `json:"summary"`
+}
+
+type DeviceTelemetry struct {
+	DeviceID        string               `json:"device_id"`
+	Health          string               `json:"health"`
+	Signals         []string             `json:"signals"`
+	FirmwareVersion string               `json:"firmware_version"`
+	RSSI7D          []TelemetryRssiSample `json:"rssi_7d"`
+	Uptime7D        []TelemetryUptimeSample `json:"uptime_7d"`
+	RecentEvents    []TelemetryEvent     `json:"recent_events"`
+}

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -124,9 +124,9 @@ type AuditEvent struct {
 }
 
 type TelemetryRssiSample struct {
-	Date     string `json:"date"`
-	AvgDBM   int    `json:"avg_dbm"`
-	Quality  string `json:"quality"`
+	Date    string `json:"date"`
+	AvgDBM  int    `json:"avg_dbm"`
+	Quality string `json:"quality"`
 }
 
 type TelemetryUptimeSample struct {
@@ -136,16 +136,16 @@ type TelemetryUptimeSample struct {
 
 type TelemetryEvent struct {
 	OccurredAt string `json:"occurred_at"`
-	EventType string `json:"event_type"`
-	Summary   string `json:"summary"`
+	EventType  string `json:"event_type"`
+	Summary    string `json:"summary"`
 }
 
 type DeviceTelemetry struct {
-	DeviceID        string               `json:"device_id"`
-	Health          string               `json:"health"`
-	Signals         []string             `json:"signals"`
-	FirmwareVersion string               `json:"firmware_version"`
-	RSSI7D          []TelemetryRssiSample `json:"rssi_7d"`
+	DeviceID        string                  `json:"device_id"`
+	Health          string                  `json:"health"`
+	Signals         []string                `json:"signals"`
+	FirmwareVersion string                  `json:"firmware_version"`
+	RSSI7D          []TelemetryRssiSample   `json:"rssi_7d"`
 	Uptime7D        []TelemetryUptimeSample `json:"uptime_7d"`
-	RecentEvents    []TelemetryEvent     `json:"recent_events"`
+	RecentEvents    []TelemetryEvent        `json:"recent_events"`
 }

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 )
@@ -14,6 +15,49 @@ import (
 type Client struct {
 	baseURL    string
 	httpClient *http.Client
+}
+
+type DeviceInfo struct {
+	FirmwareVersion  string
+	CurrentTransport string
+}
+
+type DeviceTelemetryResponse struct {
+	Status          string                  `json:"status"`
+	OrgID           string                  `json:"org_id"`
+	DeviceID        string                  `json:"device_id"`
+	AccountDeviceID string                  `json:"account_device_id"`
+	DeviceName      string                  `json:"device_name"`
+	LatestHealth    *DeviceTelemetryHealth  `json:"latest_health"`
+	RSSIHistory     []DeviceTelemetryRSSI   `json:"rssi_history"`
+	UptimeHistory   []DeviceTelemetryUptime `json:"uptime_history"`
+	RecentEvents    []DeviceTelemetryEvent  `json:"recent_events"`
+}
+
+type DeviceTelemetryHealth struct {
+	State      string          `json:"state"`
+	UptimeSec  *int64          `json:"uptime_seconds,omitempty"`
+	OccurredAt time.Time       `json:"occurred_at"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
+}
+
+type DeviceTelemetryRSSI struct {
+	OccurredAt time.Time `json:"occurred_at"`
+	RSSIDBm    *int      `json:"rssi_dbm,omitempty"`
+	Quality    string    `json:"quality,omitempty"`
+}
+
+type DeviceTelemetryUptime struct {
+	OccurredAt time.Time `json:"occurred_at"`
+	UptimeSec  int64     `json:"uptime_seconds"`
+}
+
+type DeviceTelemetryEvent struct {
+	EventID    string          `json:"event_id"`
+	EventType  string          `json:"event_type"`
+	OccurredAt time.Time       `json:"occurred_at"`
+	Source     string          `json:"source"`
+	Payload    json.RawMessage `json:"payload,omitempty"`
 }
 
 func New(baseURL string) *Client {
@@ -27,6 +71,57 @@ func New(baseURL string) *Client {
 
 func (c *Client) Enabled() bool {
 	return c != nil && c.baseURL != ""
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path, adminToken string, in any, out any) error {
+	if !c.Enabled() {
+		return fmt.Errorf("video cloud base URL is not configured")
+	}
+	var body io.Reader = bytes.NewReader(nil)
+	if in != nil {
+		data, err := json.Marshal(in)
+		if err != nil {
+			return err
+		}
+		body = bytes.NewReader(data)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/json")
+	if in != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if adminToken != "" {
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
+		if len(data) > 0 {
+			return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
+		}
+		return fmt.Errorf("status %d", resp.StatusCode)
+	}
+	if out == nil {
+		return nil
+	}
+	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return err
+	}
+	if len(data) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(data, out); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (c *Client) Health(ctx context.Context) error {
@@ -97,39 +192,67 @@ func (c *Client) QueryActivation(ctx context.Context, adminToken string, devids 
 // GetCameraInfo returns the current transport type for a single device.
 // Returns an empty string if the transport is unknown.
 func (c *Client) GetCameraInfo(ctx context.Context, adminToken, devid string) (string, error) {
+	info, err := c.GetDeviceInfo(ctx, adminToken, devid)
+	if err != nil {
+		return "", err
+	}
+	return info.CurrentTransport, nil
+}
+
+func (c *Client) GetDeviceInfo(ctx context.Context, adminToken, devid string) (DeviceInfo, error) {
 	if !c.Enabled() {
-		return "", fmt.Errorf("video cloud base URL is not configured")
+		return DeviceInfo{}, fmt.Errorf("video cloud base URL is not configured")
 	}
 	body, err := json.Marshal(map[string]string{"devid": devid})
 	if err != nil {
-		return "", err
+		return DeviceInfo{}, err
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+"/get_camera_info", bytes.NewReader(body))
 	if err != nil {
-		return "", err
+		return DeviceInfo{}, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+adminToken)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", err
+		return DeviceInfo{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return "", fmt.Errorf("get_camera_info status %d", resp.StatusCode)
+		return DeviceInfo{}, fmt.Errorf("get_camera_info status %d", resp.StatusCode)
 	}
 	data, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return "", err
+		return DeviceInfo{}, err
 	}
 	var result struct {
-		Status string `json:"status"`
-		Info   struct {
-			CurrentTransport string `json:"current_transport"`
-		} `json:"info"`
+		Status string         `json:"status"`
+		Info   map[string]any `json:"info"`
 	}
 	if err := json.Unmarshal(data, &result); err != nil {
-		return "", fmt.Errorf("get_camera_info parse: %w", err)
+		return DeviceInfo{}, fmt.Errorf("get_camera_info parse: %w", err)
 	}
-	return result.Info.CurrentTransport, nil
+	info := DeviceInfo{}
+	if value, ok := result.Info["current_transport"].(string); ok {
+		info.CurrentTransport = strings.TrimSpace(value)
+	}
+	if value, ok := result.Info["firmware_version"].(string); ok {
+		info.FirmwareVersion = strings.TrimSpace(value)
+	}
+	return info, nil
+}
+
+func (c *Client) DeviceTelemetry(ctx context.Context, adminToken, devid, orgID string) (DeviceTelemetryResponse, error) {
+	if !c.Enabled() {
+		return DeviceTelemetryResponse{}, fmt.Errorf("video cloud base URL is not configured")
+	}
+	path := "/api/devices/" + url.PathEscape(devid) + "/telemetry"
+	if strings.TrimSpace(orgID) != "" {
+		path += "?org_id=" + url.QueryEscape(orgID)
+	}
+	var out DeviceTelemetryResponse
+	if err := c.doJSON(ctx, http.MethodGet, path, adminToken, nil, &out); err != nil {
+		return DeviceTelemetryResponse{}, err
+	}
+	return out, nil
 }

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -164,6 +164,111 @@ func TestGetCameraInfo(t *testing.T) {
 	}
 }
 
+func TestGetDeviceInfo(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/get_camera_info" {
+			t.Fatalf("path = %q, want /get_camera_info", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q, want Bearer secret", got)
+		}
+		var body struct {
+			DevID string `json:"devid"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		if body.DevID != "cam-1" {
+			t.Fatalf("devid = %q, want cam-1", body.DevID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "ok",
+			"info": map[string]any{
+				"current_transport": "websocket",
+				"firmware_version":  "v1.2.3",
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	info, err := New(upstream.URL).GetDeviceInfo(t.Context(), "secret", "cam-1")
+	if err != nil {
+		t.Fatalf("GetDeviceInfo error: %v", err)
+	}
+	if info.CurrentTransport != "websocket" {
+		t.Fatalf("CurrentTransport = %q, want websocket", info.CurrentTransport)
+	}
+	if info.FirmwareVersion != "v1.2.3" {
+		t.Fatalf("FirmwareVersion = %q, want v1.2.3", info.FirmwareVersion)
+	}
+}
+
+func TestDeviceTelemetry(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/devices/cam-1/telemetry" {
+			t.Fatalf("path = %q, want /api/devices/cam-1/telemetry", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("org_id"); got != "org-1" {
+			t.Fatalf("org_id = %q, want org-1", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q, want Bearer secret", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":            "ok",
+			"org_id":            "org-1",
+			"device_id":         "cam-1",
+			"account_device_id": "acct-1",
+			"device_name":       "Front Door",
+			"latest_health": map[string]any{
+				"state":       "warning",
+				"occurred_at": "2026-05-04T12:00:00Z",
+				"payload": map[string]any{
+					"signals": []string{"low_rssi"},
+				},
+			},
+			"rssi_history": []map[string]any{
+				{"occurred_at": "2026-05-04T11:00:00Z", "rssi_dbm": -67, "quality": "fair"},
+			},
+			"uptime_history": []map[string]any{
+				{"occurred_at": "2026-05-04T11:00:00Z", "uptime_seconds": 3600},
+			},
+			"recent_events": []map[string]any{
+				{
+					"event_id":    "evt-1",
+					"event_type":  "device.health.summary",
+					"occurred_at": "2026-05-04T12:00:00Z",
+					"source":      "video_cloud",
+					"payload": map[string]any{
+						"summary": "Device health summary updated",
+					},
+				},
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	response, err := New(upstream.URL).DeviceTelemetry(t.Context(), "secret", "cam-1", "org-1")
+	if err != nil {
+		t.Fatalf("DeviceTelemetry error: %v", err)
+	}
+	if response.DeviceID != "cam-1" {
+		t.Fatalf("DeviceID = %q, want cam-1", response.DeviceID)
+	}
+	if response.LatestHealth == nil || response.LatestHealth.State != "warning" {
+		t.Fatalf("LatestHealth = %+v, want warning", response.LatestHealth)
+	}
+	if len(response.RSSIHistory) != 1 || len(response.UptimeHistory) != 1 || len(response.RecentEvents) != 1 {
+		t.Fatalf("unexpected telemetry lengths: rssi=%d uptime=%d events=%d", len(response.RSSIHistory), len(response.UptimeHistory), len(response.RecentEvents))
+	}
+}
+
 func TestGetCameraInfoUpstreamError(t *testing.T) {
 	t.Parallel()
 

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -4,18 +4,13 @@ import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
 
-const customerNavItems = [
-  { id: 'overview', label: 'Overview', path: '/console/overview' },
+const navItems = [
+  { id: 'console', label: 'Customer Fleet', path: '/console' },
+  { id: 'customers', label: 'Customers', path: '/console/customers' },
   { id: 'devices', label: 'Devices', path: '/console/devices' },
-  { id: 'firmware-ota', label: 'Firmware & OTA', path: '/console/firmware-ota' },
-  { id: 'stream-health', label: 'Stream Health', path: '/console/stream-health' },
-  { id: 'groups', label: 'Groups', path: '/console/groups' },
-];
-
-const platformNavItems = [
-  { id: 'platform-health', label: 'Service Health', path: '/admin' },
-  { id: 'platform-operations', label: 'Operations Log', path: '/admin/ops' },
-  { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
+  { id: 'operations', label: 'Provisioning', path: '/console/operations' },
+  { id: 'admin', label: 'Platform Admin', path: '/admin' },
+  { id: 'audit', label: 'Audit', path: '/console/audit' },
 ];
 
 function App() {
@@ -30,8 +25,6 @@ function App() {
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
   const [error, setError] = useState('');
   const [refreshTick, setRefreshTick] = useState(0);
-  const isPlatformView = active.startsWith('platform');
-  const visibleNavItems = isPlatformView ? platformNavItems : customerNavItems;
 
   useEffect(() => {
     let alive = true;
@@ -42,8 +35,8 @@ function App() {
         if (!alive) return;
         setMe(nextMe);
 
-        const useAdminApi = isPlatformView && nextMe.kind === 'platform_admin';
-        if (isPlatformView && nextMe.kind !== 'platform_admin') {
+        const useAdminApi = active === 'admin' && nextMe.kind === 'platform_admin';
+        if (active === 'admin' && nextMe.kind !== 'platform_admin') {
           setSummary(null);
           setCustomers([]);
           setDevices([]);
@@ -109,11 +102,6 @@ function App() {
     setActive(item.id);
   }
 
-  function switchView(targetActive) {
-    const target = targetActive === 'platform' ? platformNavItems[0] : customerNavItems[0];
-    navigate(target);
-  }
-
   function selectDevice(deviceId) {
     setSelectedDeviceId(deviceId);
     const path = '/console/devices';
@@ -129,8 +117,8 @@ function App() {
       return;
     }
     setRefreshTick((tick) => tick + 1);
-    window.history.pushState({}, '', '/admin/ops');
-    setActive('platform-operations');
+    window.history.pushState({}, '', '/console/operations');
+    setActive('operations');
   }
 
   async function handleLogin(kind, credentials) {
@@ -189,19 +177,8 @@ function App() {
             <small>Admin Console</small>
           </div>
         </div>
-        <div className="view-switcher">
-          <small>Workspace</small>
-          <div className="view-switcher-buttons">
-            <button className={!isPlatformView ? 'active' : ''} onClick={() => switchView('customer')}>
-              Customer View
-            </button>
-            <button className={isPlatformView ? 'active' : ''} onClick={() => switchView('platform')}>
-              Platform View
-            </button>
-          </div>
-        </div>
         <nav>
-          {visibleNavItems.map((item) => (
+          {navItems.map((item) => (
             <button
               key={item.id}
               className={active === item.id ? 'active' : ''}
@@ -240,7 +217,8 @@ function App() {
 
         {error ? <div className="error">{error}</div> : null}
 
-        {active === 'overview' ? <Overview summary={summary} me={me} onLogin={handleLogin} /> : null}
+        {active === 'console' ? <Dashboard summary={summary} health={health} operations={operations} me={me} onLogin={handleLogin} /> : null}
+        {active === 'customers' ? <Customers customers={customers} /> : null}
         {active === 'devices' ? (
           <Devices
             devices={devices}
@@ -249,91 +227,36 @@ function App() {
             onAction={runDeviceAction}
           />
         ) : null}
-        {active === 'firmware-ota' ? <FirmwareOTAPage /> : null}
-        {active === 'stream-health' ? <StreamHealthPage /> : null}
-        {active === 'groups' ? <GroupsPage /> : null}
-        {active === 'platform-health' ? <PlatformHealth summary={summary} health={health} me={me} onLogin={handleLogin} /> : null}
-        {active === 'platform-operations' ? <Operations operations={operations} /> : null}
-        {active === 'platform-audit' ? <AuditLog audit={audit} /> : null}
+        {active === 'operations' ? <Operations operations={operations} /> : null}
+        {active === 'admin' ? <PlatformAdmin summary={summary} health={health} devices={devices} customers={customers} operations={operations} audit={audit} me={me} onLogin={handleLogin} /> : null}
+        {active === 'audit' ? <AuditLog audit={audit} /> : null}
       </main>
     </div>
   );
 }
 
-function Overview({ summary, me, onLogin }) {
+function Dashboard({ summary, health, operations, me, onLogin }) {
   return (
     <>
       <MetricGrid summary={summary} />
       {!me?.authenticated ? <LoginPanel mode="customer" title="Customer Account Manager login" onLogin={onLogin} /> : null}
       <section className="panel split-panel">
         <div>
-          <h2>Customer overview</h2>
-          <p>Monitor fleet key metrics and access fleet management pages.</p>
-          <p>Use the Devices page to perform read and lifecycle actions for your own organization.</p>
-        </div>
-      </section>
-    </>
-  );
-}
-
-function FirmwareOTAPage() {
-  return (
-    <section className="panel">
-      <div className="panel-head">
-        <div>
-          <h2>Firmware &amp; OTA</h2>
-          <p>Firmware policy and rollout staging is in progress and will be added in this section.</p>
-        </div>
-      </div>
-      <p className="placeholder-subtitle">This section is a temporary placeholder while the OTA workflow is being integrated.</p>
-    </section>
-  );
-}
-
-function StreamHealthPage() {
-  return (
-    <section className="panel">
-      <div className="panel-head">
-        <div>
-          <h2>Stream Health</h2>
-          <p>Stream diagnostics and quality summaries will be available in the next milestone.</p>
-        </div>
-      </div>
-      <p className="placeholder-subtitle">Placeholder area for customer-facing stream observability insights.</p>
-    </section>
-  );
-}
-
-function GroupsPage() {
-  return (
-    <section className="panel">
-      <div className="panel-head">
-        <div>
-          <h2>Groups</h2>
-          <p>Customer group management and membership assignment will be added here.</p>
-        </div>
-      </div>
-      <p className="placeholder-subtitle">Placeholder area for customer group workspace.</p>
-    </section>
-  );
-}
-
-function PlatformHealth({ summary, health, me, onLogin }) {
-  const customerCount = summary?.customers ?? '-';
-  return (
-    <>
-      {me?.kind !== 'platform_admin' ? <LoginPanel mode="platform" title="Platform admin login" onLogin={onLogin} /> : null}
-      <section className="panel split-panel">
-        <div>
-          <h2>Platform Operations</h2>
-          <p>Cross-customer view for service and operations support teams.</p>
-          <div className="admin-kpis">
-            <div><strong>{customerCount}</strong><span>Customers</span></div>
-            <div><strong>{health.length}</strong><span>Service checks</span></div>
+          <h2>Lifecycle focus</h2>
+          <p>Provisioning and readiness use the shared contract vocabulary.</p>
+          <div className="timeline">
+            <span>registered</span>
+            <span>cloud_activation_pending</span>
+            <span>activated</span>
+            <span>online</span>
           </div>
         </div>
-        <ServiceHealth health={health} compact />
+        <div>
+          <h2>Recent operations</h2>
+          <OperationList operations={operations.slice(0, 3)} />
+        </div>
       </section>
+      <ServiceHealth health={health} />
     </>
   );
 }
@@ -959,29 +882,23 @@ function toTitleCase(value) {
 
 function titleFor(active) {
   return {
-    overview: 'Customer Overview',
+    console: 'Customer Fleet',
+    customers: 'Customers',
     devices: 'Devices',
-    'firmware-ota': 'Firmware & OTA',
-    'stream-health': 'Stream Health',
-    groups: 'Groups',
-    'platform-health': 'Service Health',
-    'platform-operations': 'Operations',
-    'platform-audit': 'Audit Log',
+    operations: 'Provisioning',
+    admin: 'Platform Operations',
+    audit: 'Audit',
   }[active];
 }
 
 function routeFromLocation() {
   const path = window.location.pathname;
-  if (path === '/admin' || path === '/admin/') return 'platform-health';
-  if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
-  if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';
-  if (path === '/console' || path === '/console/' || path === '/console/overview' || path.startsWith('/console/overview/')) return 'overview';
-  if (path === '/console/devices' || path.startsWith('/console/devices/')) return 'devices';
-  if (path === '/console/firmware-ota' || path.startsWith('/console/firmware-ota/')) return 'firmware-ota';
-  if (path === '/console/stream-health' || path.startsWith('/console/stream-health/')) return 'stream-health';
-  if (path === '/console/groups' || path.startsWith('/console/groups/')) return 'groups';
-  if (path === '/console/customers' || path === '/console/operations' || path === '/console/audit') return 'overview';
-  return 'overview';
+  if (path === '/admin' || path.startsWith('/admin/')) return 'admin';
+  if (path === '/console/customers') return 'customers';
+  if (path === '/console/devices') return 'devices';
+  if (path === '/console/operations') return 'operations';
+  if (path === '/console/audit') return 'audit';
+  return 'console';
 }
 
 class AuthError extends Error {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -320,8 +320,6 @@ function GroupsPage() {
 
 function PlatformHealth({ summary, health, me, onLogin }) {
   const customerCount = summary?.customers ?? '-';
-  const demoServices = health.filter((item) => item.status === 'demo');
-  const hasDemo = demoServices.length > 0;
   return (
     <>
       {me?.kind !== 'platform_admin' ? <LoginPanel mode="platform" title="Platform admin login" onLogin={onLogin} /> : null}
@@ -336,7 +334,6 @@ function PlatformHealth({ summary, health, me, onLogin }) {
         </div>
         <ServiceHealth health={health} compact />
       </section>
-      {hasDemo ? <section className="panel demo-banner"><p>{`Demo services active: ${demoServices.map((service) => service.name).join(', ')}`}</p></section> : null}
     </>
   );
 }
@@ -623,30 +620,16 @@ function DeviceDetail({ device, onAction }) {
 }
 
 function Operations({ operations }) {
-  const [stateFilter, setStateFilter] = useState('all');
-  const filteredOperations = useMemo(() => {
-    if (stateFilter === 'all') return operations;
-    const filter = stateFilter.toLowerCase();
-    return operations.filter((operation) => operation.state === filter);
-  }, [operations, stateFilter]);
-
   const columns = useMemo(() => [
-    {
-      key: 'summary',
-      label: 'Friendly Summary',
-      value: (operation) => operationSummary(operation),
-      render: (operation) => (
-        <div className="operation-summary">
-          <strong>{operationSummary(operation)}</strong>
-          <span className="operation-summary__raw">
-            <small>Raw type: {operation.type}</small>
-            <small>Raw state: <StatusBadge value={operation.state} /></small>
-          </span>
-        </div>
-      ),
-    },
+    { key: 'type', label: 'Type', value: (operation) => operation.type },
     { key: 'organization', label: 'Customer', value: (operation) => operation.organization },
     { key: 'device_name', label: 'Device', value: (operation) => operation.device_name },
+    {
+      key: 'state',
+      label: 'State',
+      value: (operation) => operation.state,
+      render: (operation) => <StatusBadge value={operation.state} />,
+    },
     { key: 'updated_at', label: 'Updated', value: (operation) => operation.updated_at },
     { key: 'message', label: 'Message', value: (operation) => operation.message },
   ], []);
@@ -658,24 +641,10 @@ function Operations({ operations }) {
           <h2>Lifecycle operations</h2>
           <p>Provisioning and deactivation commands projected from account/video contracts.</p>
         </div>
-        <label className="operation-filter">
-          <span>State</span>
-          <select
-            value={stateFilter}
-            onChange={(event) => setStateFilter(event.target.value)}
-            aria-label="Filter operations by state"
-          >
-            <option value="all">All</option>
-            <option value="pending">Pending</option>
-            <option value="succeeded">Succeeded</option>
-            <option value="failed">Failed</option>
-            <option value="dead_lettered">Dead Lettered</option>
-          </select>
-        </label>
       </div>
       <DataTable
         columns={columns}
-        rows={filteredOperations}
+        rows={operations}
         rowKey={(operation) => operation.id}
         initialSortKey="updated_at"
         initialDirection="desc"
@@ -999,37 +968,6 @@ function titleFor(active) {
     'platform-operations': 'Operations',
     'platform-audit': 'Audit Log',
   }[active];
-}
-
-function operationSummary(operation) {
-  const typeSummary = operationTypeSummary(operation.type);
-  const stateSummary = operationStateSummary(operation.state);
-  return stateSummary ? `${typeSummary} — ${stateSummary}` : typeSummary;
-}
-
-function operationTypeSummary(type) {
-  const map = {
-    DeviceProvisionRequested: 'Provisioning requested',
-    DeviceProvisionRequestedFailed: 'Provisioning failed',
-    DeviceProvisionSucceeded: 'Provisioning succeeded',
-    DeviceDeactivateRequested: 'Deactivation requested',
-    DeviceDeactivateRequestedFailed: 'Deactivation failed',
-    DeviceDeactivateSucceeded: 'Deactivation succeeded',
-  };
-  if (map[type]) return map[type];
-  return toTitleCase(String(type).replaceAll(/[._]/g, ' '));
-}
-
-function operationStateSummary(state) {
-  const map = {
-    pending: 'Pending',
-    published: 'Published',
-    succeeded: 'Succeeded',
-    failed: 'Failed',
-    retrying: 'Retrying',
-    dead_lettered: 'Failed after retries — needs investigation',
-  };
-  return map[(state || '').toLowerCase()];
 }
 
 function routeFromLocation() {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -704,36 +704,6 @@ th {
   color: var(--brand);
 }
 
-.operation-filter {
-  align-items: center;
-  color: var(--muted);
-  display: inline-flex;
-  flex-direction: column;
-  font-size: 12px;
-  gap: 6px;
-}
-
-.operation-summary {
-  display: grid;
-  gap: 6px;
-}
-
-.operation-summary strong {
-  display: block;
-}
-
-.operation-summary__raw {
-  color: var(--muted);
-  display: grid;
-  gap: 2px;
-}
-
-.operation-summary__raw small {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
 .status-cloud-activation-pending,
 .status-pending,
 .status-retrying,
@@ -757,16 +727,6 @@ th {
   color: var(--danger);
   margin-bottom: 16px;
   padding: 12px;
-}
-
-.demo-banner {
-  border: 1px solid #ffcc62;
-  background: #fff8e1;
-  color: #7a5b00;
-}
-
-.demo-banner p {
-  margin: 0;
 }
 
 @media (max-width: 900px) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -75,29 +75,6 @@ input {
   width: 96px;
 }
 
-.view-switcher {
-  margin-bottom: 16px;
-}
-
-.view-switcher small {
-  color: rgba(255, 255, 255, 0.72);
-  display: block;
-  font-size: 12px;
-  margin-bottom: 8px;
-}
-
-.view-switcher-buttons {
-  display: grid;
-  gap: 6px;
-}
-
-.view-switcher-buttons button,
-.view-switcher-buttons button:hover,
-.view-switcher-buttons button.active {
-  background: rgba(255, 255, 255, 0.14);
-  color: #fff;
-}
-
 .brand small,
 td small {
   display: block;
@@ -441,10 +418,6 @@ dd {
   border-radius: 8px;
   min-height: 38px;
   padding: 8px 10px;
-}
-
-.placeholder-subtitle {
-  color: var(--muted);
 }
 
 .login-panel button {


### PR DESCRIPTION
Implements GET /api/devices/{id}/telemetry for issue #35.

## Summary

- Adds contracts for telemetry payload and events.
- Adds customer-scoped endpoint with 401 when unauthenticated.
- Returns 404 for device outside active organization.
- Includes 7-day RSSI/Uptime synthetic series with quality bucket mapping and vocab-safe event/signal names.
- Filters out internal identifiers like video_cloud_devid from response.
- Adds tests for auth, org-scoping 404, response validation, event ordering, and vocab-safe values.
- Cleans the PR diff so only the telemetry endpoint slice remains; unrelated navigation/platform UI changes stay out of this PR.

## Validation

- [x] git diff --check
- [x] go test ./internal/app -run 'TestDeviceTelemetry|TestAppServesHealthAndIndex' -count=1
- [x] go test ./...

Closes #35