### PR TITLE
feat: GET /api/fleet/firmware-distribution endpoint

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -90,6 +90,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/devices/{id}", s.apiDevice)
 	s.mux.HandleFunc("GET /api/devices/{id}/telemetry", s.apiDeviceTelemetry)
 	s.mux.HandleFunc("GET /api/fleet/health-summary", s.apiFleetHealthSummary)
+	s.mux.HandleFunc("GET /api/fleet/firmware-distribution", s.apiFleetFirmwareDistribution)
 	s.mux.HandleFunc("GET /api/operations", s.apiOperations)
 	s.mux.HandleFunc("GET /api/admin/operations", s.apiAdminOperations)
 	s.mux.HandleFunc("GET /api/service-health", s.apiServiceHealth)
@@ -489,6 +490,32 @@ func (s *Server) apiFleetHealthSummary(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, fleetHealthSummary(orgID, devices, days))
 }
 
+func (s *Server) apiFleetFirmwareDistribution(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requestSession(r)
+	if !ok || session.Kind != "customer" {
+		http.Error(w, "customer authentication required", http.StatusUnauthorized)
+		return
+	}
+	orgID, err := s.customerOrgIDForSession(r.Context(), session)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	devices, err := s.firmwareDistributionDevices(r.Context(), session, orgID)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	if dist, ok, err := s.proxyFirmwareDistribution(r.Context(), devices, orgID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	} else if ok {
+		writeJSON(w, dist)
+		return
+	}
+	writeJSON(w, demoFirmwareDistribution(orgID, devices))
+}
+
 func (s *Server) customerOrgIDForSession(ctx context.Context, session store.Session) (string, error) {
 	if session.ActiveOrgID != "" {
 		return session.ActiveOrgID, nil
@@ -542,9 +569,9 @@ func fleetHealthTrend(current contracts.FleetHealthCurrent, total, days int) []c
 	if total == 0 {
 		for i := days - 1; i >= 0; i-- {
 			trend = append(trend, contracts.FleetHealthTrendPoint{
-				Date:         today.AddDate(0, 0, -i).Format("2006-01-02"),
-				OnlinePct:    0,
-				WarningCount: 0,
+				Date:          today.AddDate(0, 0, -i).Format("2006-01-02"),
+				OnlinePct:     0,
+				WarningCount:  0,
 				CriticalCount: 0,
 			})
 		}
@@ -579,6 +606,449 @@ func fleetHealthTrend(current contracts.FleetHealthCurrent, total, days int) []c
 		})
 	}
 	return trend
