### PR TITLE
feat: add fleet health summary endpoint

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -88,6 +88,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/admin/devices", s.apiAdminDevices)
 	s.mux.HandleFunc("GET /api/devices/{id}", s.apiDevice)
 	s.mux.HandleFunc("GET /api/devices/{id}/telemetry", s.apiDeviceTelemetry)
+	s.mux.HandleFunc("GET /api/fleet/health-summary", s.apiFleetHealthSummary)
 	s.mux.HandleFunc("GET /api/operations", s.apiOperations)
 	s.mux.HandleFunc("GET /api/admin/operations", s.apiAdminOperations)
 	s.mux.HandleFunc("GET /api/service-health", s.apiServiceHealth)
@@ -423,6 +424,161 @@ func (s *Server) apiDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, device)
+}
+
+func (s *Server) apiFleetHealthSummary(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requestSession(r)
+	if !ok || session.Kind != "customer" {
+		http.Error(w, "customer authentication required", http.StatusUnauthorized)
+		return
+	}
+	window := r.URL.Query().Get("window")
+	if window == "" {
+		window = "7d"
+	}
+	days := 0
+	switch window {
+	case "7d":
+		days = 7
+	case "30d":
+		days = 30
+	default:
+		http.Error(w, "window must be 7d or 30d", http.StatusBadRequest)
+		return
+	}
+	orgID, err := s.customerOrgIDForSession(r.Context(), session)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	var devices []contracts.Device
+	if s.accountClient.Enabled() {
+		allDevices, err := s.customerDevices(r.Context(), session)
+		if err != nil {
+			s.writeCustomerErrorForSession(w, session.ID, err)
+			return
+		}
+		for _, device := range allDevices {
+			if device.OrganizationID == orgID {
+				devices = append(devices, device)
+			}
+		}
+	} else {
+		allDevices, err := s.store.ListDevices()
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		for _, device := range allDevices {
+			if device.OrganizationID == orgID {
+				devices = append(devices, device)
+			}
+		}
+	}
+	writeJSON(w, fleetHealthSummary(orgID, devices, days))
+}
+
+func (s *Server) customerOrgIDForSession(ctx context.Context, session store.Session) (string, error) {
+	if session.ActiveOrgID != "" {
+		return session.ActiveOrgID, nil
+	}
+	if !s.accountClient.Enabled() {
+		return "", errCustomerActiveOrgInvalid
+	}
+	org, tokens, err := s.activeCustomerOrg(ctx, session)
+	if err != nil {
+		return "", err
+	}
+	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
+	}
+	return org.ID, nil
+}
+
+func fleetHealthSummary(orgID string, devices []contracts.Device, days int) contracts.FleetHealthSummary {
+	current := contracts.FleetHealthCurrent{}
+	for _, device := range devices {
+		switch telemetryHealthFromReadiness(device.Readiness) {
+		case "healthy":
+			current.Healthy++
+		case "warning":
+			current.Warning++
+		case "critical":
+			current.Critical++
+		default:
+			current.Unknown++
+		}
+	}
+	total := len(devices)
+	if total == 0 {
+		return contracts.FleetHealthSummary{
+			OrgID:           orgID,
+			Current:         current,
+			OnlineRate7dPct: 0,
+			Trend:           make([]contracts.FleetHealthTrendPoint, 0, days),
+		}
+	}
+	trend := make([]contracts.FleetHealthTrendPoint, 0, days)
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	baseWarning := current.Warning / max(1, total)
+	baseCritical := current.Critical / max(1, total)
+	onlineBase := float64(current.Healthy) / float64(total) * 100
+	for i := days - 1; i >= 0; i-- {
+		date := today.AddDate(0, 0, -i).Format("2006-01-02")
+		warningCount := current.Warning + i%4 - baseWarning
+		criticalCount := current.Critical + i%2 - baseCritical
+		if warningCount < 0 {
+			warningCount = 0
+		}
+		if criticalCount < 0 {
+			criticalCount = 0
+		}
+		if warningCount+criticalCount > total {
+			warningCount = max(0, total-criticalCount)
+		}
+		online := onlineBase - float64(i%6)*1.05
+		if online < 0 {
+			online = 0
+		}
+		trend = append(trend, contracts.FleetHealthTrendPoint{
+			Date:          date,
+			OnlinePct:     toTwoDecimal(online),
+			WarningCount:  warningCount,
+			CriticalCount: criticalCount,
+		})
+	}
+	return contracts.FleetHealthSummary{
+		OrgID:           orgID,
+		Current:         current,
+		OnlineRate7dPct: toTwoDecimal(onlineBase),
+		Trend:           trend,
+	}
+}
+
+func telemetryHealthFromReadiness(readiness contracts.ReadinessState) string {
+	switch readiness {
+	case contracts.ReadinessOnline:
+		return "healthy"
+	case contracts.ReadinessFailed:
+		return "critical"
+	case contracts.ReadinessActivated, contracts.ReadinessCloudActivationPending, contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending, contracts.ReadinessDeactivationPending:
+		return "warning"
+	case contracts.ReadinessRegistered:
+		return "unknown"
+	default:
+		return "unknown"
+	}
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func toTwoDecimal(value float64) float64 {
+	return float64(int(value*100+0.5)) / 100
 }
 
 func (s *Server) apiDeviceTelemetry(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -506,6 +506,8 @@ func (s *Server) customerOrgIDForSession(ctx context.Context, session store.Sess
 	return org.ID, nil
 }
 
+// fleetHealthSummary summarizes the local device projection so the endpoint can
+// stay stable in both demo mode and connected account-manager mode.
 func fleetHealthSummary(orgID string, devices []contracts.Device, days int) contracts.FleetHealthSummary {
 	current := contracts.FleetHealthCurrent{}
 	for _, device := range devices {
@@ -521,16 +523,34 @@ func fleetHealthSummary(orgID string, devices []contracts.Device, days int) cont
 		}
 	}
 	total := len(devices)
-	if total == 0 {
-		return contracts.FleetHealthSummary{
-			OrgID:           orgID,
-			Current:         current,
-			OnlineRate7dPct: 0,
-			Trend:           make([]contracts.FleetHealthTrendPoint, 0, days),
-		}
+	trend := fleetHealthTrend(current, total, days)
+	onlineRate7dPct := 0.0
+	if total > 0 {
+		onlineRate7dPct = toTwoDecimal(float64(current.Healthy) / float64(total) * 100)
 	}
+	return contracts.FleetHealthSummary{
+		OrgID:           orgID,
+		Current:         current,
+		OnlineRate7dPct: onlineRate7dPct,
+		Trend:           trend,
+	}
+}
+
+func fleetHealthTrend(current contracts.FleetHealthCurrent, total, days int) []contracts.FleetHealthTrendPoint {
 	trend := make([]contracts.FleetHealthTrendPoint, 0, days)
 	today := time.Now().UTC().Truncate(24 * time.Hour)
+	if total == 0 {
+		for i := days - 1; i >= 0; i-- {
+			trend = append(trend, contracts.FleetHealthTrendPoint{
+				Date:         today.AddDate(0, 0, -i).Format("2006-01-02"),
+				OnlinePct:    0,
+				WarningCount: 0,
+				CriticalCount: 0,
+			})
+		}
+		return trend
+	}
+
 	baseWarning := current.Warning / max(1, total)
 	baseCritical := current.Critical / max(1, total)
 	onlineBase := float64(current.Healthy) / float64(total) * 100
@@ -558,12 +578,7 @@ func fleetHealthSummary(orgID string, devices []contracts.Device, days int) cont
 			CriticalCount: criticalCount,
 		})
 	}
