### PR TITLE
feat: device detail drawer

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -158,7 +158,7 @@ func (s *Server) shell(w http.ResponseWriter, r *http.Request) {
 <body>
   <div id="root">
     <h1>RTK Cloud Admin</h1>
-    <p>Customer Fleet</p>
+    <p>Fleet Health Overview</p>
     <p>Platform Operations</p>
     <p>cam-a-001</p>
     <p>DeviceProvisionRequested</p>

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1859,12 +1859,12 @@ func TestConsoleAndAdminPagesRenderSeedData(t *testing.T) {
 		path string
 		want string
 	}{
-		{path: "/console", want: "Customer Fleet"},
-		{path: "/console/overview", want: "Customer Fleet"},
+		{path: "/console", want: "Fleet Health Overview"},
+		{path: "/console/overview", want: "Fleet Health Overview"},
 		{path: "/console/devices", want: "cam-a-001"},
-		{path: "/console/firmware-ota", want: "Customer Fleet"},
-		{path: "/console/stream-health", want: "Customer Fleet"},
-		{path: "/console/groups", want: "Customer Fleet"},
+		{path: "/console/firmware-ota", want: "Fleet Health Overview"},
+		{path: "/console/stream-health", want: "Fleet Health Overview"},
+		{path: "/console/groups", want: "Fleet Health Overview"},
 		{path: "/admin", want: "Platform Operations"},
 		{path: "/admin/ops", want: "DeviceProvisionRequested"},
 		{path: "/admin/audit", want: "Platform Operations"},

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -18,6 +18,7 @@ function App() {
   const [health, setHealth] = useState([]);
   const [audit, setAudit] = useState([]);
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
+  const [deviceDrawerOpen, setDeviceDrawerOpen] = useState(false);
   const [overviewWindow, setOverviewWindow] = useState('7d');
   const [error, setError] = useState('');
   const [refreshTick, setRefreshTick] = useState(0);
@@ -118,15 +119,20 @@ function App() {
   }, [active, overviewWindow, refreshTick]);
 
   useEffect(() => {
-    const onPopState = () => setActive(routeFromLocation());
+    const onPopState = () => {
+      setActive(routeFromLocation());
+      const deviceId = deviceIdFromLocation();
+      setSelectedDeviceId(deviceId);
+      setDeviceDrawerOpen(Boolean(deviceId));
+    };
     window.addEventListener('popstate', onPopState);
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const deviceId = params.get('device');
-    if (deviceId) setSelectedDeviceId(deviceId);
+    const deviceId = deviceIdFromLocation();
+    setSelectedDeviceId(deviceId);
+    setDeviceDrawerOpen(Boolean(deviceId));
   }, [active]);
 
   function navigate(item) {
@@ -141,15 +147,19 @@ function App() {
 
   function selectDevice(deviceId) {
     setSelectedDeviceId(deviceId);
-    const path = '/console/devices';
-    window.history.pushState({}, '', `${path}?device=${encodeURIComponent(deviceId)}`);
+    setDeviceDrawerOpen(true);
+    updateDevicesLocation({ deviceId });
     setActive('devices');
   }
 
   function filterDevicesByHealth(healthState) {
-    const path = '/console/devices';
-    window.history.pushState({}, '', `${path}?health=${encodeURIComponent(healthState)}`);
+    updateDevicesLocation({ health: healthState, deviceId: '' });
     setActive('devices');
+  }
+
+  function closeDeviceDrawer() {
+    setDeviceDrawerOpen(false);
+    updateDevicesLocation({ deviceId: '' });
   }
 
   async function runDeviceAction(deviceId, action) {
@@ -204,8 +214,8 @@ function App() {
   }
 
   const selectedDevice = useMemo(() => {
-    if (!devices.length) return null;
-    return devices.find((device) => device.id === selectedDeviceId) || devices[0];
+    if (!selectedDeviceId) return null;
+    return devices.find((device) => device.id === selectedDeviceId) || null;
   }, [devices, selectedDeviceId]);
 
   return (
@@ -291,7 +301,9 @@ function App() {
             active={active}
             devices={devices}
             selectedDevice={selectedDevice}
+            deviceDrawerOpen={deviceDrawerOpen}
             setSelectedDeviceId={selectDevice}
+            closeDeviceDrawer={closeDeviceDrawer}
             onAction={runDeviceAction}
           />
         ) : null}
@@ -631,11 +643,14 @@ function RecentAlertsPanel({ loading, alerts }) {
   );
 }
 
-function Devices({ active, devices, selectedDevice, setSelectedDeviceId, onAction }) {
+function Devices({ active, devices, selectedDevice, deviceDrawerOpen, setSelectedDeviceId, closeDeviceDrawer, onAction }) {
   const [readinessFilter, setReadinessFilter] = useState('All');
   const [healthFilter, setHealthFilter] = useState('All');
   const [signalFilter, setSignalFilter] = useState('All');
   const [firmwareFilter, setFirmwareFilter] = useState('All');
+  const [telemetryById, setTelemetryById] = useState({});
+  const [telemetryLoadingId, setTelemetryLoadingId] = useState('');
+  const [telemetryError, setTelemetryError] = useState('');
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -646,6 +661,53 @@ function Devices({ active, devices, selectedDevice, setSelectedDeviceId, onActio
       setHealthFilter('All');
     }
   }, [active]);
+
+  useEffect(() => {
+    if (!deviceDrawerOpen || !selectedDevice?.id) return;
+    if (telemetryById[selectedDevice.id]) {
+      setTelemetryError('');
+      setTelemetryLoadingId('');
+      return;
+    }
+    let alive = true;
+    setTelemetryError('');
+    setTelemetryLoadingId(selectedDevice.id);
+    fetchJSON(`/api/devices/${selectedDevice.id}/telemetry`)
+      .then((payload) => {
+        if (!alive) return;
+        setTelemetryById((current) => ({
+          ...current,
+          [selectedDevice.id]: payload,
+        }));
+      })
+      .catch((err) => {
+        if (!alive) return;
+        setTelemetryError(err.message);
+      })
+      .finally(() => {
+        if (!alive) return;
+        setTelemetryLoadingId('');
+      });
+    return () => {
+      alive = false;
+    };
+  }, [deviceDrawerOpen, selectedDevice?.id, telemetryById]);
+
+  useEffect(() => {
+    if (!deviceDrawerOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        closeDeviceDrawer();
+      }
+    };
+    window.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener('keydown', onKeyDown);
+    };
+  }, [deviceDrawerOpen, closeDeviceDrawer]);
 
   const processedDevices = useMemo(() => {
     const withDeviceSignals = devices.map((device) => ({
@@ -733,6 +795,9 @@ function Devices({ active, devices, selectedDevice, setSelectedDeviceId, onActio
     },
   ], [onAction]);
 
+  const selectedTelemetry = selectedDevice ? telemetryById[selectedDevice.id] || null : null;
+  const telemetryBusy = deviceDrawerOpen && selectedDevice?.id && telemetryLoadingId === selectedDevice.id && !selectedTelemetry;
+
   return (
     <section className="device-workspace">
       <div className="panel device-table-panel">
@@ -786,11 +851,20 @@ function Devices({ active, devices, selectedDevice, setSelectedDeviceId, onActio
           initialSortKey="name"
           searchPlaceholder="Search devices"
           emptyLabel="No devices match the current filter."
-          rowClassName={(device) => selectedDevice?.id === device.id ? 'selected-row' : ''}
+          rowClassName={(device) => deviceDrawerOpen && selectedDevice?.id === device.id ? 'selected-row' : ''}
           onRowClick={(device) => setSelectedDeviceId(device.id)}
         />
       </div>
-      <DeviceDetail device={selectedDevice} onAction={onAction} />
+      {deviceDrawerOpen ? (
+        <DeviceDrawer
+          device={selectedDevice}
+          telemetry={selectedTelemetry}
+          loading={telemetryBusy}
+          error={telemetryError}
+          onClose={closeDeviceDrawer}
+          onAction={onAction}
+        />
+      ) : null}
     </section>
   );
 }
@@ -842,62 +916,276 @@ function Customers({ customers }) {
   );
 }
 
-function DeviceDetail({ device, onAction }) {
-  if (!device) {
-    return (
-      <aside className="panel detail-panel">
-        <h2>Device detail</h2>
-        <p>No device selected.</p>
+function DeviceDrawer({ device, telemetry, loading, error, onClose, onAction }) {
+  return (
+    <div className="drawer-backdrop" role="presentation" onClick={onClose}>
+      <aside className="drawer-panel" role="dialog" aria-modal="true" aria-label="Device detail drawer" onClick={(event) => event.stopPropagation()}>
+        <div className="drawer-header">
+          <div>
+            <p className="eyebrow">Device detail</p>
+            <h2>{device?.name || 'Device selected'}</h2>
+            <p>{device ? `${device.organization} · ${device.model}` : 'Select a device row to inspect its telemetry.'}</p>
+          </div>
+          <button type="button" className="drawer-close" onClick={onClose} aria-label="Close device drawer">
+            Close
+          </button>
+        </div>
+
+        {!device ? (
+          <p className="empty-state">No device selected.</p>
+        ) : (
+          <>
+            <section className="drawer-identity">
+              <div>
+                <span>Device</span>
+                <strong>{device.name}</strong>
+              </div>
+              <div>
+                <span>Serial</span>
+                <strong>{device.serial_number || '—'}</strong>
+              </div>
+              <div>
+                <span>Model</span>
+                <strong>{device.model || '—'}</strong>
+              </div>
+              <div>
+                <span>Organization</span>
+                <strong>{device.organization || '—'}</strong>
+              </div>
+            </section>
+
+            {loading ? <p className="empty-state">Loading telemetry for this device.</p> : null}
+            {error ? <p className="drawer-error">{error}</p> : null}
+
+            <section className="drawer-summary">
+              <div className="summary-card">
+                <span>Health</span>
+                <StatusBadge value={normalizeStatusKey(telemetry?.health || device.health || 'unknown')} label={toTitleCase(telemetry?.health || device.health || 'unknown')} />
+                <small>{telemetry ? `Signals: ${telemetry.signals?.length ? telemetry.signals.map(formatTelemetrySignal).join(', ') : 'none reported'}` : 'Telemetry not loaded yet.'}</small>
+              </div>
+              <div className="summary-card">
+                <span>Firmware</span>
+                <strong>{telemetry?.firmware_version || device.firmware_version || '—'}</strong>
+                <small>{telemetry?.recent_events?.[0]?.occurred_at ? `Last updated ${formatRelativeTime(telemetry.recent_events[0].occurred_at)}` : device.last_seen_at ? `Last seen ${formatRelativeTime(device.last_seen_at)}` : 'No update timestamp available.'}</small>
+              </div>
+              <div className="summary-card">
+                <span>Active stream</span>
+                <StatusBadge value={deriveStreamStatus(telemetry).tone} label={deriveStreamStatus(telemetry).label} />
+                <small>{deriveStreamStatus(telemetry).detail}</small>
+              </div>
+            </section>
+
+            <section className="drawer-charts">
+              <TelemetryChart
+                title="RSSI history"
+                subtitle="Daily average dBm and quality bucket"
+                samples={telemetry?.rssi_7d || []}
+                valueKey="avg_dbm"
+                valueFormatter={(value) => `${value} dBm`}
+                tone="brand"
+                ariaLabel="RSSI history sparkline"
+                emptyLabel="No RSSI samples available."
+                sampleLabel={(sample) => `${sample.date}: ${sample.avg_dbm} dBm (${toTitleCase(sample.quality)})`}
+              />
+              <TelemetryChart
+                title="Uptime history"
+                subtitle="Daily online percentage"
+                samples={telemetry?.uptime_7d || []}
+                valueKey="online_pct"
+                valueFormatter={(value) => `${value.toFixed(1)}%`}
+                tone="accent"
+                ariaLabel="Uptime history sparkline"
+                emptyLabel="No uptime samples available."
+                sampleLabel={(sample) => `${sample.date}: ${sample.online_pct.toFixed(1)}% online`}
+              />
+            </section>
+
+            <section className="drawer-events">
+              <div className="panel-head">
+                <div>
+                  <h3>Recent events</h3>
+                  <p>Last 10 telemetry events from this device.</p>
+                </div>
+              </div>
+              {telemetry?.recent_events?.length ? (
+                <div className="event-list">
+                  {telemetry.recent_events.map((event) => (
+                    <article className="event-row" key={`${event.occurred_at}:${event.event_type}`}>
+                      <div>
+                        <strong>{formatTelemetryEventType(event.event_type)}</strong>
+                        <span>{event.summary}</span>
+                      </div>
+                      <time title={event.occurred_at}>{formatRelativeTime(event.occurred_at)}</time>
+                    </article>
+                  ))}
+                </div>
+              ) : (
+                <p className="empty-state">No recent telemetry events available.</p>
+              )}
+            </section>
+
+            <div className="drawer-actions">
+              <button onClick={() => onAction(device.id, 'provision')}>Provision device</button>
+              <button onClick={() => onAction(device.id, 'deactivate')}>Deactivate device</button>
+            </div>
+          </>
+        )}
       </aside>
-    );
-  }
+    </div>
+  );
+}
+
+function TelemetryChart({ title, subtitle, samples, valueKey, valueFormatter, tone, ariaLabel, emptyLabel, sampleLabel }) {
+  const chart = useMemo(() => buildTelemetryChart(samples, valueKey), [samples, valueKey]);
+  const latestSample = samples.length ? samples[samples.length - 1] : null;
+  const latestValue = latestSample ? latestSample[valueKey] : null;
 
   return (
-    <aside className="panel detail-panel">
-      <div className="detail-heading">
+    <article className={`telemetry-card tone-${tone}`}>
+      <div className="panel-head">
         <div>
-          <p className="eyebrow">Selected device</p>
-          <h2>{device.name}</h2>
+          <h3>{title}</h3>
+          <p>{subtitle}</p>
         </div>
-        <StatusBadge value={device.readiness} />
+        {latestValue !== null && latestValue !== undefined ? <strong>{valueFormatter(latestValue)}</strong> : null}
       </div>
-      <dl>
-        <div><dt>Customer</dt><dd>{device.organization}</dd></div>
-        <div><dt>Model</dt><dd>{device.model}</dd></div>
-        <div><dt>Serial</dt><dd>{device.serial_number}</dd></div>
-        <div><dt>Firmware</dt><dd>{device.firmware_version || '—'}</dd></div>
-        <div><dt>Health</dt><dd>{device.health || 'Unknown'}</dd></div>
-        <div><dt>Signal</dt><dd>{device.signal_quality || '—'}</dd></div>
-        <div><dt>Registry status</dt><dd>{device.status}</dd></div>
-        <div><dt>Last seen</dt><dd>{device.last_seen_at || 'No transport evidence'}</dd></div>
-      </dl>
-      <div className="readiness-steps">
-        {['registered', 'cloud_activation_pending', 'activated', 'online'].map((step) => (
-          <span key={step} className={device.readiness === step ? 'current' : ''}>{formatReadinessLabel(step)}</span>
-        ))}
-      </div>
-      <div className="source-facts">
-        <h3>Source facts</h3>
-        {(device.source_facts || []).length ? (device.source_facts || []).map((fact) => (
-          <article className="source-fact" key={`${fact.layer}-${fact.state}-${fact.operation_id || ''}`}>
-            <div>
-              <strong>{fact.layer}</strong>
-              <span>{fact.detail}</span>
-              {fact.updated_at ? <time>{fact.updated_at}</time> : null}
-              {fact.error_code ? <small>{fact.error_code}</small> : null}
-              {fact.operation_id ? <small>{fact.operation_id}</small> : null}
-              {fact.state === 'failed' ? <small>{fact.retryable ? 'retryable' : 'not retryable'}</small> : null}
-            </div>
-            <StatusBadge value={fact.state || 'missing'} />
-          </article>
-        )) : <p>No source facts available.</p>}
-      </div>
-      <div className="detail-actions">
-        <button onClick={() => onAction(device.id, 'provision')}>Provision device</button>
-        <button onClick={() => onAction(device.id, 'deactivate')}>Deactivate device</button>
-      </div>
-    </aside>
+      {chart.points.length ? (
+        <>
+          <svg viewBox="0 0 420 126" className="sparkline-chart" role="img" aria-label={ariaLabel}>
+            <defs>
+              <linearGradient id={`sparkFill-${tone}`} x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="rgba(0, 104, 183, 0.22)" />
+                <stop offset="100%" stopColor="rgba(0, 104, 183, 0.03)" />
+              </linearGradient>
+            </defs>
+            <polyline points={chart.areaPoints} className="sparkline-area" />
+            <polyline points={chart.linePoints} className={`sparkline-line tone-${tone}`} />
+            {chart.points.map((point, index) => (
+              <circle
+                key={`${point.label}-${index}`}
+                cx={point.x}
+                cy={point.y}
+                r="3.5"
+                className={`sparkline-dot tone-${tone}`}
+              >
+                <title>{sampleLabel(samples[index])}</title>
+              </circle>
+            ))}
+          </svg>
+          <div className="sparkline-foot">
+            <span>{chart.minLabel}</span>
+            <span>{chart.maxLabel}</span>
+          </div>
+        </>
+      ) : (
+        <p className="empty-state">{emptyLabel}</p>
+      )}
+    </article>
   );
+}
+
+function buildTelemetryChart(samples, valueKey) {
+  if (!samples.length) {
+    return { points: [], linePoints: '', areaPoints: '', minLabel: '-', maxLabel: '-' };
+  }
+  const values = samples
+    .map((sample) => Number(sample[valueKey]))
+    .filter((value) => Number.isFinite(value));
+  if (!values.length) {
+    return { points: [], linePoints: '', areaPoints: '', minLabel: '-', maxLabel: '-' };
+  }
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max === min ? 1 : max - min;
+  const width = 360;
+  const left = 24;
+  const top = 18;
+  const bottom = 92;
+  const points = samples.map((sample, index) => {
+    const value = Number(sample[valueKey]);
+    const x = left + (index * width) / Math.max(samples.length - 1, 1);
+    const normalized = Number.isFinite(value) ? (value - min) / range : 0.5;
+    const y = bottom - normalized * (bottom - top);
+    return {
+      x,
+      y,
+      label: sample.date || `${index}`,
+      value,
+    };
+  });
+  const linePoints = points.map((point) => `${point.x},${point.y}`).join(' ');
+  const areaPoints = `${points.map((point) => `${point.x},${point.y}`).join(' ')} ${points.at(-1)?.x ?? left},108 ${points[0]?.x ?? left},108`;
+  return {
+    points,
+    linePoints,
+    areaPoints,
+    minLabel: formatTelemetryChartValue(min, valueKey),
+    maxLabel: formatTelemetryChartValue(max, valueKey),
+  };
+}
+
+function formatTelemetryChartValue(value, valueKey) {
+  if (valueKey === 'avg_dbm') return `${value} dBm`;
+  if (valueKey === 'online_pct') return `${value.toFixed(1)}%`;
+  return String(value);
+}
+
+function formatTelemetrySignal(signal) {
+  const map = {
+    low_rssi: 'Low RSSI',
+    recent_reboot: 'Recent reboot',
+    low_memory: 'Low memory',
+    recent_crash: 'Recent crash',
+    offline_risk: 'Offline risk',
+  };
+  return map[signal] || toTitleCase(signal);
+}
+
+function deriveStreamStatus(telemetry) {
+  const events = telemetry?.recent_events || [];
+  const joined = events
+    .map((event) => `${event.event_type} ${event.summary}`.toLowerCase())
+    .join(' ');
+  if (/stream|session/.test(joined)) {
+    if (/(started|opened|active|playing|live)/.test(joined)) {
+      return {
+        tone: 'healthy',
+        label: 'Active',
+        detail: 'Recent telemetry suggests a live stream session is open.',
+      };
+    }
+    if (/(ended|closed|stopped|offline)/.test(joined)) {
+      return {
+        tone: 'inactive',
+        label: 'Inactive',
+        detail: 'Recent telemetry suggests no stream session is open.',
+      };
+    }
+    return {
+      tone: 'warning',
+      label: 'Unknown',
+      detail: 'Telemetry references stream activity but not an explicit open/closed state.',
+    };
+  }
+  return {
+    tone: 'unknown',
+    label: 'Unknown',
+    detail: 'No explicit stream-session event surfaced in recent telemetry.',
+  };
+}
+
+function formatTelemetryEventType(eventType) {
+  const map = {
+    'device.health.summary': 'Health summary',
+    'device.health.rssi_sample': 'RSSI sample',
+    'device.health.memory_sample': 'Memory sample',
+    'device.health.offline_risk': 'Offline risk',
+    'device.reboot.reported': 'Device reboot',
+    'device.crash.reported': 'Device crash',
+    'firmware.version.observed': 'Firmware observed',
+  };
+  if (map[eventType]) return map[eventType];
+  return toTitleCase(String(eventType || '').replaceAll(/[._]/g, ' '));
 }
 
 function Operations({ operations }) {
@@ -1428,6 +1716,32 @@ function formatTrendLabel(date) {
   const parsed = Date.parse(date);
   if (Number.isNaN(parsed)) return date;
   return new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric' }).format(new Date(parsed));
+}
+
+function deviceIdFromLocation() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('device') || '';
+}
+
+function updateDevicesLocation({ deviceId, health } = {}) {
+  const params = new URLSearchParams(window.location.search);
+  if (deviceId !== undefined) {
+    if (deviceId) {
+      params.set('device', deviceId);
+    } else {
+      params.delete('device');
+    }
+  }
+  if (health !== undefined) {
+    if (health) {
+      params.set('health', health);
+    } else {
+      params.delete('health');
+    }
+  }
+  const query = params.toString();
+  const path = query ? `/console/devices?${query}` : '/console/devices';
+  window.history.pushState({}, '', path);
 }
 
 function runRowAction(event, onAction, deviceId, action) {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1385,15 +1385,21 @@ function buildFleetTrendChart(trend) {
   const height = 184;
   const top = 28;
   const bottom = 228;
-  const maxAlerts = Math.max(...trend.map((point) => point.WarningCount + point.CriticalCount), 1);
+  const maxAlerts = Math.max(
+    ...trend.map((point) => trendPointValue(point, 'warning_count', 'WarningCount') + trendPointValue(point, 'critical_count', 'CriticalCount')),
+    1,
+  );
   const points = trend.map((point, index) => {
     const x = 52 + (index * width) / Math.max(trend.length - 1, 1);
-    const onlineY = bottom - ((point.OnlinePct || 0) / 100) * (bottom - top);
-    const alerts = point.WarningCount + point.CriticalCount;
+    const onlinePct = trendPointValue(point, 'online_pct', 'OnlinePct');
+    const warningCount = trendPointValue(point, 'warning_count', 'WarningCount');
+    const criticalCount = trendPointValue(point, 'critical_count', 'CriticalCount');
+    const onlineY = bottom - ((onlinePct || 0) / 100) * (bottom - top);
+    const alerts = warningCount + criticalCount;
     const alertY = bottom - ((alerts / maxAlerts) * (bottom - top));
     return {
-      date: point.Date,
-      label: formatTrendLabel(point.Date),
+      date: point.date || point.Date,
+      label: formatTrendLabel(point.date || point.Date),
       x,
       onlineY,
       alertY,
@@ -1408,6 +1414,14 @@ function buildFleetTrendChart(trend) {
     maxAlerts,
     labelStep: Math.max(1, Math.ceil(points.length / 6)),
   };
+}
+
+function trendPointValue(point, snakeKey, camelKey) {
+  const snake = point?.[snakeKey];
+  if (snake !== undefined && snake !== null) return snake;
+  const camel = point?.[camelKey];
+  if (camel !== undefined && camel !== null) return camel;
+  return 0;
 }
 
 function formatTrendLabel(date) {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -9,14 +9,19 @@ function App() {
   const [active, setActive] = useState(routeFromLocation());
   const [me, setMe] = useState(null);
   const [summary, setSummary] = useState(null);
+  const [fleetHealth, setFleetHealth] = useState(null);
+  const [streamStats, setStreamStats] = useState(null);
+  const [recentAlerts, setRecentAlerts] = useState([]);
   const [customers, setCustomers] = useState([]);
   const [devices, setDevices] = useState([]);
   const [operations, setOperations] = useState([]);
   const [health, setHealth] = useState([]);
   const [audit, setAudit] = useState([]);
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
+  const [overviewWindow, setOverviewWindow] = useState('7d');
   const [error, setError] = useState('');
   const [refreshTick, setRefreshTick] = useState(0);
+  const [loading, setLoading] = useState(true);
   const isPlatformView = active.startsWith('platform');
   const visibleNavItems = isPlatformView ? platformNavItems : customerNavItems;
   const needsPlatformAccess = isPlatformView && me?.kind !== 'platform_admin';
@@ -25,6 +30,7 @@ function App() {
     let alive = true;
     async function loadData() {
       setError('');
+      setLoading(true);
       try {
         const nextMe = await fetchJSON('/api/me');
         if (!alive) return;
@@ -33,23 +39,28 @@ function App() {
         const useAdminApi = isPlatformView && nextMe.kind === 'platform_admin';
         if (isPlatformView && nextMe.kind !== 'platform_admin') {
           setSummary(null);
+          setFleetHealth(null);
+          setStreamStats(null);
+          setRecentAlerts([]);
           setCustomers([]);
           setDevices([]);
           setOperations([]);
           setHealth([]);
           setAudit([]);
+          setLoading(false);
           return;
         }
 
         const prefix = useAdminApi ? '/api/admin' : '/api';
-        const [nextSummary, nextCustomers, nextDevices, nextOperations, nextHealth, nextAudit] = await Promise.all([
+        const baseRequests = [
           fetchJSON(`${prefix}/summary`),
           fetchJSON(`${prefix}/customers`),
           fetchJSON(`${prefix}/devices`),
           fetchJSON(`${prefix}/operations`),
           fetchJSON(`${prefix}/service-health`),
           fetchJSON(`${prefix}/audit`),
-        ]);
+        ];
+        const [nextSummary, nextCustomers, nextDevices, nextOperations, nextHealth, nextAudit] = await Promise.all(baseRequests);
         if (!alive) return;
         setSummary(nextSummary);
         setCustomers(nextCustomers);
@@ -57,6 +68,27 @@ function App() {
         setOperations(nextOperations);
         setHealth(nextHealth);
         setAudit(nextAudit);
+
+        if (nextMe.authenticated && nextMe.kind === 'customer' && !useAdminApi) {
+          const [nextFleetHealth, nextStreamStats] = await Promise.all([
+            fetchJSON(`/api/fleet/health-summary?window=${overviewWindow}`),
+            fetchJSON(`/api/fleet/stream-stats?window=${overviewWindow}`),
+          ]);
+          if (!alive) return;
+          setFleetHealth(nextFleetHealth);
+          setStreamStats(nextStreamStats);
+          if (active === 'overview') {
+            const nextAlerts = await fetchRecentAlerts(nextDevices);
+            if (!alive) return;
+            setRecentAlerts(nextAlerts);
+          } else {
+            setRecentAlerts([]);
+          }
+        } else {
+          setFleetHealth(null);
+          setStreamStats(null);
+          setRecentAlerts([]);
+        }
       } catch (err) {
         if (!alive) return;
         if (err.isAuthError) {
@@ -70,15 +102,20 @@ function App() {
           setOperations([]);
           setHealth([]);
           setAudit([]);
+          setFleetHealth(null);
+          setStreamStats(null);
+          setRecentAlerts([]);
         }
         if (alive) setError(err.message);
+      } finally {
+        if (alive) setLoading(false);
       }
     }
     loadData();
     return () => {
       alive = false;
     };
-  }, [active, refreshTick]);
+  }, [active, overviewWindow, refreshTick]);
 
   useEffect(() => {
     const onPopState = () => setActive(routeFromLocation());
@@ -106,6 +143,12 @@ function App() {
     setSelectedDeviceId(deviceId);
     const path = '/console/devices';
     window.history.pushState({}, '', `${path}?device=${encodeURIComponent(deviceId)}`);
+    setActive('devices');
+  }
+
+  function filterDevicesByHealth(healthState) {
+    const path = '/console/devices';
+    window.history.pushState({}, '', `${path}?health=${encodeURIComponent(healthState)}`);
     setActive('devices');
   }
 
@@ -229,9 +272,23 @@ function App() {
         {error ? <div className="error">{error}</div> : null}
 
         {needsPlatformAccess ? <PlatformAccessGate active={active} onLogin={handleLogin} /> : null}
-        {!needsPlatformAccess && active === 'overview' ? <Overview summary={summary} me={me} onLogin={handleLogin} /> : null}
+        {!needsPlatformAccess && active === 'overview' ? (
+          <Overview
+            summary={summary}
+            fleetHealth={fleetHealth}
+            streamStats={streamStats}
+            recentAlerts={recentAlerts}
+            overviewWindow={overviewWindow}
+            setOverviewWindow={setOverviewWindow}
+            me={me}
+            loading={loading}
+            onLogin={handleLogin}
+            onHealthFilter={filterDevicesByHealth}
+          />
+        ) : null}
         {!needsPlatformAccess && active === 'devices' ? (
           <Devices
+            active={active}
             devices={devices}
             selectedDevice={selectedDevice}
             setSelectedDeviceId={selectDevice}
@@ -250,19 +307,60 @@ function App() {
   );
 }
 
-function Overview({ summary, me, onLogin }) {
+function Overview({
+  summary,
+  fleetHealth,
+  streamStats,
+  recentAlerts,
+  overviewWindow,
+  setOverviewWindow,
+  me,
+  loading,
+  onLogin,
+  onHealthFilter,
+}) {
+  const current = fleetHealth?.current || {};
+  const onlineCount = summary?.online_devices ?? '-';
+  const onlineRate = fleetHealth?.online_rate_7d_pct ?? '-';
+  const needsAttention = current.warning !== undefined || current.critical !== undefined
+    ? (current.warning || 0) + (current.critical || 0)
+    : '-';
+  const activeStreams = streamStats?.active_sessions ?? '-';
+
   return (
-    <>
-      <MetricGrid summary={summary} />
-      {!me?.authenticated ? <LoginPanel mode="customer" title="Customer Account Manager login" onLogin={onLogin} /> : null}
-      <section className="panel split-panel">
-        <div>
-          <h2>Customer overview</h2>
-          <p>Monitor fleet key metrics and access fleet management pages.</p>
-          <p>Use the Devices page to perform read and lifecycle actions for your own organization.</p>
+    <div className="overview-layout">
+      <section className="panel hero-panel">
+        <div className="hero-copy">
+          <p className="eyebrow">Customer View</p>
+          <h2>Fleet Health Overview</h2>
+          <p>Single-glance fleet health, trend, and alert awareness for Tier 2 operators.</p>
         </div>
+        {!me?.authenticated ? <LoginPanel mode="customer" title="Customer Account Manager login" onLogin={onLogin} /> : null}
       </section>
-    </>
+
+      <section className="metrics overview-metrics">
+        <MetricCard label="Online" value={onlineCount} hint={summary ? `${summary.total_devices ?? 0} total devices` : 'Waiting for summary data'} tone="good" />
+        <MetricCard label="Online Rate (7d)" value={formatPercent(onlineRate)} hint={fleetHealth ? 'Daily online share across the current window' : 'Sign in to load fleet health'} tone="info" />
+        <MetricCard label="Needs Attention" value={needsAttention} hint={fleetHealth ? 'Devices in warning or critical health' : 'No health summary yet'} tone={needsAttention === 0 ? 'good' : 'warn'} />
+        <MetricCard label="Active Streams" value={activeStreams} hint={streamStats ? 'Open sessions right now' : 'Stream stats unavailable'} tone="info" />
+      </section>
+
+      <section className="overview-grid">
+        <FleetHealthTrendPanel
+          loading={loading}
+          trend={fleetHealth?.trend || []}
+          window={overviewWindow}
+          onWindowChange={setOverviewWindow}
+        />
+        <HealthDistributionPanel
+          loading={loading}
+          current={fleetHealth?.current}
+          onFilter={onHealthFilter}
+        />
+      </section>
+
+      <RecentAlertsPanel loading={loading} alerts={recentAlerts} />
+    </div>
   );
 }
 
@@ -366,17 +464,194 @@ function MetricGrid({ summary }) {
   );
 }
 
-function Devices({ devices, selectedDevice, setSelectedDeviceId, onAction }) {
+function MetricCard({ label, value, hint, tone = 'neutral' }) {
+  return (
+    <div className={`metric-card tone-${tone}`}>
+      <span>{label}</span>
+      <strong>{value}</strong>
+      <small>{hint}</small>
+    </div>
+  );
+}
+
+function FleetHealthTrendPanel({ loading, trend, window, onWindowChange }) {
+  const chart = useMemo(() => buildFleetTrendChart(trend), [trend]);
+  return (
+    <section className="panel overview-panel trend-panel">
+      <div className="panel-head">
+        <div>
+          <h2>Fleet health trend</h2>
+          <p>Daily online share and warning/critical volume across the current window.</p>
+        </div>
+        <div className="window-toggle" role="tablist" aria-label="Fleet health window">
+          {['7d', '30d'].map((value) => (
+            <button
+              key={value}
+              type="button"
+              className={window === value ? 'active' : ''}
+              onClick={() => onWindowChange(value)}
+            >
+              {value.toUpperCase()}
+            </button>
+          ))}
+        </div>
+      </div>
+      {loading && !trend.length ? (
+        <p className="empty-state">Loading fleet trend data.</p>
+      ) : chart.points.length ? (
+        <>
+          <div className="chart-legend">
+            <span><i className="legend-line legend-online" /> Online %</span>
+            <span><i className="legend-line legend-alerts" /> Warning + critical</span>
+          </div>
+          <svg viewBox="0 0 720 280" className="trend-chart" role="img" aria-label="Fleet health trend chart">
+            <defs>
+              <linearGradient id="trendFill" x1="0" x2="0" y1="0" y2="1">
+                <stop offset="0%" stopColor="rgba(0, 104, 183, 0.22)" />
+                <stop offset="100%" stopColor="rgba(0, 104, 183, 0.03)" />
+              </linearGradient>
+            </defs>
+            {chart.grid.map((line, index) => (
+              <line key={`grid-${index}`} x1="52" x2="676" y1={line} y2={line} className="chart-grid-line" />
+            ))}
+            <line x1="52" x2="676" y1="228" y2="228" className="chart-axis-line" />
+            <polyline points={chart.onlinePoints} className="chart-line chart-line-online" />
+            <polyline points={chart.alertPoints} className="chart-line chart-line-alerts" />
+            {chart.points.map((point, index) => (
+              <g key={point.date}>
+                <circle cx={point.x} cy={point.onlineY} r="4" className="chart-dot chart-dot-online" />
+                <circle cx={point.x} cy={point.alertY} r="4" className="chart-dot chart-dot-alerts" />
+                {index % chart.labelStep === 0 ? (
+                  <text x={point.x} y="256" textAnchor="middle" className="chart-label">
+                    {point.label}
+                  </text>
+                ) : null}
+              </g>
+            ))}
+            <text x="14" y="34" className="chart-axis-label">{chart.maxPct}%</text>
+            <text x="14" y="228" className="chart-axis-label">0%</text>
+            <text x="700" y="34" textAnchor="end" className="chart-axis-label">{chart.maxAlerts}</text>
+            <text x="700" y="228" textAnchor="end" className="chart-axis-label">0</text>
+          </svg>
+          <p className="chart-footnote">
+            Alert counts are plotted on the same grid as a normalized line for the selected window.
+          </p>
+        </>
+      ) : (
+        <p className="empty-state">No fleet health trend data available.</p>
+      )}
+    </section>
+  );
+}
+
+function HealthDistributionPanel({ loading, current, onFilter }) {
+  const items = [
+    { key: 'healthy', label: 'Healthy', count: current?.healthy ?? 0, tone: 'good' },
+    { key: 'warning', label: 'Warning', count: current?.warning ?? 0, tone: 'warn' },
+    { key: 'critical', label: 'Critical', count: current?.critical ?? 0, tone: 'danger' },
+    { key: 'unknown', label: 'Unknown', count: current?.unknown ?? 0, tone: 'neutral' },
+  ];
+  const total = items.reduce((sum, item) => sum + item.count, 0);
+
+  return (
+    <section className="panel overview-panel distribution-panel">
+      <div className="panel-head">
+        <div>
+          <h2>Health distribution</h2>
+          <p>Breakdown of the current fleet by telemetry health state.</p>
+        </div>
+      </div>
+      {loading && !current ? (
+        <p className="empty-state">Loading fleet health distribution.</p>
+      ) : total > 0 ? (
+        <div className="distribution-stack">
+          <div className="distribution-bar" aria-label="Fleet health distribution">
+            {items.map((item) => (
+              <button
+                key={item.key}
+                type="button"
+                className={`distribution-segment tone-${item.tone}`}
+                style={{ width: `${Math.max(item.count / total * 100, item.count ? 8 : 0)}%` }}
+                onClick={() => onFilter(item.key)}
+              >
+                <span>{item.label}</span>
+                <strong>{item.count}</strong>
+              </button>
+            ))}
+          </div>
+          <div className="distribution-list">
+            {items.map((item) => (
+              <button key={`legend-${item.key}`} type="button" className="distribution-row" onClick={() => onFilter(item.key)}>
+                <span className={`status status-${item.key}`}>{item.label}</span>
+                <strong>{item.count}</strong>
+                <small>{formatPercent(total ? (item.count / total) * 100 : 0)}</small>
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : (
+        <p className="empty-state">No health data available yet.</p>
+      )}
+    </section>
+  );
+}
+
+function RecentAlertsPanel({ loading, alerts }) {
+  return (
+    <section className="panel overview-panel alerts-panel">
+      <div className="panel-head">
+        <div>
+          <h2>Recent alerts</h2>
+          <p>Last 10 telemetry events that resulted in a health change.</p>
+        </div>
+      </div>
+      {loading && !alerts.length ? (
+        <p className="empty-state">Loading recent alerts.</p>
+      ) : alerts.length ? (
+        <div className="alerts-table">
+          <div className="alerts-table-head">
+            <span>Time</span>
+            <span>Device</span>
+            <span>Signal</span>
+            <span>Health</span>
+          </div>
+          {alerts.map((alert) => (
+            <div className="alerts-table-row" key={alert.id}>
+              <time title={alert.occurred_at}>{formatRelativeTime(alert.occurred_at)}</time>
+              <strong>{alert.device_name}</strong>
+              <span>{alert.signal}</span>
+              <StatusBadge value={normalizeStatusKey(alert.health)} label={toTitleCase(alert.health)} />
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="empty-state">No recent alert events yet.</p>
+      )}
+    </section>
+  );
+}
+
+function Devices({ active, devices, selectedDevice, setSelectedDeviceId, onAction }) {
   const [readinessFilter, setReadinessFilter] = useState('All');
   const [healthFilter, setHealthFilter] = useState('All');
   const [signalFilter, setSignalFilter] = useState('All');
   const [firmwareFilter, setFirmwareFilter] = useState('All');
 
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const health = params.get('health');
+    if (health) {
+      setHealthFilter(toTitleCase(health));
+    } else {
+      setHealthFilter('All');
+    }
+  }, [active]);
+
   const processedDevices = useMemo(() => {
     const withDeviceSignals = devices.map((device) => ({
       ...device,
       firmware_version_display: device.firmware_version || '—',
-      health_display: device.health || 'Unknown',
+      health_display: formatHealthLabel(device.health),
       signal_display: device.signal_quality || '—',
       readiness_display: formatReadinessLabel(device.readiness),
     }));
@@ -978,6 +1253,11 @@ function formatReadinessLabel(readiness) {
   return map[readiness] || toTitleCase(String(readiness).replaceAll('_', ' '));
 }
 
+function formatHealthLabel(health) {
+  if (health === null || health === undefined || health === '') return 'Unknown';
+  return toTitleCase(String(health).replaceAll('_', ' '));
+}
+
 function normalizeStatusKey(value) {
   if (value === null || value === undefined || value === '') return 'unknown';
   return String(value).toLowerCase().replaceAll(' ', '-');
@@ -1036,6 +1316,104 @@ async function fetchJSON(url) {
   if (response.status === 403) throw new AuthError(403, 'Access denied.');
   if (!response.ok) throw new Error(`${url} failed with ${response.status}`);
   return response.json();
+}
+
+async function fetchRecentAlerts(devices) {
+  if (!devices.length) return [];
+  const settled = await Promise.allSettled(
+    devices.map((device) => fetchJSON(`/api/devices/${device.id}/telemetry`)),
+  );
+  const alerts = [];
+  settled.forEach((result, index) => {
+    if (result.status !== 'fulfilled') return;
+    const device = devices[index];
+    const telemetry = result.value || {};
+    for (const event of telemetry.recent_events || []) {
+      alerts.push({
+        id: `${device.id}:${event.occurred_at}:${event.event_type}`,
+        occurred_at: event.occurred_at,
+        device_name: device.name,
+        signal: alertSignalLabel(event.event_type, event.summary),
+        health: telemetry.health || 'unknown',
+      });
+    }
+  });
+  alerts.sort((left, right) => compareValues(right.occurred_at, left.occurred_at));
+  return alerts.slice(0, 10);
+}
+
+function alertSignalLabel(eventType, summary) {
+  const map = {
+    'device.health.rssi_sample': 'Low RSSI',
+    'device.health.summary': 'Health summary',
+    'device.health.memory_sample': 'Memory sample',
+    'device.health.offline_risk': 'Offline risk',
+    'device.reboot.reported': 'Recent reboot',
+    'device.crash.reported': 'Recent crash',
+    'firmware.version.observed': 'Firmware observed',
+  };
+  if (map[eventType]) return map[eventType];
+  if (summary) return summary;
+  return toTitleCase(String(eventType || '').replaceAll(/[._]/g, ' '));
+}
+
+function formatPercent(value) {
+  if (value === null || value === undefined || value === '-') return '-';
+  if (typeof value !== 'number') return value;
+  return `${value.toFixed(1)}%`;
+}
+
+function formatRelativeTime(iso) {
+  const timestamp = Date.parse(iso);
+  if (Number.isNaN(timestamp)) return iso || '-';
+  const deltaSeconds = Math.round((Date.now() - timestamp) / 1000);
+  const abs = Math.abs(deltaSeconds);
+  if (abs < 60) return deltaSeconds >= 0 ? `${abs}s ago` : `in ${abs}s`;
+  const minutes = Math.round(abs / 60);
+  if (minutes < 60) return deltaSeconds >= 0 ? `${minutes}m ago` : `in ${minutes}m`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 24) return deltaSeconds >= 0 ? `${hours}h ago` : `in ${hours}h`;
+  const days = Math.round(hours / 24);
+  return deltaSeconds >= 0 ? `${days}d ago` : `in ${days}d`;
+}
+
+function buildFleetTrendChart(trend) {
+  if (!trend.length) {
+    return { points: [], onlinePoints: '', alertPoints: '', grid: [], maxPct: 100, maxAlerts: 0, labelStep: 1 };
+  }
+  const width = 624;
+  const height = 184;
+  const top = 28;
+  const bottom = 228;
+  const maxAlerts = Math.max(...trend.map((point) => point.WarningCount + point.CriticalCount), 1);
+  const points = trend.map((point, index) => {
+    const x = 52 + (index * width) / Math.max(trend.length - 1, 1);
+    const onlineY = bottom - ((point.OnlinePct || 0) / 100) * (bottom - top);
+    const alerts = point.WarningCount + point.CriticalCount;
+    const alertY = bottom - ((alerts / maxAlerts) * (bottom - top));
+    return {
+      date: point.Date,
+      label: formatTrendLabel(point.Date),
+      x,
+      onlineY,
+      alertY,
+    };
+  });
+  return {
+    points,
+    onlinePoints: points.map((point) => `${point.x},${point.onlineY}`).join(' '),
+    alertPoints: points.map((point) => `${point.x},${point.alertY}`).join(' '),
+    grid: [68, 108, 148, 188],
+    maxPct: 100,
+    maxAlerts,
+    labelStep: Math.max(1, Math.ceil(points.length / 6)),
+  };
+}
+
+function formatTrendLabel(date) {
+  const parsed = Date.parse(date);
+  if (Number.isNaN(parsed)) return date;
+  return new Intl.DateTimeFormat('en', { month: 'short', day: 'numeric' }).format(new Date(parsed));
 }
 
 function runRowAction(event, onAction, deviceId, action) {

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -15,7 +15,7 @@ export const platformNavItems = [
 
 export function titleFor(active) {
   return {
-    overview: 'Customer Overview',
+    overview: 'Fleet Health Overview',
     devices: 'Devices',
     operations: 'Operations',
     'firmware-ota': 'Firmware & OTA',

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { routeFromPath } from './routes.mjs';
+import { routeFromPath, titleFor } from './routes.mjs';
 
 test('maps platform shell paths to platform routes', () => {
   assert.equal(routeFromPath('/admin'), 'platform-health');
@@ -18,4 +18,8 @@ test('maps customer shell paths to customer routes', () => {
   assert.equal(routeFromPath('/console/firmware-ota'), 'firmware-ota');
   assert.equal(routeFromPath('/console/stream-health'), 'stream-health');
   assert.equal(routeFromPath('/console/groups'), 'groups');
+});
+
+test('uses fleet health overview title for the customer landing page', () => {
+  assert.equal(titleFor('overview'), 'Fleet Health Overview');
 });

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -214,6 +214,10 @@ p {
   margin-bottom: 18px;
 }
 
+.overview-metrics {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .metric,
 .panel {
   background: rgba(255, 255, 255, 0.92);
@@ -249,6 +253,316 @@ p {
   display: block;
   font-size: 28px;
   margin-top: 8px;
+}
+
+.metric-card {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.96) 0%, rgba(238, 248, 251, 0.92) 100%);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow: var(--shadow-soft);
+  padding: 18px;
+  position: relative;
+  overflow: hidden;
+}
+
+.metric-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 auto auto 0;
+  height: 3px;
+  width: 100%;
+}
+
+.metric-card span {
+  color: var(--muted);
+  display: block;
+  font-size: 13px;
+}
+
+.metric-card strong {
+  color: var(--navy);
+  display: block;
+  font-size: 30px;
+  margin-top: 8px;
+}
+
+.metric-card small {
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+  margin-top: 6px;
+}
+
+.metric-card.tone-good::before {
+  background: #34a853;
+}
+
+.metric-card.tone-info::before {
+  background: var(--brand-cyan);
+}
+
+.metric-card.tone-warn::before {
+  background: #f79009;
+}
+
+.metric-card.tone-danger::before {
+  background: var(--danger);
+}
+
+.overview-layout {
+  display: grid;
+  gap: 18px;
+}
+
+.hero-panel {
+  align-items: flex-start;
+  background:
+    radial-gradient(circle at top right, rgba(109, 206, 221, 0.14), transparent 32%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(234, 246, 251, 0.94) 100%);
+  display: flex;
+  gap: 20px;
+  justify-content: space-between;
+}
+
+.hero-copy {
+  max-width: 52ch;
+}
+
+.overview-grid {
+  display: grid;
+  gap: 18px;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.9fr);
+}
+
+.overview-panel {
+  min-height: 100%;
+}
+
+.window-toggle {
+  display: inline-flex;
+  gap: 8px;
+}
+
+.window-toggle button {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--brand-dark);
+  cursor: pointer;
+  min-height: 34px;
+  padding: 6px 12px;
+}
+
+.window-toggle button.active {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
+}
+
+.trend-chart {
+  display: block;
+  height: auto;
+  margin-top: 14px;
+  width: 100%;
+}
+
+.chart-grid-line,
+.chart-axis-line {
+  stroke: rgba(37, 56, 76, 0.12);
+  stroke-width: 1;
+}
+
+.chart-axis-line {
+  stroke: rgba(37, 56, 76, 0.24);
+}
+
+.chart-line {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 3.5;
+}
+
+.chart-line-online {
+  stroke: var(--brand);
+}
+
+.chart-line-alerts {
+  stroke: #f79009;
+}
+
+.chart-dot {
+  stroke: #fff;
+  stroke-width: 2;
+}
+
+.chart-dot-online {
+  fill: var(--brand);
+}
+
+.chart-dot-alerts {
+  fill: #f79009;
+}
+
+.chart-label,
+.chart-axis-label {
+  fill: var(--muted);
+  font-size: 11px;
+}
+
+.chart-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 6px;
+}
+
+.chart-legend span {
+  align-items: center;
+  color: var(--muted);
+  display: inline-flex;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.legend-line {
+  border-radius: 999px;
+  display: inline-block;
+  height: 3px;
+  width: 18px;
+}
+
+.legend-online {
+  background: var(--brand);
+}
+
+.legend-alerts {
+  background: #f79009;
+}
+
+.chart-footnote,
+.empty-state {
+  color: var(--muted);
+  margin-top: 12px;
+}
+
+.distribution-stack {
+  display: grid;
+  gap: 14px;
+}
+
+.distribution-bar {
+  align-items: stretch;
+  background: #f8fbfd;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  display: flex;
+  overflow: hidden;
+}
+
+.distribution-segment {
+  border: 0;
+  color: #fff;
+  cursor: pointer;
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  padding: 14px 12px;
+  text-align: left;
+}
+
+.distribution-segment span {
+  font-size: 12px;
+  font-weight: 700;
+  opacity: 0.92;
+}
+
+.distribution-segment strong {
+  font-size: 20px;
+}
+
+.distribution-list {
+  display: grid;
+  gap: 8px;
+}
+
+.distribution-row {
+  align-items: center;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  cursor: pointer;
+  display: grid;
+  gap: 8px;
+  grid-template-columns: auto auto 1fr;
+  padding: 10px 12px;
+  text-align: left;
+}
+
+.distribution-row strong {
+  color: var(--navy);
+}
+
+.distribution-row small {
+  color: var(--muted);
+  justify-self: end;
+}
+
+.distribution-segment.tone-good {
+  background: linear-gradient(180deg, rgba(52, 168, 83, 0.92) 0%, rgba(40, 145, 71, 0.92) 100%);
+}
+
+.distribution-segment.tone-warn {
+  background: linear-gradient(180deg, rgba(247, 144, 9, 0.92) 0%, rgba(224, 122, 0, 0.92) 100%);
+}
+
+.distribution-segment.tone-danger {
+  background: linear-gradient(180deg, rgba(180, 35, 24, 0.92) 0%, rgba(147, 28, 18, 0.92) 100%);
+}
+
+.distribution-segment.tone-neutral {
+  background: linear-gradient(180deg, rgba(37, 56, 76, 0.88) 0%, rgba(72, 88, 108, 0.88) 100%);
+}
+
+.alerts-table {
+  display: grid;
+  gap: 8px;
+}
+
+.alerts-table-head,
+.alerts-table-row {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: 120px minmax(180px, 1.6fr) minmax(140px, 1fr) minmax(120px, 0.8fr);
+  align-items: center;
+}
+
+.alerts-table-head {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.alerts-table-row {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 12px;
+}
+
+.alerts-table-row time {
+  color: var(--navy);
+  font-size: 13px;
+}
+
+.alerts-table-row strong {
+  color: var(--navy);
+}
+
+.alerts-table-row .status {
+  justify-self: start;
 }
 
 .panel {
@@ -663,6 +977,7 @@ th {
 }
 
 .status-online,
+.status-healthy,
 .status-ok,
 .status-succeeded,
 .status-present {
@@ -677,6 +992,7 @@ th {
   color: var(--brand);
 }
 
+.status-warning,
 .status-cloud-activation-pending,
 .status-pending,
 .status-retrying,
@@ -686,11 +1002,17 @@ th {
   color: var(--navy);
 }
 
+.status-critical,
 .status-failed,
 .status-dead-lettered,
 .status-down {
   background: #fef3f2;
   color: var(--danger);
+}
+
+.status-unknown {
+  background: rgba(37, 56, 76, 0.08);
+  color: var(--navy);
 }
 
 .error {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -572,20 +572,11 @@ p {
 }
 
 .device-workspace {
-  align-items: start;
-  display: grid;
-  gap: 18px;
-  grid-template-columns: minmax(0, 1fr) 330px;
+  display: block;
 }
 
 .device-table-panel {
   min-width: 0;
-}
-
-.detail-panel {
-  overflow: visible;
-  position: sticky;
-  top: 24px;
 }
 
 .detail-heading {
@@ -673,6 +664,266 @@ dd {
 }
 
 .detail-actions button:last-child {
+  background: #fff;
+  color: var(--brand-dark);
+}
+
+.drawer-backdrop {
+  align-items: stretch;
+  background: rgba(17, 28, 45, 0.34);
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 0;
+  z-index: 30;
+}
+
+.drawer-panel {
+  background:
+    radial-gradient(circle at top right, rgba(109, 206, 221, 0.12), transparent 30%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(243, 249, 252, 0.98) 100%);
+  border-left: 1px solid rgba(37, 56, 76, 0.12);
+  box-shadow: -18px 0 44px rgba(3, 83, 144, 0.18);
+  display: grid;
+  gap: 16px;
+  max-width: min(560px, 100vw);
+  overflow-y: auto;
+  padding: 22px;
+  width: 100%;
+}
+
+.drawer-header {
+  align-items: flex-start;
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.drawer-header h2 {
+  margin-bottom: 4px;
+}
+
+.drawer-header p {
+  margin-bottom: 0;
+}
+
+.drawer-close {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--brand-dark);
+  cursor: pointer;
+  min-height: 36px;
+  padding: 6px 14px;
+}
+
+.drawer-close:hover {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(0, 104, 183, 0.1);
+}
+
+.drawer-identity {
+  display: grid;
+  gap: 10px 14px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.drawer-identity div,
+.summary-card,
+.telemetry-card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: var(--shadow-soft);
+}
+
+.drawer-identity div {
+  padding: 12px 14px;
+}
+
+.drawer-identity span,
+.summary-card span {
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.drawer-identity strong,
+.summary-card strong {
+  color: var(--navy);
+  display: block;
+  font-size: 15px;
+  margin-top: 6px;
+}
+
+.summary-card small {
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+  margin-top: 8px;
+}
+
+.drawer-summary {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.summary-card {
+  padding: 14px;
+}
+
+.drawer-charts {
+  display: grid;
+  gap: 12px;
+}
+
+.telemetry-card {
+  padding: 16px;
+}
+
+.telemetry-card .panel-head {
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.telemetry-card h3,
+.drawer-events h3 {
+  color: var(--navy);
+  font-size: 15px;
+  margin: 0;
+}
+
+.telemetry-card p,
+.drawer-events p {
+  margin-bottom: 0;
+}
+
+.telemetry-card strong {
+  color: var(--navy);
+  font-size: 18px;
+}
+
+.sparkline-chart {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+
+.sparkline-line {
+  fill: none;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 3;
+}
+
+.sparkline-line.tone-brand {
+  stroke: var(--brand);
+}
+
+.sparkline-line.tone-accent {
+  stroke: #f79009;
+}
+
+.sparkline-area {
+  fill: rgba(0, 104, 183, 0.06);
+  stroke: none;
+}
+
+.sparkline-dot {
+  fill: #fff;
+  stroke-width: 2;
+}
+
+.sparkline-dot.tone-brand {
+  stroke: var(--brand);
+}
+
+.sparkline-dot.tone-accent {
+  stroke: #f79009;
+}
+
+.sparkline-foot {
+  display: flex;
+  justify-content: space-between;
+  color: var(--muted);
+  font-size: 12px;
+  margin-top: 6px;
+}
+
+.drawer-events {
+  display: grid;
+  gap: 10px;
+}
+
+.event-list {
+  display: grid;
+  gap: 10px;
+}
+
+.event-row {
+  align-items: flex-start;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  padding: 12px;
+}
+
+.event-row strong {
+  color: var(--navy);
+  display: block;
+  margin-bottom: 4px;
+}
+
+.event-row span {
+  color: var(--muted);
+  display: block;
+  font-size: 13px;
+}
+
+.event-row time {
+  color: var(--muted);
+  flex: 0 0 auto;
+  font-size: 12px;
+}
+
+.drawer-error {
+  background: #fff7f7;
+  border: 1px solid rgba(180, 35, 24, 0.2);
+  border-radius: 10px;
+  color: var(--danger);
+  margin: 0;
+  padding: 12px;
+}
+
+.drawer-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.drawer-actions button {
+  border: 1px solid var(--brand);
+  border-radius: 8px;
+  cursor: pointer;
+  min-height: 38px;
+  padding: 8px 12px;
+}
+
+.drawer-actions button:first-child {
+  background: var(--brand);
+  color: #fff;
+}
+
+.drawer-actions button:last-child {
   background: #fff;
   color: var(--brand-dark);
 }
@@ -1015,6 +1266,17 @@ th {
   color: var(--navy);
 }
 
+.status-active,
+.status-open {
+  background: #e7f6f7;
+  color: var(--brand-dark);
+}
+
+.status-inactive {
+  background: rgba(37, 56, 76, 0.08);
+  color: var(--navy);
+}
+
 .error {
   background: #fff7f7;
   border: 1px solid rgba(180, 35, 24, 0.2);
@@ -1038,11 +1300,7 @@ th {
   }
 
   .device-workspace {
-    grid-template-columns: 1fr;
-  }
-
-  .detail-panel {
-    position: static;
+    display: block;
   }
 
   .topbar,
@@ -1060,5 +1318,15 @@ th {
     align-items: stretch;
     display: grid;
     justify-content: stretch;
+  }
+
+  .drawer-panel {
+    max-width: 100vw;
+    padding: 18px;
+  }
+
+  .drawer-summary,
+  .drawer-identity {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
## Summary

- Replace the device detail side panel with a slide-over drawer that opens from device rows.
- Fetch and render per-device telemetry on demand: health summary, contributing signals, firmware, RSSI 7d sparkline, uptime 7d sparkline, recent events, and a best-effort active-stream indicator.
- Keep the selected device in the URL query string and support ESC / backdrop close.

## Validation

- `npm test`
- `npm run build`

Closes #28
