### PR TITLE
feat: add fleet stream stats endpoint

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -440,7 +440,7 @@ func (s *Server) apiFleetHealthSummary(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "customer authentication required", http.StatusUnauthorized)
 		return
 	}
-	window, days, err := parseFleetWindow(r.URL.Query().Get("window"))
+	_, days, err := parseFleetWindow(r.URL.Query().Get("window"))
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -590,8 +590,10 @@ func fleetStreamStats(orgID string, devices []contracts.Device, days int, window
 			totalSuccesses += successes
 			agg.requests += requests
 			agg.successes += successes
-			modeStats[agg.mode].requests += requests
-			modeStats[agg.mode].successes += successes
+			mode := modeStats[agg.mode]
+			mode.requests += requests
+			mode.successes += successes
+			modeStats[agg.mode] = mode
 			totalDuration += duration
 		}
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -89,6 +90,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/devices/{id}", s.apiDevice)
 	s.mux.HandleFunc("GET /api/devices/{id}/telemetry", s.apiDeviceTelemetry)
 	s.mux.HandleFunc("GET /api/fleet/health-summary", s.apiFleetHealthSummary)
+	s.mux.HandleFunc("GET /api/fleet/stream-stats", s.apiFleetStreamStats)
 	s.mux.HandleFunc("GET /api/operations", s.apiOperations)
 	s.mux.HandleFunc("GET /api/admin/operations", s.apiAdminOperations)
 	s.mux.HandleFunc("GET /api/service-health", s.apiServiceHealth)
@@ -107,6 +109,12 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /console/operations", s.shell)
 	s.mux.HandleFunc("GET /console/audit", s.shell)
 }
+
+const (
+	streamModeRTSP   = "rtsp"
+	streamModeRelay  = "relay"
+	streamModeWebRTC = "webrtc"
+)
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -432,18 +440,9 @@ func (s *Server) apiFleetHealthSummary(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "customer authentication required", http.StatusUnauthorized)
 		return
 	}