+}
+
+func (s *Server) firmwareDistributionDevices(ctx context.Context, session store.Session, orgID string) ([]contracts.Device, error) {
+	if s.accountClient.Enabled() {
+		return s.customerDevices(ctx, session)
+	}
+	devices, err := s.store.ListDevices()
+	if err != nil {
+		return nil, err
+	}
+	filtered := make([]contracts.Device, 0, len(devices))
+	for _, device := range devices {
+		if device.OrganizationID == orgID {
+			filtered = append(filtered, device)
+		}
+	}
+	return filtered, nil
+}
+
+func (s *Server) proxyFirmwareDistribution(ctx context.Context, devices []contracts.Device, orgID string) (contracts.FirmwareDistribution, bool, error) {
+	if !s.videoClient.Enabled() || strings.TrimSpace(s.cfg.VideoCloudAdminToken) == "" {
+		return contracts.FirmwareDistribution{}, false, nil
+	}
+
+	type deviceVersion struct {
+		version   string
+		updatedAt time.Time
+	}
+
+	deviceVersions := make(map[string]deviceVersion, len(devices))
+	for _, device := range devices {
+		version := firmwareVersionFromDevice(device)
+		deviceVersions[firmwareDistributionDeviceKey(device)] = deviceVersion{version: version}
+		if id := strings.TrimSpace(device.ID); id != "" {
+			deviceVersions[id] = deviceVersion{version: version}
+		}
+	}
+
+	models := make(map[string]struct{}, len(devices))
+	for _, device := range devices {
+		model := strings.TrimSpace(device.Model)
+		if model != "" {
+			models[model] = struct{}{}
+		}
+	}
+
+	latestVersions := map[string]bool{}
+	campaigns := make([]contracts.FirmwareDistributionCampaign, 0)
+	for model := range models {
+		enumResp, err := s.videoClient.EnumFirmware(ctx, s.cfg.VideoCloudAdminToken, model)
+		if err != nil {
+			return contracts.FirmwareDistribution{}, true, err
+		}
+		if latest := latestFirmwareVersion(enumResp); latest != "" {
+			latestVersions[latest] = true
+		}
+
+		rolloutResp, err := s.videoClient.QueryFirmwareRollout(ctx, s.cfg.VideoCloudAdminToken, model, "")
+		if err != nil {
+			return contracts.FirmwareDistribution{}, true, err
+		}
+		for _, rollout := range rolloutResp.Rollouts {
+			version := strings.TrimSpace(rollout.CurrentVersion)
+			if version == "" {
+				version = strings.TrimSpace(rollout.TargetVersion)
+			}
+			if version == "" {
+				continue
+			}
+			updatedAt := parseFirmwareTimestamp(rollout.UpdatedAt)
+			if updatedAt.IsZero() {
+				updatedAt = parseFirmwareTimestamp(rollout.LastUpdated)
+			}
+			matched := false
+			for _, device := range devices {
+				if rollout.DeviceID != device.ID && rollout.DeviceID != strings.TrimSpace(device.VideoCloudDevID) {
+					continue
+				}
+				for _, key := range []string{firmwareDistributionDeviceKey(device), strings.TrimSpace(device.ID)} {
+					if key == "" {
+						continue
+					}
+					if prev, ok := deviceVersions[key]; !ok || updatedAt.After(prev.updatedAt) || prev.version == "" {
+						deviceVersions[key] = deviceVersion{version: version, updatedAt: updatedAt}
+					}
+				}
+				matched = true
+			}
+			if !matched {
+				if prev, ok := deviceVersions[rollout.DeviceID]; !ok || updatedAt.After(prev.updatedAt) || prev.version == "" {
+					deviceVersions[rollout.DeviceID] = deviceVersion{version: version, updatedAt: updatedAt}
+				}
+			}
+		}
+
+		campaignResp, err := s.videoClient.QueryFirmwareCampaigns(ctx, s.cfg.VideoCloudAdminToken, model, false)
+		if err != nil {
+			return contracts.FirmwareDistribution{}, true, err
+		}
+		rolloutsByCampaign := make(map[string][]videoclient.FirmwareRolloutRecord)
+		for _, rollout := range rolloutResp.Rollouts {
+			if campaignID := strings.TrimSpace(rollout.CampaignID); campaignID != "" {
+				rolloutsByCampaign[campaignID] = append(rolloutsByCampaign[campaignID], rollout)
+			}
+		}
+		for _, campaign := range campaignResp {
+			if !isVisibleFirmwareCampaignState(campaign.State) {
+				continue
+			}
+			if campaignSummary := summarizeFirmwareCampaign(campaign, rolloutsByCampaign[campaign.ID]); campaignSummary.CampaignID != "" {
+				campaigns = append(campaigns, campaignSummary)
+			}
+		}
+	}
+
+	facts := make(map[string]string, len(deviceVersions))
+	for deviceID, fact := range deviceVersions {
+		version := strings.TrimSpace(fact.version)
+		if version == "" {
+			version = "unknown"
+		}
+		facts[deviceID] = version
+	}
+	dist := buildFirmwareDistribution(orgID, devices, facts, latestVersions, campaigns)
+	return dist, true, nil
+}
+
+func demoFirmwareDistribution(orgID string, devices []contracts.Device) contracts.FirmwareDistribution {
+	currentVersions := make(map[string]string, len(devices))
+	latestVersions := map[string]bool{}
+	topVersion := ""
+	for _, device := range devices {
+		version := firmwareVersionFromDevice(device)
+		if strings.TrimSpace(version) == "" {
+			version = "unknown"
+		}
+		currentVersions[firmwareDistributionDeviceKey(device)] = version
+		if id := strings.TrimSpace(device.ID); id != "" {
+			currentVersions[id] = version
+		}
+		if version != "unknown" && (topVersion == "" || compareFirmwareVersions(version, topVersion) > 0) {
+			topVersion = version
+		}
+	}
+	if topVersion != "" {
+		latestVersions[topVersion] = true
+	}
+	dist := buildFirmwareDistribution(orgID, devices, currentVersions, latestVersions, nil)
+	if len(dist.Campaigns) == 0 {
+		total := len(devices)
+		if total == 0 {
+			dist.Campaigns = []contracts.FirmwareDistributionCampaign{{
+				CampaignID:    "campaign-demo",
+				TargetVersion: "unknown",
+				Policy:        "normal",
+				State:         "active",
+				StartedAt:     time.Now().UTC().Format(time.RFC3339),
+			}}
+			return dist
+		}
+		if topVersion == "" {
+			topVersion = "unknown"
+		}
+		applied := 0
+		failed := 0
+		skipped := 0
+		for _, device := range devices {
+			if strings.EqualFold(strings.TrimSpace(currentVersions[device.ID]), topVersion) {
+				applied++
+			}
+			if device.Readiness == contracts.ReadinessFailed {
+				failed++
+			}
+			if device.Readiness == contracts.ReadinessDeactivated {
+				skipped++
+			}
+		}
+		pending := max(0, total-applied-failed-skipped)
+		dist.Campaigns = []contracts.FirmwareDistributionCampaign{{
+			CampaignID:    "campaign-demo",
+			TargetVersion: topVersion,
+			Policy:        "normal",
+			State:         "active",
+			Applied:       applied,
+			Pending:       pending,
+			Failed:        failed,
+			Skipped:       skipped,
+			Total:         total,
+			StartedAt:     time.Now().UTC().AddDate(0, 0, -7).Format(time.RFC3339),
+		}}
+	}
+	return dist
+}
+
+func buildFirmwareDistribution(orgID string, devices []contracts.Device, currentVersions map[string]string, latestVersions map[string]bool, campaigns []contracts.FirmwareDistributionCampaign) contracts.FirmwareDistribution {
+	counts := make(map[string]int)
+	for _, device := range devices {
+		version := strings.TrimSpace(currentVersions[firmwareDistributionDeviceKey(device)])
+		if version == "" {
+			version = strings.TrimSpace(currentVersions[strings.TrimSpace(device.ID)])
+		}
+		if version == "" {
+			version = "unknown"
+		}
+		counts[version]++
+	}
+
+	versionRows := make([]contracts.FirmwareDistributionVersion, 0, len(counts))
+	for version, count := range counts {
+		versionRows = append(versionRows, contracts.FirmwareDistributionVersion{
+			Version:  version,
+			Count:    count,
+			IsLatest: latestVersions[version],
+		})
+	}
+	sort.Slice(versionRows, func(i, j int) bool {
+		if versionRows[i].IsLatest != versionRows[j].IsLatest {
+			return versionRows[i].IsLatest
+		}
+		if versionRows[i].Count != versionRows[j].Count {
+			return versionRows[i].Count > versionRows[j].Count
+		}
+		return compareFirmwareVersions(versionRows[i].Version, versionRows[j].Version) > 0
+	})
+	assignFirmwareDistributionPercents(versionRows)
+
+	if len(campaigns) > 0 {
+		sort.Slice(campaigns, func(i, j int) bool {
+			if campaigns[i].StartedAt != campaigns[j].StartedAt {
+				return campaigns[i].StartedAt > campaigns[j].StartedAt
+			}
+			return campaigns[i].CampaignID < campaigns[j].CampaignID
+		})
+	}
+
+	return contracts.FirmwareDistribution{
+		OrgID:     orgID,
+		Versions:  versionRows,
+		Campaigns: campaigns,
+	}
+}
+
+func assignFirmwareDistributionPercents(rows []contracts.FirmwareDistributionVersion) {
+	if len(rows) == 0 {
+		return
+	}
+	total := 0
+	for _, row := range rows {
+		total += row.Count
+	}
+	if total == 0 {
+		for i := range rows {
+			rows[i].Pct = 0
+		}
+		return
+	}
+	sum := 0.0
+	for i := range rows {
+		if i == len(rows)-1 {
+			rows[i].Pct = toTwoDecimal(100 - sum)
+			continue
+		}
+		rows[i].Pct = toTwoDecimal(float64(rows[i].Count) / float64(total) * 100)
+		sum += rows[i].Pct
+	}
+}
+
+func latestFirmwareVersion(resp videoclient.FirmwareEnumResponse) string {
+	if len(resp.Versions) > 0 {
+		return strings.TrimSpace(resp.Versions[len(resp.Versions)-1])
+	}
+	latest := ""
+	for _, release := range resp.Releases {
+		version := strings.TrimSpace(release.Version)
+		if version == "" {
+			continue
+		}
+		if latest == "" || compareFirmwareVersions(version, latest) > 0 {
+			latest = version
+		}
+	}
+	return latest
+}
+
+func summarizeFirmwareCampaign(campaign videoclient.FirmwareCampaignRecord, rollouts []videoclient.FirmwareRolloutRecord) contracts.FirmwareDistributionCampaign {
+	summary := contracts.FirmwareDistributionCampaign{
+		CampaignID:    firstNonEmpty(strings.TrimSpace(campaign.ID), strings.TrimSpace(campaign.CampaignID)),
+		TargetVersion: strings.TrimSpace(campaign.TargetVersion),
+		Policy:        strings.TrimSpace(campaign.Policy.Name),
+		State:         strings.TrimSpace(campaign.State),
+		StartedAt:     campaign.CreatedAt,
+	}
+	if summary.Policy == "" {
+		summary.Policy = "normal"
+	}
+	if summary.State == "" {
+		summary.State = "active"
+	}
+	if summary.CampaignID == "" {
+		return contracts.FirmwareDistributionCampaign{}
+	}
+	if summary.StartedAt == "" {
+		summary.StartedAt = campaign.UpdatedAt
+	}
+	for _, rollout := range rollouts {
+		status := rolloutStatus(rollout)
+		summary.Total++
+		switch status {
+		case "applied":
+			summary.Applied++
+		case "failed":
+			summary.Failed++
+		case "skipped":
+			summary.Skipped++
+		case "pending", "eligible", "downloading":
+			summary.Pending++
+		default:
+			summary.Pending++
+		}
+	}
+	if summary.StartedAt == "" && len(rollouts) > 0 {
+		summary.StartedAt = oldestFirmwareTimestamp(rollouts).Format(time.RFC3339)
+	}
+	if summary.StartedAt == "" {
+		summary.StartedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+	return summary
+}
+
+func isVisibleFirmwareCampaignState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "active", "scheduled":
+		return true
+	default:
+		return false
+	}
+}
+
+func rolloutStatus(rollout videoclient.FirmwareRolloutRecord) string {
+	if status := strings.TrimSpace(rollout.RolloutStatus); status != "" {
+		return status
+	}
+	return strings.TrimSpace(rollout.Status)
+}
+
+func oldestFirmwareTimestamp(rollouts []videoclient.FirmwareRolloutRecord) time.Time {
+	var oldest time.Time
+	for _, rollout := range rollouts {
+		ts := parseFirmwareTimestamp(firstNonEmpty(rollout.UpdatedAt, rollout.LastUpdated))
+		if ts.IsZero() {
+			continue
+		}
+		if oldest.IsZero() || ts.Before(oldest) {
+			oldest = ts
+		}
+	}
+	return oldest
+}
+
+func parseFirmwareTimestamp(raw string) time.Time {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{time.RFC3339Nano, time.RFC3339} {
+		if parsed, err := time.Parse(layout, raw); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func firmwareDistributionDeviceKey(device contracts.Device) string {
+	if key := strings.TrimSpace(device.VideoCloudDevID); key != "" {
+		return key
+	}
+	return strings.TrimSpace(device.ID)
+}
+
+func compareFirmwareVersions(a, b string) int {
+	left, okLeft := parseFirmwareVersionParts(a)
+	right, okRight := parseFirmwareVersionParts(b)
+	if okLeft && okRight {
+		n := len(left)
+		if len(right) > n {
+			n = len(right)
+		}
+		for i := 0; i < n; i++ {
+			li := 0
+			ri := 0
+			if i < len(left) {
+				li = left[i]
+			}
+			if i < len(right) {
+				ri = right[i]
+			}
+			if li < ri {
+				return -1
+			}
+			if li > ri {
+				return 1
+			}
+		}
+		return 0
+	}
+	return strings.Compare(strings.TrimSpace(a), strings.TrimSpace(b))
+}
+
+func parseFirmwareVersionParts(raw string) ([]int, bool) {
+	raw = strings.TrimSpace(strings.TrimPrefix(strings.ToLower(raw), "v"))
+	if raw == "" {
+		return nil, false
+	}
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r < '0' || r > '9'
+	})
+	if len(parts) == 0 {
+		return nil, false
+	}
+	out := make([]int, 0, len(parts))
+	for _, part := range parts {
+		if part == "" {
+			continue
+		}
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return nil, false
+		}
+		out = append(out, value)
+	}
+	if len(out) == 0 {
+		return nil, false
+	}
+	return out, true
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func telemetryHealthFromReadiness(readiness contracts.ReadinessState) string {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -681,7 +681,7 @@ func (s *Server) proxyFirmwareDistribution(ctx context.Context, devices []contra
 			}
 			matched := false
 			for _, device := range devices {
-				if rollout.DeviceID != device.ID && rollout.DeviceID != strings.TrimSpace(device.VideoCloudDevID) {
+				if !matchesFirmwareRolloutDevice(device, rollout) {
 					continue
 				}
 				for _, key := range []string{firmwareDistributionDeviceKey(device), strings.TrimSpace(device.ID)} {
@@ -707,7 +707,10 @@ func (s *Server) proxyFirmwareDistribution(ctx context.Context, devices []contra
 		}
 		rolloutsByCampaign := make(map[string][]videoclient.FirmwareRolloutRecord)
 		for _, rollout := range rolloutResp.Rollouts {
-			if campaignID := strings.TrimSpace(rollout.CampaignID); campaignID != "" {
+			for _, campaignID := range firmwareCampaignKeys(rollout.CampaignID, "") {
+				if campaignID == "" {
+					continue
+				}
 				rolloutsByCampaign[campaignID] = append(rolloutsByCampaign[campaignID], rollout)
 			}
 		}
@@ -715,7 +718,11 @@ func (s *Server) proxyFirmwareDistribution(ctx context.Context, devices []contra
 			if !isVisibleFirmwareCampaignState(campaign.State) {
 				continue
 			}
-			if campaignSummary := summarizeFirmwareCampaign(campaign, rolloutsByCampaign[campaign.ID]); campaignSummary.CampaignID != "" {
+			rollouts := make([]videoclient.FirmwareRolloutRecord, 0)
+			for _, campaignID := range firmwareCampaignKeys(campaign.ID, campaign.CampaignID) {
+				rollouts = append(rollouts, rolloutsByCampaign[campaignID]...)
+			}
+			if campaignSummary := summarizeFirmwareCampaign(campaign, rollouts); campaignSummary.CampaignID != "" {
 				campaigns = append(campaigns, campaignSummary)
 			}
 		}
@@ -933,6 +940,32 @@ func summarizeFirmwareCampaign(campaign videoclient.FirmwareCampaignRecord, roll
 		summary.StartedAt = time.Now().UTC().Format(time.RFC3339)
 	}
 	return summary
+}
+
+func matchesFirmwareRolloutDevice(device contracts.Device, rollout videoclient.FirmwareRolloutRecord) bool {
+	rolloutID := strings.TrimSpace(rollout.DeviceID)
+	accountID := strings.TrimSpace(rollout.AccountDeviceID)
+	deviceID := strings.TrimSpace(device.ID)
+	videoCloudID := strings.TrimSpace(device.VideoCloudDevID)
+	return rolloutID != "" && (rolloutID == deviceID || rolloutID == videoCloudID) ||
+		accountID != "" && (accountID == deviceID || accountID == videoCloudID)
+}
+
+func firmwareCampaignKeys(values ...string) []string {
+	keys := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		key := strings.TrimSpace(value)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys
 }
 
 func isVisibleFirmwareCampaignState(state string) bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1246,6 +1246,86 @@ func TestFleetFirmwareDistributionProxyMode(t *testing.T) {
 	}
 }
 
+func TestFleetFirmwareDistributionProxyModeUsesAlternateRolloutKeys(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs/org-up/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-up-1","name":"cam-up-1","model":"cam-a","serial_number":"SERIAL-1","video_cloud_devid":"device-1","status":"online","readiness":"online","last_seen_at":"2026-05-01T00:00:00Z","updated_at":"2026-05-01T00:00:00Z"},{"id":"dev-up-2","name":"cam-up-2","model":"cam-a","serial_number":"SERIAL-2","video_cloud_devid":"device-2","status":"online","readiness":"online","last_seen_at":"2026-05-01T00:00:00Z","updated_at":"2026-05-01T00:00:00Z"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/enum_firmware":
+			_, _ = w.Write([]byte(`{"status":"ok","versions":["v1.2.3","v1.2.4"],"releases":[{"version":"v1.2.3"},{"version":"v1.2.4"}]}`))
+		case "/query_firmware_campaign":
+			_, _ = w.Write([]byte(`{"status":"ok","campaigns":[{"campaign_id":"campaign-2026-04","model":"cam-a","target_version":"v1.2.4","policy":{"name":"normal"},"state":"active","created_at":"2026-04-01T00:00:00Z","updated_at":"2026-04-01T00:00:00Z"}]}`))
+		case "/query_firmware_rollout":
+			_, _ = w.Write([]byte(`{"status":"ok","model":"cam-a","target":"v1.2.4","rollouts":[{"account_device_id":"device-1","campaign_id":"campaign-2026-04","target_version":"v1.2.4","current_version":"v1.2.4","rollout_status":"applied","updated_at":"2026-04-01T00:00:00Z"},{"device_id":"dev-up-2","campaign_id":"campaign-2026-04","target_version":"v1.2.4","current_version":"v1.2.3","rollout_status":"pending","updated_at":"2026-04-01T00:00:00Z"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config: config.Config{
+			AccountManagerBaseURL: accountUpstream.URL,
+			VideoCloudBaseURL:     videoUpstream.URL,
+			VideoCloudAdminToken:  "secret-admin",
+		},
+		AccountClient: accountclient.New(accountUpstream.URL),
+		VideoClient:   videoclient.New(videoUpstream.URL),
+	})
+	session, err := st.CreateSession("customer", "u1", "user@example.com", "access", "refresh", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/firmware-distribution", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("firmware distribution status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var payload contracts.FirmwareDistribution
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode firmware distribution: %v", err)
+	}
+	if len(payload.Versions) != 2 {
+		t.Fatalf("versions length = %d, want 2", len(payload.Versions))
+	}
+	if payload.Versions[0].Version != "v1.2.4" || !payload.Versions[0].IsLatest {
+		t.Fatalf("first version = %+v, want latest v1.2.4", payload.Versions[0])
+	}
+	if len(payload.Campaigns) != 1 {
+		t.Fatalf("campaigns length = %d, want 1", len(payload.Campaigns))
+	}
+	if payload.Campaigns[0].CampaignID != "campaign-2026-04" {
+		t.Fatalf("campaign id = %q, want campaign-2026-04", payload.Campaigns[0].CampaignID)
+	}
+	if payload.Campaigns[0].Applied != 1 || payload.Campaigns[0].Pending != 1 || payload.Campaigns[0].Total != 2 {
+		t.Fatalf("campaign summary = %+v, want applied=1 pending=1 total=2", payload.Campaigns[0])
+	}
+}
+
 func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1077,6 +1077,175 @@ func TestFleetHealthSummaryEmptyOrgReturnsFullWindow(t *testing.T) {
 	}
 }
 
+func TestFleetFirmwareDistributionRequiresCustomerSession(t *testing.T) {
+	t.Parallel()
+
+	srv, err := NewTestServer(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("NewTestServer returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/api/fleet/firmware-distribution", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("firmware distribution status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+}
+
+func TestFleetFirmwareDistributionDemoPayload(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := New(st)
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/firmware-distribution", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("firmware distribution status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var payload contracts.FirmwareDistribution
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode firmware distribution: %v", err)
+	}
+	if payload.OrgID != "org-acme" {
+		t.Fatalf("org_id = %q, want org-acme", payload.OrgID)
+	}
+	if len(payload.Versions) != 2 {
+		t.Fatalf("versions length = %d, want 2", len(payload.Versions))
+	}
+	if !payload.Versions[0].IsLatest {
+		t.Fatalf("first version is not latest: %+v", payload.Versions[0])
+	}
+	totalPct := 0.0
+	totalCount := 0
+	for _, version := range payload.Versions {
+		totalPct += version.Pct
+		totalCount += version.Count
+	}
+	if totalCount != 2 {
+		t.Fatalf("version count total = %d, want 2", totalCount)
+	}
+	if totalPct != 100 {
+		t.Fatalf("version pct total = %f, want 100", totalPct)
+	}
+	if len(payload.Campaigns) != 1 {
+		t.Fatalf("campaigns length = %d, want 1", len(payload.Campaigns))
+	}
+	if payload.Campaigns[0].State != "active" || payload.Campaigns[0].Policy != "normal" {
+		t.Fatalf("campaign summary = %+v, want active normal", payload.Campaigns[0])
+	}
+}
+
+func TestFleetFirmwareDistributionProxyMode(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"owner"}]}`))
+		case "/v1/orgs/org-up/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-up-1","name":"cam-up-1","model":"cam-a","serial_number":"SERIAL-1","video_cloud_devid":"device-1","status":"online","readiness":"online","last_seen_at":"2026-05-01T00:00:00Z","updated_at":"2026-05-01T00:00:00Z"},{"id":"dev-up-2","name":"cam-up-2","model":"cam-a","serial_number":"SERIAL-2","video_cloud_devid":"device-2","status":"online","readiness":"online","last_seen_at":"2026-05-01T00:00:00Z","updated_at":"2026-05-01T00:00:00Z"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/query_camera_activate":
+			_, _ = w.Write([]byte(`{"status":"ok","devices":["1","1"]}`))
+		case "/get_camera_info":
+			var body struct {
+				DevID string `json:"devid"`
+			}
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			version := "v1.2.4"
+			if body.DevID == "device-2" {
+				version = "v1.2.3"
+			}
+			_, _ = w.Write([]byte(fmt.Sprintf(`{"status":"ok","info":{"current_transport":"websocket","firmware_version":"%s"}}`, version)))
+		case "/enum_firmware":
+			_, _ = w.Write([]byte(`{"status":"ok","versions":["v1.2.3","v1.2.4"],"releases":[{"version":"v1.2.3"},{"version":"v1.2.4"}]}`))
+		case "/query_firmware_campaign":
+			_, _ = w.Write([]byte(`{"status":"ok","campaigns":[{"id":"campaign-2026-04","model":"cam-a","target_version":"v1.2.4","policy":{"name":"normal"},"state":"active","created_at":"2026-04-01T00:00:00Z","updated_at":"2026-04-01T00:00:00Z"}]}`))
+		case "/query_firmware_rollout":
+			_, _ = w.Write([]byte(`{"status":"ok","model":"cam-a","target":"v1.2.4","rollouts":[{"device_id":"dev-up-1","campaign_id":"campaign-2026-04","target_version":"v1.2.4","current_version":"v1.2.4","rollout_status":"applied","updated_at":"2026-04-01T00:00:00Z"},{"device_id":"dev-up-2","campaign_id":"campaign-2026-04","target_version":"v1.2.4","current_version":"v1.2.3","rollout_status":"pending","updated_at":"2026-04-01T00:00:00Z"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config: config.Config{
+			AccountManagerBaseURL: accountUpstream.URL,
+			VideoCloudBaseURL:     videoUpstream.URL,
+			VideoCloudAdminToken:  "secret-admin",
+		},
+		AccountClient: accountclient.New(accountUpstream.URL),
+		VideoClient:   videoclient.New(videoUpstream.URL),
+	})
+	session, err := st.CreateSession("customer", "u1", "user@example.com", "access", "refresh", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/firmware-distribution", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("firmware distribution status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	var payload contracts.FirmwareDistribution
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode firmware distribution: %v", err)
+	}
+	if payload.OrgID != "org-up" {
+		t.Fatalf("org_id = %q, want org-up", payload.OrgID)
+	}
+	if len(payload.Versions) != 2 {
+		t.Fatalf("versions length = %d, want 2", len(payload.Versions))
+	}
+	if payload.Versions[0].Version != "v1.2.4" || !payload.Versions[0].IsLatest {
+		t.Fatalf("first version = %+v, want latest v1.2.4", payload.Versions[0])
+	}
+	if len(payload.Campaigns) != 1 {
+		t.Fatalf("campaigns length = %d, want 1", len(payload.Campaigns))
+	}
+	if payload.Campaigns[0].Applied != 1 || payload.Campaigns[0].Pending != 1 || payload.Campaigns[0].Total != 2 {
+		t.Fatalf("campaign summary = %+v, want applied=1 pending=1 total=2", payload.Campaigns[0])
+	}
+}
+
 func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -170,3 +170,29 @@ type FleetHealthSummary struct {
 	OnlineRate7dPct float64                 `json:"online_rate_7d_pct"`
 	Trend           []FleetHealthTrendPoint `json:"trend"`
 }
+
+type FirmwareDistributionVersion struct {
+	Version  string  `json:"version"`
+	Count    int     `json:"count"`
+	Pct      float64 `json:"pct"`
+	IsLatest bool    `json:"is_latest"`
+}
+
+type FirmwareDistributionCampaign struct {
+	CampaignID    string `json:"campaign_id"`
+	TargetVersion string `json:"target_version"`
+	Policy        string `json:"policy"`
+	State         string `json:"state"`
+	Applied       int    `json:"applied"`
+	Pending       int    `json:"pending"`
+	Failed        int    `json:"failed"`
+	Skipped       int    `json:"skipped"`
+	Total         int    `json:"total"`
+	StartedAt     string `json:"started_at"`
+}
+
+type FirmwareDistribution struct {
+	OrgID     string                         `json:"org_id"`
+	Versions  []FirmwareDistributionVersion  `json:"versions"`
+	Campaigns []FirmwareDistributionCampaign `json:"campaigns"`
+}

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -22,6 +22,65 @@ type DeviceInfo struct {
 	CurrentTransport string
 }
 
+type FirmwareRelease struct {
+	Version string `json:"version"`
+	Model   string `json:"model,omitempty"`
+}
+
+type FirmwareRolloutRecord struct {
+	DeviceID        string `json:"device_id"`
+	AccountDeviceID string `json:"account_device_id,omitempty"`
+	DeviceName      string `json:"device_name,omitempty"`
+	Model           string `json:"model,omitempty"`
+	CampaignID      string `json:"campaign_id,omitempty"`
+	TargetVersion   string `json:"target_version,omitempty"`
+	CurrentVersion  string `json:"current_version,omitempty"`
+	RolloutStatus   string `json:"rollout_status,omitempty"`
+	Status          string `json:"status,omitempty"`
+	Reason          string `json:"reason,omitempty"`
+	UpdatedAt       string `json:"updated_at,omitempty"`
+	LastUpdated     string `json:"last_updated,omitempty"`
+}
+
+type FirmwareRolloutResponse struct {
+	Status   string                  `json:"status"`
+	Model    string                  `json:"model"`
+	Target   string                  `json:"target,omitempty"`
+	Rollouts []FirmwareRolloutRecord `json:"rollouts,omitempty"`
+}
+
+type FirmwareCampaignPolicy struct {
+	Name        string `json:"name"`
+	StartAt     string `json:"start_at,omitempty"`
+	EndAt       string `json:"end_at,omitempty"`
+	TimeZone    string `json:"time_zone,omitempty"`
+	WindowStart string `json:"window_start,omitempty"`
+	WindowEnd   string `json:"window_end,omitempty"`
+}
+
+type FirmwareCampaignRecord struct {
+	ID            string                 `json:"id"`
+	CampaignID    string                 `json:"campaign_id,omitempty"`
+	Model         string                 `json:"model"`
+	TargetVersion string                 `json:"target_version"`
+	Policy        FirmwareCampaignPolicy `json:"policy"`
+	State         string                 `json:"state"`
+	CreatedAt     string                 `json:"created_at"`
+	UpdatedAt     string                 `json:"updated_at"`
+}
+
+type FirmwareCampaignResponse struct {
+	Status    string                   `json:"status"`
+	Campaigns []FirmwareCampaignRecord `json:"campaigns,omitempty"`
+	Campaign  *FirmwareCampaignRecord  `json:"campaign,omitempty"`
+}
+
+type FirmwareEnumResponse struct {
+	Status   string            `json:"status"`
+	Versions []string          `json:"versions,omitempty"`
+	Releases []FirmwareRelease `json:"releases,omitempty"`
+}
+
 type DeviceTelemetryResponse struct {
 	Status          string                  `json:"status"`
 	OrgID           string                  `json:"org_id"`
@@ -240,6 +299,50 @@ func (c *Client) GetDeviceInfo(ctx context.Context, adminToken, devid string) (D
 		info.FirmwareVersion = strings.TrimSpace(value)
 	}
 	return info, nil
+}
+
+func (c *Client) EnumFirmware(ctx context.Context, adminToken, model string) (FirmwareEnumResponse, error) {
+	if !c.Enabled() {
+		return FirmwareEnumResponse{}, fmt.Errorf("video cloud base URL is not configured")
+	}
+	var out FirmwareEnumResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/enum_firmware", adminToken, map[string]string{"model": model}, &out); err != nil {
+		return FirmwareEnumResponse{}, err
+	}
+	return out, nil
+}
+
+func (c *Client) QueryFirmwareRollout(ctx context.Context, adminToken, model, campaignID string) (FirmwareRolloutResponse, error) {
+	if !c.Enabled() {
+		return FirmwareRolloutResponse{}, fmt.Errorf("video cloud base URL is not configured")
+	}
+	req := map[string]string{"model": model}
+	if strings.TrimSpace(campaignID) != "" {
+		req["campaign_id"] = strings.TrimSpace(campaignID)
+	}
+	var out FirmwareRolloutResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/query_firmware_rollout", adminToken, req, &out); err != nil {
+		return FirmwareRolloutResponse{}, err
+	}
+	return out, nil
+}
+
+func (c *Client) QueryFirmwareCampaigns(ctx context.Context, adminToken, model string, includeArchived bool) ([]FirmwareCampaignRecord, error) {
+	if !c.Enabled() {
+		return nil, fmt.Errorf("video cloud base URL is not configured")
+	}
+	req := map[string]any{"model": model}
+	if includeArchived {
+		req["include_archived"] = true
+	}
+	var out FirmwareCampaignResponse
+	if err := c.doJSON(ctx, http.MethodPost, "/query_firmware_campaign", adminToken, req, &out); err != nil {
+		return nil, err
+	}
+	if out.Campaign != nil {
+		return []FirmwareCampaignRecord{*out.Campaign}, nil
+	}
+	return out.Campaigns, nil
 }
 
 func (c *Client) DeviceTelemetry(ctx context.Context, adminToken, devid, orgID string) (DeviceTelemetryResponse, error) {

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -74,6 +74,15 @@ func TestDisabledClient(t *testing.T) {
 	if _, err := client.GetCameraInfo(t.Context(), "tok", "d1"); err == nil {
 		t.Fatal("expected disabled GetCameraInfo error")
 	}
+	if _, err := client.EnumFirmware(t.Context(), "tok", "cam-a"); err == nil {
+		t.Fatal("expected disabled EnumFirmware error")
+	}
+	if _, err := client.QueryFirmwareRollout(t.Context(), "tok", "cam-a", ""); err == nil {
+		t.Fatal("expected disabled QueryFirmwareRollout error")
+	}
+	if _, err := client.QueryFirmwareCampaigns(t.Context(), "tok", "cam-a", false); err == nil {
+		t.Fatal("expected disabled QueryFirmwareCampaigns error")
+	}
 }
 
 func TestQueryActivation(t *testing.T) {
@@ -266,6 +275,74 @@ func TestDeviceTelemetry(t *testing.T) {
 	}
 	if len(response.RSSIHistory) != 1 || len(response.UptimeHistory) != 1 || len(response.RecentEvents) != 1 {
 		t.Fatalf("unexpected telemetry lengths: rssi=%d uptime=%d events=%d", len(response.RSSIHistory), len(response.UptimeHistory), len(response.RecentEvents))
+	}
+}
+
+func TestEnumFirmwareAndRolloutAndCampaigns(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/enum_firmware":
+			if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+				t.Fatalf("Authorization = %q, want Bearer secret", got)
+			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode enum body: %v", err)
+			}
+			if body["model"] != "cam-a" {
+				t.Fatalf("model = %v, want cam-a", body["model"])
+			}
+			_, _ = w.Write([]byte(`{"status":"ok","versions":["v1.2.3","v1.2.4"],"releases":[{"version":"v1.2.3"},{"version":"v1.2.4"}]}`))
+		case "/query_firmware_rollout":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode rollout body: %v", err)
+			}
+			if body["model"] != "cam-a" {
+				t.Fatalf("model = %v, want cam-a", body["model"])
+			}
+			if body["campaign_id"] != "campaign-2026-04" {
+				t.Fatalf("campaign_id = %v, want campaign-2026-04", body["campaign_id"])
+			}
+			_, _ = w.Write([]byte(`{"status":"ok","model":"cam-a","target":"v1.2.4","rollouts":[{"device_id":"dev-1","campaign_id":"campaign-2026-04","target_version":"v1.2.4","current_version":"v1.2.4","rollout_status":"applied","updated_at":"2026-04-01T00:00:00Z"}]}`))
+		case "/query_firmware_campaign":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode campaign body: %v", err)
+			}
+			if body["model"] != "cam-a" {
+				t.Fatalf("model = %v, want cam-a", body["model"])
+			}
+			_, _ = w.Write([]byte(`{"status":"ok","campaigns":[{"id":"campaign-2026-04","model":"cam-a","target_version":"v1.2.4","policy":{"name":"normal"},"state":"active","created_at":"2026-04-01T00:00:00Z","updated_at":"2026-04-01T00:00:00Z"}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL)
+	enumResp, err := client.EnumFirmware(t.Context(), "secret", "cam-a")
+	if err != nil {
+		t.Fatalf("EnumFirmware error: %v", err)
+	}
+	if len(enumResp.Versions) != 2 || enumResp.Versions[1] != "v1.2.4" {
+		t.Fatalf("enum response = %#v", enumResp)
+	}
+	rolloutResp, err := client.QueryFirmwareRollout(t.Context(), "secret", "cam-a", "campaign-2026-04")
+	if err != nil {
+		t.Fatalf("QueryFirmwareRollout error: %v", err)
+	}
+	if rolloutResp.Target != "v1.2.4" || len(rolloutResp.Rollouts) != 1 {
+		t.Fatalf("rollout response = %#v", rolloutResp)
+	}
+	campaigns, err := client.QueryFirmwareCampaigns(t.Context(), "secret", "cam-a", false)
+	if err != nil {
+		t.Fatalf("QueryFirmwareCampaigns error: %v", err)
+	}
+	if len(campaigns) != 1 || campaigns[0].ID != "campaign-2026-04" {
+		t.Fatalf("campaigns = %#v", campaigns)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `GET /api/fleet/firmware-distribution` for customer-authenticated org views.
- Return org-scoped firmware version distribution plus active campaign summaries.
- Support demo/local projections and proxy mode backed by Video Cloud rollout/campaign routes.
- Add focused client and app tests for auth, demo payloads, and proxy aggregation.

Closes #33
Refs #29