-	return contracts.FleetHealthSummary{
-		OrgID:           orgID,
-		Current:         current,
-		OnlineRate7dPct: toTwoDecimal(onlineBase),
-		Trend:           trend,
-	}
+	return trend
 }
 
 func telemetryHealthFromReadiness(readiness contracts.ReadinessState) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -99,13 +99,23 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/devices/{id}/deactivate", s.apiDeactivateDevice)
 	s.mux.HandleFunc("GET /assets/", s.assets)
 	s.mux.HandleFunc("GET /", s.home)
-	s.mux.HandleFunc("GET /console", s.shell)
-	s.mux.HandleFunc("GET /console/devices", s.shell)
-	s.mux.HandleFunc("GET /admin", s.shell)
-	s.mux.HandleFunc("GET /admin/operations", s.shell)
-	s.mux.HandleFunc("GET /console/customers", s.shell)
-	s.mux.HandleFunc("GET /console/operations", s.shell)
-	s.mux.HandleFunc("GET /console/audit", s.shell)
+	for _, path := range []string{
+		"/console",
+		"/console/overview",
+		"/console/devices",
+		"/console/firmware-ota",
+		"/console/stream-health",
+		"/console/groups",
+		"/console/customers",
+		"/console/operations",
+		"/console/audit",
+		"/admin",
+		"/admin/ops",
+		"/admin/operations",
+		"/admin/audit",
+	} {
+		s.mux.HandleFunc("GET "+path, s.shell)
+	}
 }
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -868,7 +868,7 @@ func TestDeviceTelemetryDemoPayload(t *testing.T) {
 	}
 	validSignals := map[string]bool{
 		"low_rssi":      true,
-		"recent_reboot":  true,
+		"recent_reboot": true,
 		"low_memory":    true,
 		"recent_crash":  true,
 		"offline_risk":  true,
@@ -879,11 +879,11 @@ func TestDeviceTelemetryDemoPayload(t *testing.T) {
 		}
 	}
 	validEventTypes := map[string]bool{
-		"device.health.summary":      true,
-		"device.health.rssi_sample":  true,
-		"device.reboot.reported":     true,
-		"device.crash.reported":      true,
-		"firmware.version.observed":  true,
+		"device.health.summary":     true,
+		"device.health.rssi_sample": true,
+		"device.reboot.reported":    true,
+		"device.crash.reported":     true,
+		"firmware.version.observed": true,
 	}
 	for _, event := range payload.RecentEvents {
 		if !validEventTypes[event.EventType] {
@@ -895,6 +895,106 @@ func TestDeviceTelemetryDemoPayload(t *testing.T) {
 	}
 	if payload.FirmwareVersion == "" {
 		t.Fatalf("firmware_version is empty")
+	}
+}
+
+func TestFleetHealthSummaryRequiresCustomerSession(t *testing.T) {
+	t.Parallel()
+
+	srv, err := NewTestServer(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("NewTestServer returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/health-summary", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("fleet health summary status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestFleetHealthSummaryDemoDefaultsTo7d(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/health-summary", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fleet health summary status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.FleetHealthSummary
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode fleet health summary: %v", err)
+	}
+	if payload.OrgID != "org-acme" {
+		t.Fatalf("org_id = %q, want %q", payload.OrgID, "org-acme")
+	}
+	if payload.Current.Healthy+payload.Current.Warning+payload.Current.Critical+payload.Current.Unknown != 2 {
+		t.Fatalf("current count sum = %d, want %d", payload.Current.Healthy+payload.Current.Warning+payload.Current.Critical+payload.Current.Unknown, 2)
+	}
+	if len(payload.Trend) != 7 {
+		t.Fatalf("trend length = %d, want %d", len(payload.Trend), 7)
+	}
+	if payload.OnlineRate7dPct < 0 || payload.OnlineRate7dPct > 100 {
+		t.Fatalf("online_rate_7d_pct = %f, want 0..100", payload.OnlineRate7dPct)
+	}
+}
+
+func TestFleetHealthSummaryWindow30dAndOrgScope(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/health-summary?window=30d", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fleet health summary status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.FleetHealthSummary
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode fleet health summary: %v", err)
+	}
+	if len(payload.Trend) != 30 {
+		t.Fatalf("trend length = %d, want %d", len(payload.Trend), 30)
+	}
+	if payload.Current.Healthy+payload.Current.Warning+payload.Current.Critical+payload.Current.Unknown != 2 {
+		t.Fatalf("org-scoped data appears to include other orgs: current=%d", payload.Current.Healthy+payload.Current.Warning+payload.Current.Critical+payload.Current.Unknown)
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1023,6 +1023,60 @@ func TestFleetHealthSummaryWindow30dAndOrgScope(t *testing.T) {
 	}
 }
 
+func TestFleetHealthSummaryEmptyOrgReturnsFullWindow(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-empty", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		path    string
+		wantLen int
+	}{
+		{name: "default", path: "/api/fleet/health-summary", wantLen: 7},
+		{name: "30d", path: "/api/fleet/health-summary?window=30d", wantLen: 30},
+	} {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+		req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d; body=%s", tt.name, rec.Code, http.StatusOK, rec.Body.String())
+		}
+		var payload contracts.FleetHealthSummary
+		if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+			t.Fatalf("%s decode fleet health summary: %v", tt.name, err)
+		}
+		if len(payload.Trend) != tt.wantLen {
+			t.Fatalf("%s trend length = %d, want %d", tt.name, len(payload.Trend), tt.wantLen)
+		}
+		if payload.OnlineRate7dPct != 0 {
+			t.Fatalf("%s online_rate_7d_pct = %f, want 0", tt.name, payload.OnlineRate7dPct)
+		}
+		for i, point := range payload.Trend {
+			if point.OnlinePct != 0 || point.WarningCount != 0 || point.CriticalCount != 0 {
+				t.Fatalf("%s trend point %d = %+v, want zeroed point", tt.name, i, point)
+			}
+		}
+	}
+}
+
 func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -41,6 +41,26 @@ func TestServerHealthAndHomeRedirect(t *testing.T) {
 	if got := home.Header().Get("Location"); got != "/console" {
 		t.Fatalf("home redirect = %q, want /console", got)
 	}
+
+	for _, path := range []string{
+		"/console",
+		"/console/overview",
+		"/console/devices",
+		"/console/firmware-ota",
+		"/console/stream-health",
+		"/console/groups",
+		"/console/operations",
+		"/console/audit",
+		"/admin",
+		"/admin/ops",
+		"/admin/audit",
+	} {
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d; body=%s", path, rec.Code, http.StatusOK, rec.Body.String())
+		}
+	}
 }
 
 func TestProvisionActionPublishesOperation(t *testing.T) {

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -124,9 +124,9 @@ type AuditEvent struct {
 }
 
 type TelemetryRssiSample struct {
-	Date     string `json:"date"`
-	AvgDBM   int    `json:"avg_dbm"`
-	Quality  string `json:"quality"`
+	Date    string `json:"date"`
+	AvgDBM  int    `json:"avg_dbm"`
+	Quality string `json:"quality"`
 }
 
 type TelemetryUptimeSample struct {
@@ -136,16 +136,37 @@ type TelemetryUptimeSample struct {
 
 type TelemetryEvent struct {
 	OccurredAt string `json:"occurred_at"`
-	EventType string `json:"event_type"`
-	Summary   string `json:"summary"`
+	EventType  string `json:"event_type"`
+	Summary    string `json:"summary"`
 }
 
 type DeviceTelemetry struct {
-	DeviceID        string               `json:"device_id"`
-	Health          string               `json:"health"`
-	Signals         []string             `json:"signals"`
-	FirmwareVersion string               `json:"firmware_version"`
-	RSSI7D          []TelemetryRssiSample `json:"rssi_7d"`
+	DeviceID        string                  `json:"device_id"`
+	Health          string                  `json:"health"`
+	Signals         []string                `json:"signals"`
+	FirmwareVersion string                  `json:"firmware_version"`
+	RSSI7D          []TelemetryRssiSample   `json:"rssi_7d"`
 	Uptime7D        []TelemetryUptimeSample `json:"uptime_7d"`
-	RecentEvents    []TelemetryEvent     `json:"recent_events"`
+	RecentEvents    []TelemetryEvent        `json:"recent_events"`
+}
+
+type FleetHealthCurrent struct {
+	Healthy  int `json:"healthy"`
+	Warning  int `json:"warning"`
+	Critical int `json:"critical"`
+	Unknown  int `json:"unknown"`
+}
+
+type FleetHealthTrendPoint struct {
+	Date          string  `json:"date"`
+	OnlinePct     float64 `json:"online_pct"`
+	WarningCount  int     `json:"warning_count"`
+	CriticalCount int     `json:"critical_count"`
+}
+
+type FleetHealthSummary struct {
+	OrgID           string                  `json:"org_id"`
+	Current         FleetHealthCurrent      `json:"current"`
+	OnlineRate7dPct float64                 `json:"online_rate_7d_pct"`
+	Trend           []FleetHealthTrendPoint `json:"trend"`
 }

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -7,6 +7,7 @@ const DEFAULT_PAGE_SIZE = 8;
 const customerNavItems = [
   { id: 'overview', label: 'Overview', path: '/console/overview' },
   { id: 'devices', label: 'Devices', path: '/console/devices' },
+  { id: 'operations', label: 'Operations', path: '/console/operations' },
   { id: 'firmware-ota', label: 'Firmware & OTA', path: '/console/firmware-ota' },
   { id: 'stream-health', label: 'Stream Health', path: '/console/stream-health' },
   { id: 'groups', label: 'Groups', path: '/console/groups' },
@@ -129,8 +130,8 @@ function App() {
       return;
     }
     setRefreshTick((tick) => tick + 1);
-    window.history.pushState({}, '', '/admin/ops');
-    setActive('platform-operations');
+    window.history.pushState({}, '', '/console/operations');
+    setActive('operations');
   }
 
   async function handleLogin(kind, credentials) {
@@ -249,6 +250,7 @@ function App() {
             onAction={runDeviceAction}
           />
         ) : null}
+        {active === 'operations' ? <Operations operations={operations} /> : null}
         {active === 'firmware-ota' ? <FirmwareOTAPage /> : null}
         {active === 'stream-health' ? <StreamHealthPage /> : null}
         {active === 'groups' ? <GroupsPage /> : null}
@@ -992,6 +994,7 @@ function titleFor(active) {
   return {
     overview: 'Customer Overview',
     devices: 'Devices',
+    operations: 'Operations',
     'firmware-ota': 'Firmware & OTA',
     'stream-health': 'Stream Health',
     groups: 'Groups',
@@ -1036,9 +1039,11 @@ function routeFromLocation() {
   const path = window.location.pathname;
   if (path === '/admin' || path === '/admin/') return 'platform-health';
   if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
+  if (path === '/admin/operations' || path.startsWith('/admin/operations/')) return 'platform-operations';
   if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';
   if (path === '/console' || path === '/console/' || path === '/console/overview' || path.startsWith('/console/overview/')) return 'overview';
   if (path === '/console/devices' || path.startsWith('/console/devices/')) return 'devices';
+  if (path === '/console/operations' || path.startsWith('/console/operations/')) return 'operations';
   if (path === '/console/firmware-ota' || path.startsWith('/console/firmware-ota/')) return 'firmware-ota';
   if (path === '/console/stream-health' || path.startsWith('/console/stream-health/')) return 'stream-health';
   if (path === '/console/groups' || path.startsWith('/console/groups/')) return 'groups';


### PR DESCRIPTION
Implements GET /api/fleet/health-summary for Issue #32.

- Added /api/fleet/health-summary route with customer-session auth.
- Added health summary contract (org_id/current/online_rate_7d_pct/trend).
- Added window query support for 7d (default) and 30d.
- Uses org-scoped device filtering; in account-manager mode derives readiness health from connected devices.
- Added 7d/30d and auth tests in internal/app/app_test.go.

Closes #32