### PR TITLE
feat: add evaluation signup and verification flows

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -78,9 +78,9 @@ Account Manager when configured. Local SQLite stays authoritative only for
 platform-admin users, sessions, audit, settings, and demo data — it does not
 become authoritative for self-service customer accounts.
 
-Self-service signup is not yet implemented; track the implementation work
-through the issues opened against this repo and `rtk_account_manager` once
-the doc baseline is approved.
+Self-service signup UI is implemented in this repo; track the remaining
+quota, verification, and cross-repo integration work through the issues opened
+against this repo and `rtk_account_manager` once the doc baseline is approved.
 
 ## Architecture
 

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -24,9 +24,11 @@ type User struct {
 }
 
 type Organization struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Role string `json:"role"`
+	ID                    string `json:"id"`
+	Name                  string `json:"name"`
+	Role                  string `json:"role"`
+	Tier                  string `json:"tier,omitempty"`
+	EvaluationDeviceQuota int    `json:"evaluation_device_quota,omitempty"`
 }
 
 type Device struct {
@@ -73,6 +75,58 @@ type MeResult struct {
 	Organizations []Organization `json:"organizations"`
 }
 
+type SignupRequest struct {
+	Email            string `json:"email"`
+	Password         string `json:"password"`
+	DisplayName      string `json:"display_name,omitempty"`
+	OrganizationName string `json:"organization_name"`
+	CaptchaToken     string `json:"captcha_token,omitempty"`
+}
+
+type SignupResult struct {
+	User         User         `json:"user"`
+	Organization Organization `json:"organization"`
+}
+
+type AuthTokenRequest struct {
+	Token string `json:"token"`
+}
+
+type VerifyEmailResult struct {
+	User   User   `json:"user"`
+	Tokens Tokens `json:"tokens,omitempty"`
+}
+
+type EmailRequest struct {
+	Email string `json:"email"`
+}
+
+type QuotaRaiseRequest struct {
+	RequestedQuota int            `json:"requested_quota"`
+	UseCase        string         `json:"use_case"`
+	ContactInfo    map[string]any `json:"contact_info"`
+}
+
+type QuotaRaiseRequestRecord struct {
+	ID             string         `json:"id"`
+	OrganizationID string         `json:"organization_id"`
+	RequestedBy    string         `json:"requested_by"`
+	RequestedQuota int            `json:"requested_quota"`
+	UseCase        string         `json:"use_case"`
+	ContactInfo    map[string]any `json:"contact_info"`
+	Status         string         `json:"status"`
+	DecidedBy      string         `json:"decided_by,omitempty"`
+	DecisionReason string         `json:"decision_reason,omitempty"`
+	CreatedAt      string         `json:"created_at"`
+	UpdatedAt      string         `json:"updated_at"`
+	DecidedAt      string         `json:"decided_at,omitempty"`
+}
+
+type QuotaRaiseRequestResult struct {
+	QuotaRaiseRequest QuotaRaiseRequestRecord `json:"quota_raise_request"`
+	Organization      Organization            `json:"organization"`
+}
+
 type HTTPError struct {
 	Method     string
 	Path       string
@@ -114,6 +168,22 @@ func (c *Client) Login(ctx context.Context, email, password string) (LoginResult
 	return out, err
 }
 
+func (c *Client) Signup(ctx context.Context, req SignupRequest) (SignupResult, error) {
+	var out SignupResult
+	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/signup", "", req, &out)
+	return out, err
+}
+
+func (c *Client) VerifyEmail(ctx context.Context, token string) (VerifyEmailResult, error) {
+	var out VerifyEmailResult
+	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/verify-email", "", AuthTokenRequest{Token: token}, &out)
+	return out, err
+}
+
+func (c *Client) ResendVerification(ctx context.Context, email string) error {
+	return c.doJSON(ctx, http.MethodPost, "/v1/auth/resend-verification", "", EmailRequest{Email: email}, nil)
+}
+
 func (c *Client) Refresh(ctx context.Context, refreshToken string) (RefreshResult, error) {
 	var out RefreshResult
 	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/refresh", "", map[string]string{
@@ -146,6 +216,13 @@ func (c *Client) Devices(ctx context.Context, accessToken, orgID string) ([]Devi
 		return nil, err
 	}
 	return body.Devices, nil
+}
+
+func (c *Client) CreateQuotaRaiseRequest(ctx context.Context, accessToken, orgID string, req QuotaRaiseRequest) (QuotaRaiseRequestResult, error) {
+	var out QuotaRaiseRequestResult
+	path := "/v1/orgs/" + url.PathEscape(orgID) + "/quota-raise-requests"
+	err := c.doJSON(ctx, http.MethodPost, path, accessToken, req, &out)
+	return out, err
 }
 
 func (c *Client) Provision(ctx context.Context, accessToken, orgID, deviceID string) (Operation, error) {

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -17,7 +17,7 @@ func TestClientLoginAndMe(t *testing.T) {
 				t.Fatalf("Authorization = %q", got)
 			}
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-1","name":"Acme","role":"owner"}]}`))
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-1","name":"Acme","role":"owner","tier":"evaluation","evaluation_device_quota":5}]}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -38,6 +38,9 @@ func TestClientLoginAndMe(t *testing.T) {
 	}
 	if len(me.Organizations) != 1 || me.Organizations[0].ID != "org-1" {
 		t.Fatalf("organizations = %#v", me.Organizations)
+	}
+	if me.Organizations[0].Tier != "evaluation" || me.Organizations[0].EvaluationDeviceQuota != 5 {
+		t.Fatalf("organization metadata = %#v", me.Organizations[0])
 	}
 }
 
@@ -63,5 +66,66 @@ func TestClientRefresh(t *testing.T) {
 	}
 	if refresh.Tokens.AccessToken != "refreshed" || refresh.Tokens.RefreshToken != "refresh-2" {
 		t.Fatalf("tokens = %#v", refresh.Tokens)
+	}
+}
+
+func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/signup":
+			if r.Method != http.MethodPost {
+				t.Fatalf("signup method = %s", r.Method)
+			}
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"signup@example.com","name":"Signup"},"organization":{"id":"org-1","name":"Acme","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
+		case "/v1/auth/verify-email":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"signup@example.com","name":"Signup"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+		case "/v1/auth/resend-verification":
+			w.WriteHeader(http.StatusAccepted)
+		case "/v1/orgs/org-1/quota-raise-requests":
+			if got := r.Header.Get("Authorization"); got != "Bearer access" {
+				t.Fatalf("Authorization = %q", got)
+			}
+			_, _ = w.Write([]byte(`{"quota_raise_request":{"id":"req-1","organization_id":"org-1","requested_by":"u1","requested_quota":25,"use_case":"growth","contact_info":{"email":"owner@example.com"},"status":"pending","created_at":"2026-05-05T00:00:00Z","updated_at":"2026-05-05T00:00:00Z"},"organization":{"id":"org-1","name":"Acme","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL)
+	signup, err := client.Signup(t.Context(), SignupRequest{
+		Email:            "signup@example.com",
+		Password:         "password123",
+		OrganizationName: "Acme",
+	})
+	if err != nil {
+		t.Fatalf("Signup returned error: %v", err)
+	}
+	if signup.Organization.Tier != "evaluation" || signup.Organization.EvaluationDeviceQuota != 5 {
+		t.Fatalf("signup organization = %#v", signup.Organization)
+	}
+
+	verify, err := client.VerifyEmail(t.Context(), "token-1")
+	if err != nil {
+		t.Fatalf("VerifyEmail returned error: %v", err)
+	}
+	if verify.Tokens.AccessToken != "access" {
+		t.Fatalf("verify tokens = %#v", verify.Tokens)
+	}
+
+	if err := client.ResendVerification(t.Context(), "signup@example.com"); err != nil {
+		t.Fatalf("ResendVerification returned error: %v", err)
+	}
+
+	raise, err := client.CreateQuotaRaiseRequest(t.Context(), "access", "org-1", QuotaRaiseRequest{
+		RequestedQuota: 25,
+		UseCase:        "growth",
+		ContactInfo:    map[string]any{"email": "owner@example.com"},
+	})
+	if err != nil {
+		t.Fatalf("CreateQuotaRaiseRequest returned error: %v", err)
+	}
+	if raise.QuotaRaiseRequest.Status != "pending" {
+		t.Fatalf("quota raise status = %q", raise.QuotaRaiseRequest.Status)
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -80,9 +80,13 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/admin/summary", s.apiAdminSummary)
 	s.mux.HandleFunc("GET /api/me", s.apiMe)
 	s.mux.HandleFunc("POST /api/me/active-org", s.apiActiveOrg)
+	s.mux.HandleFunc("POST /api/auth/customer/signup", s.apiCustomerSignup)
 	s.mux.HandleFunc("POST /api/auth/customer/login", s.apiCustomerLogin)
+	s.mux.HandleFunc("POST /api/auth/customer/verify-email", s.apiCustomerVerifyEmail)
+	s.mux.HandleFunc("POST /api/auth/customer/resend-verification", s.apiCustomerResendVerification)
 	s.mux.HandleFunc("POST /api/auth/platform/login", s.apiPlatformLogin)
 	s.mux.HandleFunc("POST /api/auth/logout", s.apiLogout)
+	s.mux.HandleFunc("POST /api/orgs/{orgId}/quota-raise-requests", s.apiQuotaRaiseRequest)
 	s.mux.HandleFunc("GET /api/customers", s.apiCustomers)
 	s.mux.HandleFunc("GET /api/admin/customers", s.apiAdminCustomers)
 	s.mux.HandleFunc("GET /api/devices", s.apiDevices)
@@ -102,6 +106,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /assets/", s.assets)
 	s.mux.HandleFunc("GET /", s.home)
 	for _, path := range []string{
+		"/signup",
+		"/signup/check-email",
+		"/verify",
 		"/console",
 		"/console/overview",
 		"/console/devices",
@@ -230,8 +237,8 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 			DemoMode:      !s.accountClient.Enabled(),
 			Authenticated: false,
 			Memberships: []contracts.Membership{
-				{OrganizationID: "org-acme", Organization: "Acme Smart Camera", Role: "owner"},
-				{OrganizationID: "org-nova", Organization: "Nova Home Labs", Role: "operator"},
+				{OrganizationID: "org-acme", Organization: "Acme Smart Camera", Role: "owner", Tier: "evaluation", EvaluationDeviceQuota: 5},
+				{OrganizationID: "org-nova", Organization: "Nova Home Labs", Role: "operator", Tier: "commercial"},
 			},
 		})
 		return
@@ -260,7 +267,7 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		me.Email = upstream.User.Email
 		me.Name = fallback(upstream.User.Name, upstream.User.Email)
 		for _, org := range upstream.Organizations {
-			me.Memberships = append(me.Memberships, contracts.Membership{OrganizationID: org.ID, Organization: org.Name, Role: org.Role})
+			me.Memberships = append(me.Memberships, membershipFromOrganization(org))
 		}
 	}
 	writeJSON(w, me)
@@ -308,6 +315,99 @@ func (s *Server) apiActiveOrg(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, map[string]string{"active_org_id": body.OrganizationID})
+}
+
+func (s *Server) apiCustomerSignup(w http.ResponseWriter, r *http.Request) {
+	if !s.accountClient.Enabled() {
+		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body accountclient.SignupRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid signup request", http.StatusBadRequest)
+		return
+	}
+	result, err := s.accountClient.Signup(r.Context(), body)
+	if err != nil {
+		s.writeCustomerError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusAccepted, result)
+}
+
+func (s *Server) apiCustomerVerifyEmail(w http.ResponseWriter, r *http.Request) {
+	if !s.accountClient.Enabled() {
+		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body accountclient.AuthTokenRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Token) == "" {
+		http.Error(w, "token is required", http.StatusBadRequest)
+		return
+	}
+	result, err := s.accountClient.VerifyEmail(r.Context(), body.Token)
+	if err != nil {
+		s.writeCustomerError(w, err)
+		return
+	}
+	if result.Tokens.AccessToken != "" {
+		session, sessionErr := s.store.CreateSession("customer", result.User.ID, result.User.Email, result.Tokens.AccessToken, result.Tokens.RefreshToken, "", tokenTTL(result.Tokens))
+		if sessionErr != nil {
+			writeError(w, sessionErr)
+			return
+		}
+		setSessionCookie(w, session.ID)
+	}
+	writeJSONStatus(w, http.StatusOK, result)
+}
+
+func (s *Server) apiCustomerResendVerification(w http.ResponseWriter, r *http.Request) {
+	if !s.accountClient.Enabled() {
+		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body accountclient.EmailRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Email) == "" {
+		http.Error(w, "email is required", http.StatusBadRequest)
+		return
+	}
+	if err := s.accountClient.ResendVerification(r.Context(), body.Email); err != nil {
+		s.writeCustomerError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusAccepted, map[string]string{"status": "accepted"})
+}
+
+func (s *Server) apiQuotaRaiseRequest(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.customerSession(r)
+	if !ok {
+		http.Error(w, "customer authentication required", http.StatusUnauthorized)
+		return
+	}
+	if !s.accountClient.Enabled() {
+		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	orgID, err := s.customerOrgIDForSession(r.Context(), session)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	if orgID != r.PathValue("orgId") {
+		http.Error(w, "quota raise requests must target the active organization", http.StatusForbidden)
+		return
+	}
+	var body accountclient.QuotaRaiseRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid quota raise request", http.StatusBadRequest)
+		return
+	}
+	result, err := s.accountClient.CreateQuotaRaiseRequest(r.Context(), session.AccessToken, orgID, body)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusCreated, result)
 }
 
 func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
@@ -1692,6 +1792,14 @@ func writeJSON(w http.ResponseWriter, v any) {
 	}
 }
 
+func writeJSONStatus(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
 func writeError(w http.ResponseWriter, err error) {
 	http.Error(w, err.Error(), http.StatusInternalServerError)
 }
@@ -2145,6 +2253,16 @@ func metadataString(metadata map[string]any, key, fallbackValue string) string {
 		return text
 	}
 	return fallbackValue
+}
+
+func membershipFromOrganization(org accountclient.Organization) contracts.Membership {
+	return contracts.Membership{
+		OrganizationID:        org.ID,
+		Organization:          org.Name,
+		Role:                  org.Role,
+		Tier:                  org.Tier,
+		EvaluationDeviceQuota: org.EvaluationDeviceQuota,
+	}
 }
 
 func fallback(value, fallbackValue string) string {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -66,6 +66,114 @@ func TestServerHealthAndHomeRedirect(t *testing.T) {
 	}
 }
 
+func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
+	t.Parallel()
+
+	var quotaRaiseBody string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/signup":
+			_, _ = w.Write([]byte(`{"user":{"id":"u-signup","email":"signup@example.com","name":"Signup User"},"organization":{"id":"org-1","name":"Acme Eval","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
+		case "/v1/auth/verify-email":
+			_, _ = w.Write([]byte(`{"user":{"id":"u-signup","email":"signup@example.com","name":"Signup User"},"tokens":{"access_token":"access-1","refresh_token":"refresh-1","expires_in":3600}}`))
+		case "/v1/auth/resend-verification":
+			w.WriteHeader(http.StatusAccepted)
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u-signup","email":"signup@example.com","name":"Signup User"},"organizations":[{"id":"org-1","name":"Acme Eval","role":"owner","tier":"evaluation","evaluation_device_quota":5}]}`))
+		case "/v1/orgs":
+			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-1","name":"Acme Eval","role":"owner","tier":"evaluation","evaluation_device_quota":5}]}`))
+		case "/v1/orgs/org-1/quota-raise-requests":
+			if got := r.Header.Get("Authorization"); got != "Bearer access-1" {
+				t.Fatalf("Authorization = %q, want Bearer access-1", got)
+			}
+			body, _ := io.ReadAll(r.Body)
+			quotaRaiseBody = string(body)
+			_, _ = w.Write([]byte(`{"quota_raise_request":{"id":"req-1","organization_id":"org-1","requested_by":"u-signup","requested_quota":25,"use_case":"growth","contact_info":{"email":"owner@example.com"},"status":"pending","created_at":"2026-05-05T00:00:00Z","updated_at":"2026-05-05T00:00:00Z"},"organization":{"id":"org-1","name":"Acme Eval","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
+		default:
+			t.Fatalf("unexpected upstream request path: %s", r.URL.Path)
+		}
+	}))
+	defer upstream.Close()
+
+	srv := NewWithOptions(mustOpenStore(t), Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	for _, path := range []string{"/signup", "/signup/check-email", "/verify"} {
+		rec := httptest.NewRecorder()
+		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, body=%s", path, rec.Code, rec.Body.String())
+		}
+	}
+
+	signupRec := httptest.NewRecorder()
+	srv.ServeHTTP(signupRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/signup", strings.NewReader(`{"email":"signup@example.com","password":"password123","organization_name":"Acme Eval","display_name":"Signup User"}`)))
+	if signupRec.Code != http.StatusAccepted {
+		t.Fatalf("signup status = %d, body=%s", signupRec.Code, signupRec.Body.String())
+	}
+	if !strings.Contains(signupRec.Body.String(), `"tier":"evaluation"`) {
+		t.Fatalf("signup body = %s", signupRec.Body.String())
+	}
+
+	resendRec := httptest.NewRecorder()
+	srv.ServeHTTP(resendRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/resend-verification", strings.NewReader(`{"email":"signup@example.com"}`)))
+	if resendRec.Code != http.StatusAccepted {
+		t.Fatalf("resend status = %d, body=%s", resendRec.Code, resendRec.Body.String())
+	}
+
+	verifyRec := httptest.NewRecorder()
+	srv.ServeHTTP(verifyRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"token-1"}`)))
+	if verifyRec.Code != http.StatusOK {
+		t.Fatalf("verify status = %d, body=%s", verifyRec.Code, verifyRec.Body.String())
+	}
+	if len(verifyRec.Result().Cookies()) != 1 {
+		t.Fatalf("verify did not set a session cookie")
+	}
+	sessionCookie := verifyRec.Result().Cookies()[0]
+
+	meRec := httptest.NewRecorder()
+	meReq := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	meReq.AddCookie(sessionCookie)
+	srv.ServeHTTP(meRec, meReq)
+	if meRec.Code != http.StatusOK {
+		t.Fatalf("me status = %d, body=%s", meRec.Code, meRec.Body.String())
+	}
+	if !strings.Contains(meRec.Body.String(), `"evaluation_device_quota":5`) {
+		t.Fatalf("me body = %s", meRec.Body.String())
+	}
+
+	quotaRec := httptest.NewRecorder()
+	quotaReq := httptest.NewRequest(http.MethodPost, "/api/orgs/org-1/quota-raise-requests", strings.NewReader(`{"requested_quota":25,"use_case":"growth","contact_info":{"email":"owner@example.com"}}`))
+	quotaReq.AddCookie(sessionCookie)
+	srv.ServeHTTP(quotaRec, quotaReq)
+	if quotaRec.Code != http.StatusCreated {
+		t.Fatalf("quota raise status = %d, body=%s", quotaRec.Code, quotaRec.Body.String())
+	}
+	if !strings.Contains(quotaRaiseBody, `"requested_quota":25`) {
+		t.Fatalf("quota raise body = %s", quotaRaiseBody)
+	}
+}
+
+func mustOpenStore(t *testing.T) *store.Store {
+	t.Helper()
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = st.Close()
+	})
+	return st
+}
+
 func TestProvisionActionPublishesOperation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -94,9 +94,11 @@ type ServiceHealth struct {
 }
 
 type Membership struct {
-	OrganizationID string `json:"organization_id"`
-	Organization   string `json:"organization"`
-	Role           string `json:"role"`
+	OrganizationID        string `json:"organization_id"`
+	Organization          string `json:"organization"`
+	Role                  string `json:"role"`
+	Tier                  string `json:"tier,omitempty"`
+	EvaluationDeviceQuota int    `json:"evaluation_device_quota,omitempty"`
 }
 
 type Me struct {

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "test": "node --test src/routes.test.mjs",
+    "test": "node --test src/*.test.mjs",
     "build": "vite build",
     "preview": "vite preview --host 127.0.0.1"
   },

--- a/web/src/http.mjs
+++ b/web/src/http.mjs
@@ -1,0 +1,15 @@
+export async function postJSON(url, body) {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const details = await response.text().catch(() => '');
+    const error = new Error(details || `${url} failed with ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+}

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -1,0 +1,39 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { postJSON } from './http.mjs';
+
+test('postJSON throws on failed verification responses', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 400,
+    text: async () => 'invalid verification token',
+  });
+
+  await assert.rejects(
+    () => postJSON('/api/auth/customer/verify-email', { token: 'bad-token' }),
+    /invalid verification token/,
+  );
+
+  globalThis.fetch = originalFetch;
+});
+
+test('postJSON throws on failed quota raise responses', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: false,
+    status: 403,
+    text: async () => 'quota raise forbidden',
+  });
+
+  await assert.rejects(
+    () => postJSON('/api/orgs/org-1/quota-raise-requests', {
+      requested_quota: 25,
+      use_case: 'growth',
+      contact_info: { email: 'owner@example.com' },
+    }),
+    /quota raise forbidden/,
+  );
+
+  globalThis.fetch = originalFetch;
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -17,11 +17,15 @@ function App() {
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
   const [error, setError] = useState('');
   const [refreshTick, setRefreshTick] = useState(0);
+  const isPublicRoute = active === 'signup' || active === 'signup-check-email' || active === 'verify';
   const isPlatformView = active.startsWith('platform');
   const visibleNavItems = isPlatformView ? platformNavItems : customerNavItems;
   const needsPlatformAccess = isPlatformView && me?.kind !== 'platform_admin';
 
   useEffect(() => {
+    if (isPublicRoute) {
+      return;
+    }
     let alive = true;
     async function loadData() {
       setError('');
@@ -78,7 +82,19 @@ function App() {
     return () => {
       alive = false;
     };
-  }, [active, refreshTick]);
+  }, [active, isPublicRoute, refreshTick]);
+
+  useEffect(() => {
+    if (!isPublicRoute) return;
+    setError('');
+    setMe(null);
+    setSummary(null);
+    setCustomers([]);
+    setDevices([]);
+    setOperations([]);
+    setHealth([]);
+    setAudit([]);
+  }, [isPublicRoute]);
 
   useEffect(() => {
     const onPopState = () => setActive(routeFromLocation());
@@ -136,6 +152,72 @@ function App() {
     setRefreshTick((tick) => tick + 1);
   }
 
+  async function handleSignup(payload) {
+    setError('');
+    const response = await fetch('/api/auth/customer/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      setError(`signup failed with ${response.status}`);
+      return null;
+    }
+    const result = await response.json();
+    window.history.pushState({}, '', `/signup/check-email?email=${encodeURIComponent(payload.email)}`);
+    setActive('signup-check-email');
+    setRefreshTick((tick) => tick + 1);
+    return result;
+  }
+
+  async function handleVerify(token) {
+    setError('');
+    const response = await fetch('/api/auth/customer/verify-email', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ token }),
+    });
+    if (!response.ok) {
+      setError(`verification failed with ${response.status}`);
+      return null;
+    }
+    const result = await response.json();
+    if (result.tokens?.access_token) {
+      window.history.pushState({}, '', '/console/overview');
+      setActive('overview');
+      setRefreshTick((tick) => tick + 1);
+    }
+    return result;
+  }
+
+  async function handleResendVerification(email) {
+    setError('');
+    const response = await fetch('/api/auth/customer/resend-verification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    });
+    if (!response.ok) {
+      setError(`verification resend failed with ${response.status}`);
+      return null;
+    }
+    return response.json();
+  }
+
+  async function handleQuotaRaiseRequest(orgId, payload) {
+    setError('');
+    const response = await fetch(`/api/orgs/${encodeURIComponent(orgId)}/quota-raise-requests`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      setError(`quota raise request failed with ${response.status}`);
+      return null;
+    }
+    return response.json();
+  }
+
   async function handleSwitchOrg(orgId) {
     setError('');
     const response = await fetch('/api/me/active-org', {
@@ -164,6 +246,18 @@ function App() {
     if (!devices.length) return null;
     return devices.find((device) => device.id === selectedDeviceId) || devices[0];
   }, [devices, selectedDeviceId]);
+
+  if (isPublicRoute) {
+    return (
+      <PublicAuthPage
+        active={active}
+        error={error}
+        onSignup={handleSignup}
+        onVerify={handleVerify}
+        onResendVerification={handleResendVerification}
+      />
+    );
+  }
 
   return (
     <div className="app-shell">
@@ -229,7 +323,7 @@ function App() {
         {error ? <div className="error">{error}</div> : null}
 
         {needsPlatformAccess ? <PlatformAccessGate active={active} onLogin={handleLogin} /> : null}
-        {!needsPlatformAccess && active === 'overview' ? <Overview summary={summary} me={me} onLogin={handleLogin} /> : null}
+        {!needsPlatformAccess && active === 'overview' ? <Overview summary={summary} me={me} onLogin={handleLogin} onRequestQuotaRaise={handleQuotaRaiseRequest} /> : null}
         {!needsPlatformAccess && active === 'devices' ? (
           <Devices
             devices={devices}
@@ -250,10 +344,34 @@ function App() {
   );
 }
 
-function Overview({ summary, me, onLogin }) {
+function Overview({ summary, me, onLogin, onRequestQuotaRaise }) {
+  const activeMembership = getActiveMembership(me);
+  const tierLabel = formatTierLabel(activeMembership?.tier);
+  const quotaLimit = activeMembership?.evaluation_device_quota ?? 5;
+  const activeDevices = summary?.total_devices ?? 0;
+  const quotaRatio = `${activeDevices} / ${quotaLimit} devices`;
+  const isEvaluation = (activeMembership?.tier || '').toLowerCase() === 'evaluation';
+  const nearQuota = isEvaluation && activeDevices >= Math.max(quotaLimit - 1, 1);
+
   return (
     <>
       <MetricGrid summary={summary} />
+      <section className="panel split-panel">
+        <div>
+          <h2>Tier and quota</h2>
+          <p>{me?.authenticated ? `${tierLabel} account for ${activeMembership?.organization || 'your active organization'}.` : 'Sign in to see the current tier and quota for your organization.'}</p>
+          {me?.authenticated ? <div className="quota-pill">{tierLabel} {isEvaluation ? quotaRatio : 'Contact sales'}</div> : null}
+          {nearQuota ? <p className="auth-status">This fleet is near its evaluation cap. Request a higher limit before the next device is added.</p> : null}
+        </div>
+        {me?.authenticated && isEvaluation ? (
+          <QuotaRaiseForm
+            organizationId={activeMembership?.organization_id}
+            organizationName={activeMembership?.organization}
+            currentQuota={quotaLimit}
+            onSubmit={onRequestQuotaRaise}
+          />
+        ) : null}
+      </section>
       {!me?.authenticated ? <LoginPanel mode="customer" title="Customer Account Manager login" onLogin={onLogin} /> : null}
       <section className="panel split-panel">
         <div>
@@ -263,6 +381,228 @@ function Overview({ summary, me, onLogin }) {
         </div>
       </section>
     </>
+  );
+}
+
+function PublicAuthPage({ active, error, onSignup, onVerify, onResendVerification }) {
+  const params = new URLSearchParams(window.location.search);
+  const email = params.get('email') || '';
+  const token = params.get('token') || '';
+
+  return (
+    <div className="public-auth-shell">
+      <section className="auth-hero">
+        <p className="eyebrow">Evaluation tier access</p>
+        <h1>{titleFor(active)}</h1>
+        <p>Self-service signup and verification for the public evaluation tier.</p>
+      </section>
+      <section className="panel auth-panel">
+        {active === 'signup' ? (
+          <SignupForm onSignup={onSignup} />
+        ) : active === 'signup-check-email' ? (
+          <CheckEmailInterstitial email={email} onResendVerification={onResendVerification} />
+        ) : (
+          <VerifyForm token={token} onVerify={onVerify} />
+        )}
+        {error ? <div className="error">{error}</div> : null}
+      </section>
+    </div>
+  );
+}
+
+function SignupForm({ onSignup }) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [organizationName, setOrganizationName] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [captchaToken, setCaptchaToken] = useState('');
+  const [acceptTerms, setAcceptTerms] = useState(false);
+  const [honeypot, setHoneypot] = useState('');
+  const [busy, setBusy] = useState(false);
+  const strength = passwordStrength(password);
+
+  async function submit(event) {
+    event.preventDefault();
+    if (!acceptTerms || honeypot) return;
+    setBusy(true);
+    try {
+      await onSignup({
+        email,
+        password,
+        display_name: displayName,
+        organization_name: organizationName,
+        captcha_token: captchaToken,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="auth-form" onSubmit={submit}>
+      <label>
+        Email
+        <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="name@company.com" required />
+      </label>
+      <label>
+        Password
+        <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
+      </label>
+      <label>
+        Organization name
+        <input value={organizationName} onChange={(event) => setOrganizationName(event.target.value)} placeholder="Acme Camera Fleet" required />
+      </label>
+      <label>
+        Display name
+        <input value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Optional contact name" />
+      </label>
+      <label className="auth-honeypot">
+        Leave this field empty
+        <input value={honeypot} onChange={(event) => setHoneypot(event.target.value)} tabIndex={-1} autoComplete="off" />
+      </label>
+      <label>
+        CAPTCHA token
+        <input value={captchaToken} onChange={(event) => setCaptchaToken(event.target.value)} placeholder="Optional if enabled" />
+      </label>
+      <div className="auth-strength">
+        <span>Password strength</span>
+        <strong>{strength}</strong>
+      </div>
+      <label className="auth-terms">
+        <input type="checkbox" checked={acceptTerms} onChange={(event) => setAcceptTerms(event.target.checked)} />
+        I accept the evaluation-tier terms.
+      </label>
+      <button type="submit" disabled={busy || !acceptTerms || !!honeypot}>Create account</button>
+    </form>
+  );
+}
+
+function CheckEmailInterstitial({ email, onResendVerification }) {
+  const [resendEmail, setResendEmail] = useState(email);
+  const [status, setStatus] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function resend(event) {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      await onResendVerification(resendEmail);
+      setStatus('Verification link requested again.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="auth-stack">
+      <p>We sent a verification link to {email || 'your email address'}.</p>
+      <form className="auth-inline" onSubmit={resend}>
+        <input type="email" value={resendEmail} onChange={(event) => setResendEmail(event.target.value)} placeholder="Email address" required />
+        <button type="submit" disabled={busy}>Resend</button>
+      </form>
+      {status ? <p className="auth-status">{status}</p> : null}
+    </div>
+  );
+}
+
+function VerifyForm({ token, onVerify }) {
+  const [value, setValue] = useState(token);
+  const [status, setStatus] = useState('Waiting for verification link.');
+  const [busy, setBusy] = useState(false);
+  const [attempted, setAttempted] = useState(false);
+
+  useEffect(() => {
+    if (!value || attempted) return;
+    setAttempted(true);
+    setBusy(true);
+    onVerify(value)
+      .then((result) => {
+        if (result?.tokens?.access_token) {
+          setStatus('Verification completed. Redirecting to the dashboard.');
+        } else {
+          setStatus('Email verified. Sign in to continue.');
+        }
+      })
+      .catch(() => setStatus('Verification failed. Check the token and try again.'))
+      .finally(() => setBusy(false));
+  }, [attempted, onVerify, value]);
+
+  async function submit(event) {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      const result = await onVerify(value);
+      if (result?.tokens?.access_token) {
+        setStatus('Verification completed. Redirecting to the dashboard.');
+      } else {
+        setStatus('Email verified. Sign in to continue.');
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="auth-stack">
+      <p>Paste the email verification token from your inbox link.</p>
+      <form className="auth-inline" onSubmit={submit}>
+        <input value={value} onChange={(event) => setValue(event.target.value)} placeholder="Verification token" required />
+        <button type="submit" disabled={busy}>Verify</button>
+      </form>
+      <p className="auth-status">{status}</p>
+    </div>
+  );
+}
+
+function QuotaRaiseForm({ organizationId, organizationName, currentQuota, onSubmit }) {
+  const [requestedQuota, setRequestedQuota] = useState(currentQuota);
+  const [useCase, setUseCase] = useState('');
+  const [contactEmail, setContactEmail] = useState('');
+  const [contactName, setContactName] = useState('');
+  const [lastStatus, setLastStatus] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  async function submit(event) {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      const result = await onSubmit(organizationId, {
+        requested_quota: Number(requestedQuota),
+        use_case: useCase,
+        contact_info: {
+          email: contactEmail,
+          name: contactName,
+          organization: organizationName,
+        },
+      });
+      setLastStatus(result?.quota_raise_request?.status ? `Latest request: ${result.quota_raise_request.status}` : 'Latest request submitted.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="quota-form" onSubmit={submit}>
+      <p className="auth-status">Current evaluation cap: {currentQuota} devices.</p>
+      <label>
+        Requested quota
+        <input type="number" min="1" max="200" value={requestedQuota} onChange={(event) => setRequestedQuota(event.target.value)} />
+      </label>
+      <label>
+        Use case
+        <input value={useCase} onChange={(event) => setUseCase(event.target.value)} placeholder="Why do you need more devices?" required />
+      </label>
+      <label>
+        Contact email
+        <input type="email" value={contactEmail} onChange={(event) => setContactEmail(event.target.value)} required />
+      </label>
+      <label>
+        Contact name
+        <input value={contactName} onChange={(event) => setContactName(event.target.value)} />
+      </label>
+      <button type="submit" disabled={busy}>Request quota raise</button>
+      {lastStatus ? <p className="auth-status">{lastStatus}</p> : null}
+    </form>
   );
 }
 
@@ -976,6 +1316,31 @@ function formatReadinessLabel(readiness) {
   };
   if (readiness === null || readiness === undefined) return 'Unknown';
   return map[readiness] || toTitleCase(String(readiness).replaceAll('_', ' '));
+}
+
+function getActiveMembership(me) {
+  if (!me?.authenticated) return null;
+  const memberships = me.memberships || [];
+  if (!memberships.length) return null;
+  return memberships.find((membership) => membership.organization_id === me.active_org_id) || memberships[0];
+}
+
+function formatTierLabel(tier) {
+  if (!tier) return 'Unknown';
+  if (tier === 'evaluation') return 'Evaluation';
+  if (tier === 'commercial') return 'Commercial';
+  return toTitleCase(String(tier).replaceAll('_', ' '));
+}
+
+function passwordStrength(password) {
+  if (!password) return 'Empty';
+  let score = 0;
+  if (password.length >= 8) score += 1;
+  if (password.length >= 12) score += 1;
+  if (/[A-Z]/.test(password)) score += 1;
+  if (/[0-9]/.test(password)) score += 1;
+  if (/[^A-Za-z0-9]/.test(password)) score += 1;
+  return ['Weak', 'Fair', 'Good', 'Strong', 'Excellent'][Math.min(score, 4)];
 }
 
 function normalizeStatusKey(value) {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { customerNavItems, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
+import { postJSON } from './http.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -154,68 +155,52 @@ function App() {
 
   async function handleSignup(payload) {
     setError('');
-    const response = await fetch('/api/auth/customer/signup', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (!response.ok) {
-      setError(`signup failed with ${response.status}`);
-      return null;
+    try {
+      const result = await postJSON('/api/auth/customer/signup', payload);
+      window.history.pushState({}, '', `/signup/check-email?email=${encodeURIComponent(payload.email)}`);
+      setActive('signup-check-email');
+      setRefreshTick((tick) => tick + 1);
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
     }
-    const result = await response.json();
-    window.history.pushState({}, '', `/signup/check-email?email=${encodeURIComponent(payload.email)}`);
-    setActive('signup-check-email');
-    setRefreshTick((tick) => tick + 1);
-    return result;
   }
 
   async function handleVerify(token) {
     setError('');
-    const response = await fetch('/api/auth/customer/verify-email', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ token }),
-    });
-    if (!response.ok) {
-      setError(`verification failed with ${response.status}`);
-      return null;
+    try {
+      const result = await postJSON('/api/auth/customer/verify-email', { token });
+      if (result.tokens?.access_token) {
+        window.history.pushState({}, '', '/console/overview');
+        setActive('overview');
+        setRefreshTick((tick) => tick + 1);
+      }
+      return result;
+    } catch (err) {
+      setError(err.message);
+      throw err;
     }
-    const result = await response.json();
-    if (result.tokens?.access_token) {
-      window.history.pushState({}, '', '/console/overview');
-      setActive('overview');
-      setRefreshTick((tick) => tick + 1);
-    }
-    return result;
   }
 
   async function handleResendVerification(email) {
     setError('');
-    const response = await fetch('/api/auth/customer/resend-verification', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email }),
-    });
-    if (!response.ok) {
-      setError(`verification resend failed with ${response.status}`);
-      return null;
+    try {
+      return await postJSON('/api/auth/customer/resend-verification', { email });
+    } catch (err) {
+      setError(err.message);
+      throw err;
     }
-    return response.json();
   }
 
   async function handleQuotaRaiseRequest(orgId, payload) {
     setError('');
-    const response = await fetch(`/api/orgs/${encodeURIComponent(orgId)}/quota-raise-requests`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-    if (!response.ok) {
-      setError(`quota raise request failed with ${response.status}`);
-      return null;
+    try {
+      return await postJSON(`/api/orgs/${encodeURIComponent(orgId)}/quota-raise-requests`, payload);
+    } catch (err) {
+      setError(err.message);
+      throw err;
     }
-    return response.json();
   }
 
   async function handleSwitchOrg(orgId) {
@@ -433,6 +418,8 @@ function SignupForm({ onSignup }) {
         organization_name: organizationName,
         captcha_token: captchaToken,
       });
+    } catch (_) {
+      return;
     } finally {
       setBusy(false);
     }
@@ -480,14 +467,22 @@ function SignupForm({ onSignup }) {
 function CheckEmailInterstitial({ email, onResendVerification }) {
   const [resendEmail, setResendEmail] = useState(email);
   const [status, setStatus] = useState('');
+  const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
 
   async function resend(event) {
     event.preventDefault();
     setBusy(true);
+    setLocalError('');
     try {
-      await onResendVerification(resendEmail);
+      const result = await onResendVerification(resendEmail);
+      if (!result) {
+        setLocalError('Failed to request a new verification link.');
+        return;
+      }
       setStatus('Verification link requested again.');
+    } catch (_) {
+      setLocalError('Failed to request a new verification link.');
     } finally {
       setBusy(false);
     }
@@ -501,6 +496,7 @@ function CheckEmailInterstitial({ email, onResendVerification }) {
         <button type="submit" disabled={busy}>Resend</button>
       </form>
       {status ? <p className="auth-status">{status}</p> : null}
+      {error ? <p className="error">{error}</p> : null}
     </div>
   );
 }
@@ -508,6 +504,7 @@ function CheckEmailInterstitial({ email, onResendVerification }) {
 function VerifyForm({ token, onVerify }) {
   const [value, setValue] = useState(token);
   const [status, setStatus] = useState('Waiting for verification link.');
+  const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
   const [attempted, setAttempted] = useState(false);
 
@@ -515,28 +512,36 @@ function VerifyForm({ token, onVerify }) {
     if (!value || attempted) return;
     setAttempted(true);
     setBusy(true);
+    setLocalError('');
     onVerify(value)
       .then((result) => {
-        if (result?.tokens?.access_token) {
+        if (!result) {
+          setLocalError('Verification failed. Check the token and try again.');
+        } else if (result.tokens?.access_token) {
           setStatus('Verification completed. Redirecting to the dashboard.');
         } else {
           setStatus('Email verified. Sign in to continue.');
         }
       })
-      .catch(() => setStatus('Verification failed. Check the token and try again.'))
+      .catch(() => setLocalError('Verification failed. Check the token and try again.'))
       .finally(() => setBusy(false));
   }, [attempted, onVerify, value]);
 
   async function submit(event) {
     event.preventDefault();
     setBusy(true);
+    setLocalError('');
     try {
       const result = await onVerify(value);
-      if (result?.tokens?.access_token) {
+      if (!result) {
+        setLocalError('Verification failed. Check the token and try again.');
+      } else if (result.tokens?.access_token) {
         setStatus('Verification completed. Redirecting to the dashboard.');
       } else {
         setStatus('Email verified. Sign in to continue.');
       }
+    } catch (_) {
+      setLocalError('Verification failed. Check the token and try again.');
     } finally {
       setBusy(false);
     }
@@ -550,6 +555,7 @@ function VerifyForm({ token, onVerify }) {
         <button type="submit" disabled={busy}>Verify</button>
       </form>
       <p className="auth-status">{status}</p>
+      {error ? <p className="error">{error}</p> : null}
     </div>
   );
 }
@@ -560,11 +566,13 @@ function QuotaRaiseForm({ organizationId, organizationName, currentQuota, onSubm
   const [contactEmail, setContactEmail] = useState('');
   const [contactName, setContactName] = useState('');
   const [lastStatus, setLastStatus] = useState('');
+  const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
 
   async function submit(event) {
     event.preventDefault();
     setBusy(true);
+    setLocalError('');
     try {
       const result = await onSubmit(organizationId, {
         requested_quota: Number(requestedQuota),
@@ -575,7 +583,13 @@ function QuotaRaiseForm({ organizationId, organizationName, currentQuota, onSubm
           organization: organizationName,
         },
       });
+      if (!result) {
+        setLocalError('Quota-raise request failed.');
+        return;
+      }
       setLastStatus(result?.quota_raise_request?.status ? `Latest request: ${result.quota_raise_request.status}` : 'Latest request submitted.');
+    } catch (_) {
+      setLocalError('Quota-raise request failed.');
     } finally {
       setBusy(false);
     }
@@ -602,6 +616,7 @@ function QuotaRaiseForm({ organizationId, organizationName, currentQuota, onSubm
       </label>
       <button type="submit" disabled={busy}>Request quota raise</button>
       {lastStatus ? <p className="auth-status">{lastStatus}</p> : null}
+      {error ? <p className="error">{error}</p> : null}
     </form>
   );
 }

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -15,6 +15,9 @@ export const platformNavItems = [
 
 export function titleFor(active) {
   return {
+    signup: 'Sign up',
+    'signup-check-email': 'Check your email',
+    verify: 'Verify email',
     overview: 'Customer Overview',
     devices: 'Devices',
     operations: 'Operations',
@@ -28,6 +31,9 @@ export function titleFor(active) {
 }
 
 export function routeFromPath(path) {
+  if (path === '/signup' || path === '/signup/') return 'signup';
+  if (path === '/signup/check-email' || path.startsWith('/signup/check-email/')) return 'signup-check-email';
+  if (path === '/verify' || path.startsWith('/verify/')) return 'verify';
   if (path === '/admin' || path === '/admin/') return 'platform-health';
   if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
   if (path === '/admin/operations' || path.startsWith('/admin/operations/')) return 'platform-operations';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -9,6 +9,12 @@ test('maps platform shell paths to platform routes', () => {
   assert.equal(routeFromPath('/admin/audit'), 'platform-audit');
 });
 
+test('maps public signup paths to auth routes', () => {
+  assert.equal(routeFromPath('/signup'), 'signup');
+  assert.equal(routeFromPath('/signup/check-email'), 'signup-check-email');
+  assert.equal(routeFromPath('/verify'), 'verify');
+});
+
 test('maps customer shell paths to customer routes', () => {
   assert.equal(routeFromPath('/console'), 'overview');
   assert.equal(routeFromPath('/console/overview'), 'overview');

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -31,6 +31,13 @@ body {
     var(--bg);
 }
 
+body:has(.public-auth-shell) {
+  background:
+    radial-gradient(circle at top left, rgba(0, 104, 183, 0.12), transparent 36%),
+    radial-gradient(circle at right 12% bottom 12%, rgba(109, 206, 221, 0.16), transparent 28%),
+    linear-gradient(165deg, rgba(242, 250, 252, 0.98) 0%, rgba(255, 255, 255, 0.98) 44%, #fff 100%);
+}
+
 button,
 input {
   font: inherit;
@@ -255,6 +262,126 @@ p {
   margin-bottom: 18px;
   overflow-x: auto;
   padding: 20px;
+}
+
+.public-auth-shell {
+  display: grid;
+  gap: 24px;
+  min-height: 100vh;
+  align-content: center;
+  padding: clamp(24px, 5vw, 64px);
+}
+
+.auth-hero {
+  max-width: 720px;
+}
+
+.auth-hero h1 {
+  font-size: clamp(40px, 6vw, 68px);
+  line-height: 0.95;
+  margin-bottom: 14px;
+}
+
+.auth-hero p {
+  max-width: 56ch;
+  font-size: 18px;
+}
+
+.auth-panel {
+  max-width: 720px;
+  backdrop-filter: blur(14px);
+}
+
+.auth-form,
+.quota-form {
+  display: grid;
+  gap: 14px;
+}
+
+.auth-form label,
+.quota-form label {
+  display: grid;
+  gap: 6px;
+  color: var(--navy);
+  font-weight: 600;
+}
+
+.auth-form input,
+.quota-form input,
+.auth-inline input {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  min-height: 42px;
+  padding: 0 12px;
+}
+
+.auth-form button,
+.quota-form button,
+.auth-inline button {
+  background: linear-gradient(180deg, var(--brand) 0%, var(--brand-dark) 100%);
+  border: 0;
+  border-radius: 10px;
+  color: #fff;
+  cursor: pointer;
+  min-height: 44px;
+  padding: 0 16px;
+}
+
+.auth-form button:disabled,
+.quota-form button:disabled,
+.auth-inline button:disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+
+.auth-inline {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.auth-inline input {
+  flex: 1 1 280px;
+}
+
+.auth-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.auth-status {
+  color: var(--brand-dark);
+  font-size: 14px;
+}
+
+.auth-strength {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.auth-terms {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+}
+
+.auth-honeypot {
+  position: absolute;
+  left: -9999px;
+}
+
+.quota-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(0, 104, 183, 0.08);
+  border: 1px solid rgba(0, 104, 183, 0.16);
+  border-radius: 999px;
+  color: var(--brand-dark);
+  font-weight: 700;
+  padding: 8px 14px;
 }
 
 .device-workspace {


### PR DESCRIPTION
## Summary

- Add public `/signup`, `/signup/check-email`, and `/verify` routes to the React shell.
- Add BFF endpoints for signup, email verification, resend verification, and quota-raise submission against Account Manager.
- Surface customer tier and evaluation quota on the dashboard, with a quota-raise request form for evaluation orgs.
- Update route tests, client tests, app tests, and `docs/SPEC.md` to reflect the signup UI being implemented.

## Validation

- `go test ./...`
- `npm test`
- `npm run build`

Closes #38