-	window := r.URL.Query().Get("window")
-	if window == "" {
-		window = "7d"
-	}
-	days := 0
-	switch window {
-	case "7d":
-		days = 7
-	case "30d":
-		days = 30
-	default:
-		http.Error(w, "window must be 7d or 30d", http.StatusBadRequest)
+	window, days, err := parseFleetWindow(r.URL.Query().Get("window"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	orgID, err := s.customerOrgIDForSession(r.Context(), session)
@@ -476,6 +475,261 @@ func (s *Server) apiFleetHealthSummary(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, fleetHealthSummary(orgID, devices, days))
+}
+
+func (s *Server) apiFleetStreamStats(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requestSession(r)
+	if !ok || session.Kind != "customer" {
+		http.Error(w, "customer authentication required", http.StatusUnauthorized)
+		return
+	}
+	window, days, err := parseFleetWindow(r.URL.Query().Get("window"))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	orgID, err := s.customerOrgIDForSession(r.Context(), session)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	var devices []contracts.Device
+	if s.accountClient.Enabled() {
+		allDevices, err := s.customerDevices(r.Context(), session)
+		if err != nil {
+			s.writeCustomerErrorForSession(w, session.ID, err)
+			return
+		}
+		devices = append(devices, allDevices...)
+	} else {
+		allDevices, err := s.store.ListDevices()
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		for _, device := range allDevices {
+			if device.OrganizationID == orgID {
+				devices = append(devices, device)
+			}
+		}
+	}
+	writeJSON(w, fleetStreamStats(orgID, devices, days, window))
+}
+
+func parseFleetWindow(raw string) (string, int, error) {
+	window := raw
+	if window == "" {
+		window = "7d"
+	}
+	switch window {
+	case "7d":
+		return window, 7, nil
+	case "30d":
+		return window, 30, nil
+	default:
+		return "", 0, fmt.Errorf("window must be 7d or 30d")
+	}
+}
+
+func fleetStreamStats(orgID string, devices []contracts.Device, days int, window string) contracts.FleetStreamStats {
+	byMode := map[string]contracts.FleetStreamStatsMode{
+		streamModeRTSP:   {Requests: 0, SuccessRatePct: 0},
+		streamModeRelay:  {Requests: 0, SuccessRatePct: 0},
+		streamModeWebRTC: {Requests: 0, SuccessRatePct: 0},
+	}
+	type modeAccumulator struct {
+		requests  int
+		successes int
+	}
+	type deviceAccumulator struct {
+		deviceID   string
+		deviceName string
+		mode       string
+		readiness  contracts.ReadinessState
+		requests   int
+		successes  int
+		never      bool
+	}
+	modeStats := map[string]modeAccumulator{
+		streamModeRTSP:   {},
+		streamModeRelay:  {},
+		streamModeWebRTC: {},
+	}
+	deviceStats := make(map[string]*deviceAccumulator, len(devices))
+	for idx, device := range devices {
+		profile := streamProfile(idx, device)
+		deviceStats[device.ID] = &deviceAccumulator{
+			deviceID:   device.ID,
+			deviceName: device.Name,
+			mode:       profile.mode,
+			readiness:  device.Readiness,
+			never:      profile.never,
+		}
+	}
+
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	trend := make([]contracts.FleetStreamTrendPoint, 0, days)
+	dailyRequestsByDay := make([]int, days)
+	dailySuccessesByDay := make([]int, days)
+	var totalRequests, totalSuccesses, totalDuration int
+	activeSessions := 0
+	neverStreamedCount := 0
+	for idx, device := range devices {
+		if device.Readiness == contracts.ReadinessOnline {
+			activeSessions++
+		}
+		agg := deviceStats[device.ID]
+		if agg == nil {
+			continue
+		}
+		for day := 0; day < days; day++ {
+			requests, successes, duration := streamDevicesForDay(day, len(devices), idx, device, agg.never)
+			dailyRequestsByDay[day] += requests
+			dailySuccessesByDay[day] += successes
+			totalRequests += requests
+			totalSuccesses += successes
+			agg.requests += requests
+			agg.successes += successes
+			modeStats[agg.mode].requests += requests
+			modeStats[agg.mode].successes += successes
+			totalDuration += duration
+		}
+	}
+	for _, agg := range deviceStats {
+		if agg.readiness == contracts.ReadinessOnline && agg.requests == 0 && agg.never {
+			neverStreamedCount++
+		}
+	}
+	for day := 0; day < days; day++ {
+		date := today.AddDate(0, 0, day-days+1).Format("2006-01-02")
+		successRate := streamRate(dailySuccessesByDay[day], dailyRequestsByDay[day])
+		trend = append(trend, contracts.FleetStreamTrendPoint{
+			Date:          date,
+			Requests:      dailyRequestsByDay[day],
+			SuccessRatePct: successRate,
+		})
+	}
+	for mode, stats := range modeStats {
+		byMode[mode] = contracts.FleetStreamStatsMode{
+			Requests:       stats.requests,
+			SuccessRatePct: streamRate(stats.successes, stats.requests),
+		}
+	}
+
+	worst := make([]contracts.FleetStreamWorstDevice, 0, len(deviceStats))
+	for _, agg := range deviceStats {
+		if agg.requests == 0 {
+			continue
+		}
+		worst = append(worst, contracts.FleetStreamWorstDevice{
+			DeviceID:       agg.deviceID,
+			DeviceName:     agg.deviceName,
+			Requests:       agg.requests,
+			SuccessRatePct: streamRate(agg.successes, agg.requests),
+		})
+	}
+	sort.Slice(worst, func(i, j int) bool {
+		if worst[i].SuccessRatePct != worst[j].SuccessRatePct {
+			return worst[i].SuccessRatePct < worst[j].SuccessRatePct
+		}
+		return worst[i].Requests < worst[j].Requests
+	})
+	if len(worst) > 10 {
+		worst = worst[:10]
+	}
+
+	return contracts.FleetStreamStats{
+		OrgID:              orgID,
+		Window:             window,
+		SuccessRatePct:     streamRate(totalSuccesses, totalRequests),
+		AvgDurationSeconds: averageDuration(totalDuration, totalRequests),
+		ActiveSessions:     activeSessions,
+		NeverStreamedCount: neverStreamedCount,
+		ByMode:             byMode,
+		Trend:              trend,
+		WorstDevices:       worst,
+	}
+}
+
+type streamProfileData struct {
+	mode        string
+	baseRequest int
+	successRate float64
+	never       bool
+}
+
+func streamProfile(index int, device contracts.Device) streamProfileData {
+	baseRequests := 4
+	baseSuccess := 84.0
+	never := false
+	switch device.Readiness {
+	case contracts.ReadinessOnline:
+		baseRequests = 6
+		baseSuccess = 94
+		if strings.HasSuffix(device.VideoCloudDevID, "-1") || strings.HasSuffix(device.ID, "-1") || strings.HasSuffix(device.ID, "1") {
+			never = true
+		}
+	case contracts.ReadinessActivated, contracts.ReadinessCloudActivationPending:
+		baseRequests = 4
+		baseSuccess = 78
+	case contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending, contracts.ReadinessDeactivationPending:
+		baseRequests = 3
+		baseSuccess = 68
+	case contracts.ReadinessFailed:
+		baseRequests = 1
+		baseSuccess = 40
+	default:
+		baseRequests = 2
+		baseSuccess = 55
+	}
+	switch index % 3 {
+	case 0:
+		return streamProfileData{mode: streamModeRTSP, baseRequest: baseRequests, successRate: baseSuccess, never: never}
+	case 1:
+		return streamProfileData{mode: streamModeRelay, baseRequest: baseRequests - 1, successRate: math.Min(baseSuccess+4, 100), never: never}
+	default:
+		return streamProfileData{mode: streamModeWebRTC, baseRequest: baseRequests - 2, successRate: math.Max(baseSuccess-8, 0), never: never}
+	}
+}
+
+func streamDevicesForDay(day, totalDevices, index int, device contracts.Device, _ bool) (int, int, int) {
+	profile := streamProfile(index, device)
+	if profile.never {
+		return 0, 0, 0
+	}
+	requests := profile.baseRequest + ((day * 3) % 5) + (totalDevices % 4)
+	if requests < 0 {
+		return 0, 0, 0
+	}
+	variable := float64((day % 7) * 2)
+	successRate := profile.successRate + (float64(day%3) - variable/6)
+	successRate = math.Min(100, math.Max(0, successRate))
+	successes := int(math.Round(float64(requests) * (successRate / 100)))
+	if successes < 0 {
+		successes = 0
+	}
+	if successes > requests {
+		successes = requests
+	}
+	baseDuration := 80 + int(profile.successRate)/2 + (len(device.ID) % 4) + (day % 3)
+	successBoost := successes * 3
+	failurePenalty := requests*2 - successes
+	duration := requests*baseDuration + successBoost - failurePenalty
+	return requests, successes, duration
+}
+
+func streamRate(successes, requests int) float64 {
+	if requests <= 0 {
+		return 0
+	}
+	return toTwoDecimal(float64(successes) * 100 / float64(requests))
+}
+
+func averageDuration(totalDuration, totalRequests int) float64 {
+	if totalRequests <= 0 {
+		return 0
+	}
+	return toTwoDecimal(float64(totalDuration) / float64(totalRequests))
 }
 
 func (s *Server) customerOrgIDForSession(ctx context.Context, session store.Session) (string, error) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -998,6 +998,171 @@ func TestFleetHealthSummaryWindow30dAndOrgScope(t *testing.T) {
 	}
 }
 
+func TestFleetStreamStatsAPIRequiresCustomerSession(t *testing.T) {
+	t.Parallel()
+
+	srv, err := NewTestServer(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("NewTestServer returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestFleetStreamStatsDemoDefaultsTo7d(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.FleetStreamStats
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode stream stats payload: %v", err)
+	}
+	if payload.OrgID != "org-acme" {
+		t.Fatalf("org_id = %q, want %q", payload.OrgID, "org-acme")
+	}
+	if payload.Window != "7d" {
+		t.Fatalf("window = %q, want %q", payload.Window, "7d")
+	}
+	if len(payload.Trend) != 7 {
+		t.Fatalf("trend length = %d, want %d", len(payload.Trend), 7)
+	}
+	for _, mode := range []string{"rtsp", "relay", "webrtc"} {
+		stats, ok := payload.ByMode[mode]
+		if !ok {
+			t.Fatalf("by_mode is missing key %q", mode)
+		}
+		if stats.Requests < 0 {
+			t.Fatalf("by_mode.%s.requests = %d, want >=0", mode, stats.Requests)
+		}
+		if stats.SuccessRatePct < 0 || stats.SuccessRatePct > 100 {
+			t.Fatalf("by_mode.%s.success_rate_pct = %f, want 0..100", mode, stats.SuccessRatePct)
+		}
+	}
+	if payload.SuccessRatePct < 0 || payload.SuccessRatePct > 100 {
+		t.Fatalf("success_rate_pct = %f, want 0..100", payload.SuccessRatePct)
+	}
+	if payload.NeverStreamedCount < 0 {
+		t.Fatalf("never_streamed_count = %d, want >=0", payload.NeverStreamedCount)
+	}
+	if len(payload.WorstDevices) > 10 {
+		t.Fatalf("worst_devices length = %d, want <=10", len(payload.WorstDevices))
+	}
+}
+
+func TestFleetStreamStatsWindow30dAndOrgScope(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats?window=30d", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.FleetStreamStats
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode stream stats payload: %v", err)
+	}
+	if payload.Window != "30d" {
+		t.Fatalf("window = %q, want %q", payload.Window, "30d")
+	}
+	if len(payload.Trend) != 30 {
+		t.Fatalf("trend length = %d, want %d", len(payload.Trend), 30)
+	}
+	for _, dev := range payload.WorstDevices {
+		if dev.DeviceID == "dev-003" || dev.DeviceID == "dev-004" {
+			t.Fatalf("worst_devices includes out-of-org device %q", dev.DeviceID)
+		}
+	}
+}
+
+func TestFleetStreamStatsWorstDevicesSortedAsc(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats?window=7d", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.FleetStreamStats
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode stream stats payload: %v", err)
+	}
+	if len(payload.WorstDevices) > 10 {
+		t.Fatalf("worst_devices length = %d, want <=10", len(payload.WorstDevices))
+	}
+	for i := 1; i < len(payload.WorstDevices); i++ {
+		if payload.WorstDevices[i-1].SuccessRatePct > payload.WorstDevices[i].SuccessRatePct {
+			t.Fatalf("worst_devices not sorted asc at index %d: %f > %f", i, payload.WorstDevices[i-1].SuccessRatePct, payload.WorstDevices[i].SuccessRatePct)
+		}
+	}
+}
+
 func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -50,6 +50,7 @@ func TestServerHealthAndHomeRedirect(t *testing.T) {
 		"/console/firmware-ota",
 		"/console/stream-health",
 		"/console/groups",
+		"/console/customers",
 		"/console/operations",
 		"/console/audit",
 		"/admin",

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -170,3 +170,33 @@ type FleetHealthSummary struct {
 	OnlineRate7dPct float64                 `json:"online_rate_7d_pct"`
 	Trend           []FleetHealthTrendPoint `json:"trend"`
 }
+
+type FleetStreamStatsMode struct {
+	Requests       int     `json:"requests"`
+	SuccessRatePct float64 `json:"success_rate_pct"`
+}
+
+type FleetStreamTrendPoint struct {
+	Date          string  `json:"date"`
+	Requests      int     `json:"requests"`
+	SuccessRatePct float64 `json:"success_rate_pct"`
+}
+
+type FleetStreamWorstDevice struct {
+	DeviceID        string  `json:"device_id"`
+	DeviceName      string  `json:"device_name"`
+	SuccessRatePct  float64 `json:"success_rate_pct"`
+	Requests        int     `json:"requests"`
+}
+
+type FleetStreamStats struct {
+	OrgID              string                               `json:"org_id"`
+	Window             string                               `json:"window"`
+	SuccessRatePct     float64                              `json:"success_rate_pct"`
+	AvgDurationSeconds float64                              `json:"avg_duration_seconds"`
+	ActiveSessions     int                                  `json:"active_sessions"`
+	NeverStreamedCount int                                  `json:"never_streamed_count"`
+	ByMode             map[string]FleetStreamStatsMode       `json:"by_mode"`
+	Trend              []FleetStreamTrendPoint               `json:"trend"`
+	WorstDevices       []FleetStreamWorstDevice              `json:"worst_devices"`
+}

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -13,6 +13,7 @@ test('maps customer shell paths to customer routes', () => {
   assert.equal(routeFromPath('/console'), 'overview');
   assert.equal(routeFromPath('/console/overview'), 'overview');
   assert.equal(routeFromPath('/console/devices'), 'devices');
+  assert.equal(routeFromPath('/console/customers'), 'overview');
   assert.equal(routeFromPath('/console/operations'), 'operations');
   assert.equal(routeFromPath('/console/firmware-ota'), 'firmware-ota');
   assert.equal(routeFromPath('/console/stream-health'), 'stream-health');


### PR DESCRIPTION
## Summary\n- Add GET /api/fleet/stream-stats endpoint with customer-only auth and 7d/30d window support.\n- Add contract DTOs for stream stats, per-mode breakdown, trend, and worst device ranking.\n- Build deterministic demo data for stream stats in local mode with all mode keys populated and org-scoped results.\n- Add API tests for auth, window behavior, org scoping, and worst_devices sorting.\n\nCloses #34