### PR TITLE
docs: add private cloud deployment profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
             --name "$container_name" \
             -e PORT=8080 \
             -e DATABASE_PATH=/data/ci.db \
+            -e ADMIN_BOOTSTRAP_EMAIL=admin@example.com \
+            -e ADMIN_BOOTSTRAP_PASSWORD=secret \
             -v "$smoke_dir:/data" \
             "$ci_image_tag")"
 
@@ -92,6 +94,20 @@ jobs:
           fi
 
           docker exec "$container_id" wget -qO- http://127.0.0.1:8080/healthz | grep -qx 'ok'
+          docker exec "$container_id" wget -qO- http://127.0.0.1:8080/api/service-health | grep -q '"status":"demo"'
+
+          printf '%s' '{"email":"admin@example.com","password":"secret"}' > "$smoke_dir/login.json"
+          docker exec "$container_id" sh -lc 'wget -S -O - --post-file=/data/login.json http://127.0.0.1:8080/api/auth/platform/login' > "$smoke_dir/login.body" 2> "$smoke_dir/login.headers"
+          session_id="$(sed -n 's/.*rtk_admin_session=\([^;[:space:]]*\).*/\1/p' "$smoke_dir/login.headers" | head -n1)"
+          if [ -z "$session_id" ]; then
+            echo "platform login did not return an rtk_admin_session cookie" >&2
+            cat "$smoke_dir/login.body" >&2 || true
+            cat "$smoke_dir/login.headers" >&2 || true
+            exit 1
+          fi
+          grep -q '"status":"ok"' "$smoke_dir/login.body"
+          docker exec "$container_id" sh -lc "wget -qO- --header='Cookie: rtk_admin_session=${session_id}' http://127.0.0.1:8080/api/me" | grep -q '"kind":"platform_admin"'
+
           docker exec "$container_id" wget -qO- http://127.0.0.1:8080/api/summary | grep -q '"total_devices"'
           docker exec "$container_id" wget -qO- http://127.0.0.1:8080/console | grep -q 'id="root"'
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Environment variables:
 - `DATABASE_PATH`: SQLite path, default `data/rtk-cloud-admin.db`
 - `ACCOUNT_MANAGER_BASE_URL`: optional upstream Account Manager URL
 - `VIDEO_CLOUD_BASE_URL`: optional upstream Video Cloud URL
+- `VIDEO_CLOUD_ADMIN_TOKEN`: optional upstream Video Cloud admin token
 - `ADMIN_BOOTSTRAP_EMAIL`: optional local platform admin email
 - `ADMIN_BOOTSTRAP_PASSWORD`: optional local platform admin password
 
@@ -161,10 +162,16 @@ docker run --rm -p 18081:8080 \
   -v "$PWD/data:/data" \
   -e ACCOUNT_MANAGER_BASE_URL="https://account-manager.example" \
   -e VIDEO_CLOUD_BASE_URL="https://video-cloud.example" \
+  -e VIDEO_CLOUD_ADMIN_TOKEN="replace-me" \
+  -e ADMIN_BOOTSTRAP_EMAIL="admin@example.com" \
+  -e ADMIN_BOOTSTRAP_PASSWORD="change-me" \
   rtk-cloud-admin
 ```
 
 Container health uses `/healthz`.
+
+For a production private-cloud deployment, see
+[`docs/private-cloud-deployment.md`](docs/private-cloud-deployment.md).
 
 ## CI
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -82,6 +82,9 @@ Self-service signup is not yet implemented; track the implementation work
 through the issues opened against this repo and `rtk_account_manager` once
 the doc baseline is approved.
 
+The production deployment profile for the admin dashboard is documented in
+[`docs/private-cloud-deployment.md`](private-cloud-deployment.md).
+
 ## Architecture
 
 Runtime components:
@@ -122,7 +125,7 @@ Public and shared routes:
 - `GET /assets/...`: built frontend assets.
 - `GET /*`: React SPA fallback.
 
-The v0.1 implementation may run without configured upstream services. In that mode, API responses use SQLite seed data and clearly show local demo status in service health. When `ACCOUNT_MANAGER_BASE_URL` is configured and a customer session exists, `/api/customers`, `/api/devices`, and lifecycle actions use Account Manager proxy mode and preserve the frontend DTO shape.
+The v0.1 implementation may run without configured upstream services. In that mode, API responses use SQLite seed data and clearly show local demo status in service health. When `ACCOUNT_MANAGER_BASE_URL` is configured and a customer session exists, `/api/customers`, `/api/devices`, and lifecycle actions use Account Manager proxy mode and preserve the frontend DTO shape. When `VIDEO_CLOUD_BASE_URL` and `VIDEO_CLOUD_ADMIN_TOKEN` are configured, firmware, telemetry, stream, and readiness enrichment paths use Video Cloud proxy mode; failures return gateway errors instead of silently falling back.
 
 ## Authentication And Sessions
 
@@ -206,6 +209,7 @@ Environment variables:
 - `DATABASE_PATH`: SQLite path, default `data/rtk-cloud-admin.db`.
 - `ACCOUNT_MANAGER_BASE_URL`: optional upstream Account Manager URL.
 - `VIDEO_CLOUD_BASE_URL`: optional upstream Video Cloud URL.
+- `VIDEO_CLOUD_ADMIN_TOKEN`: optional upstream Video Cloud admin token.
 - `ADMIN_BOOTSTRAP_EMAIL`: optional first local platform admin email.
 - `ADMIN_BOOTSTRAP_PASSWORD`: optional first local platform admin password for development.
 
@@ -217,3 +221,4 @@ Environment variables:
 - App tests for customer login, upstream proxy mode, provision proxy, and platform admin route guards.
 - Frontend build verification with `npm run build`.
 - Backend build verification with `go test ./...` and `go build ./cmd/server`.
+- Container smoke verification for `/healthz`, `/api/service-health`, platform admin login/session, `/api/summary`, and `/console`.

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -44,5 +44,9 @@ If the runner gets stuck or disk usage climbs too high:
 6. If smoke checks fail again, reproduce locally:
    - `docker run --rm -p 18080:8080 -e DATABASE_PATH=/tmp/ci.db rtk-cloud-admin:ci`
    - `curl http://127.0.0.1:18080/healthz`
+   - `curl http://127.0.0.1:18080/api/service-health`
+   - `curl -X POST http://127.0.0.1:18080/api/auth/platform/login` after
+     setting `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD`
+   - `curl http://127.0.0.1:18080/api/me` after replaying the login cookie
    - `curl http://127.0.0.1:18080/api/summary`
    - `curl http://127.0.0.1:18080/console`

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -1,0 +1,103 @@
+# Private Cloud Deployment Profile
+
+Status: draft.
+
+This document describes the supported production deployment profile for
+`rtk_cloud_admin` when it is run as the admin dashboard in a private-cloud
+environment.
+
+## Target Shape
+
+Recommended production layout:
+
+- run the Go server as a container image or as a native system service
+- place it behind a reverse proxy that terminates TLS
+- mount a persistent SQLite volume for `DATABASE_PATH`
+- configure upstream Account Manager and Video Cloud endpoints explicitly
+- keep admin bootstrap secrets out of source control and inject them at deploy
+  time
+
+The app is not a stateless frontend. Local SQLite holds sessions, platform
+admins, audit metadata, settings, and upstream cache projections. Treat the
+database file as production state and back it up accordingly.
+
+## Runtime Configuration
+
+Required or recommended environment variables:
+
+- `PORT`: listen port for the HTTP server, default `8080`
+- `DATABASE_PATH`: SQLite file path, typically on a persistent volume
+- `ACCOUNT_MANAGER_BASE_URL`: upstream Account Manager base URL
+- `VIDEO_CLOUD_BASE_URL`: upstream Video Cloud base URL
+- `VIDEO_CLOUD_ADMIN_TOKEN`: admin token used for telemetry, firmware, and
+  stream queries
+- `ADMIN_BOOTSTRAP_EMAIL`: local platform admin bootstrap email
+- `ADMIN_BOOTSTRAP_PASSWORD`: local platform admin bootstrap password
+
+Production mode should set all upstream variables. Demo or cache-only mode is
+only appropriate for local development or isolated validation.
+
+## Reverse Proxy And TLS
+
+The application itself serves plain HTTP. TLS should be terminated by the
+fronting proxy or ingress controller.
+
+Operational expectations:
+
+- expose the app only on the private network or loopback interface
+- forward client requests over HTTPS at the edge
+- preserve the `Host` header and standard forwarding headers used by the
+  operator's proxy stack
+- keep the session cookie `HttpOnly` and treat it as an authenticated browser
+  session, not an API token
+
+## Data Ownership
+
+`rtk_cloud_admin` is a BFF and cache layer, not the source of truth for fleet
+state.
+
+- Account Manager remains authoritative for users, memberships, organizations,
+  and registry devices
+- Video Cloud remains authoritative for activation, telemetry, stream, and
+  firmware facts
+- local SQLite remains authoritative for admin sessions, platform admins,
+  audit metadata, and cached projections used by the dashboard
+
+In production, upstream failures must be visible. The dashboard should surface
+gateway errors instead of silently falling back when a configured upstream is
+unreachable.
+
+## Backup, Restore, And Rollback
+
+Back up the SQLite database file together with any `-wal` or `-shm` sidecar
+files when the database is in use.
+
+Practical workflow:
+
+1. Stop the service or quiesce traffic.
+2. Copy the current database file from `DATABASE_PATH`.
+3. Archive the container image tag or native binary version that produced the
+   running release.
+4. Restore by replacing the database file and redeploying the known-good image
+   or binary.
+5. Roll back by restoring the previous database snapshot and the previous app
+   artifact together.
+
+The fastest rollback path is to pin the previous image tag and point it at the
+last known good SQLite snapshot.
+
+## Smoke Checks
+
+The production profile should be validated with a small set of deterministic
+checks after startup:
+
+- `GET /healthz` returns `ok`
+- `GET /api/service-health` returns the upstream status summary
+- `POST /api/auth/platform/login` accepts the bootstrap admin credentials
+- `GET /api/me` succeeds when the login cookie is replayed
+- `GET /api/summary` returns the dashboard summary payload
+- `GET /console` renders the dashboard shell
+
+The CI workflow in this repository mirrors that profile and should be kept in
+sync with any future runtime or auth changes.
+

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -7,6 +7,7 @@ func TestFromEnvDefaultsAndOverrides(t *testing.T) {
 	t.Setenv("DATABASE_PATH", "data/test.db")
 	t.Setenv("ACCOUNT_MANAGER_BASE_URL", "https://account.example")
 	t.Setenv("VIDEO_CLOUD_BASE_URL", "https://video.example")
+	t.Setenv("VIDEO_CLOUD_ADMIN_TOKEN", "video-admin-token")
 	t.Setenv("ADMIN_BOOTSTRAP_EMAIL", "admin@example.com")
 	t.Setenv("ADMIN_BOOTSTRAP_PASSWORD", "secret")
 
@@ -22,6 +23,9 @@ func TestFromEnvDefaultsAndOverrides(t *testing.T) {
 	}
 	if cfg.VideoCloudBaseURL != "https://video.example" {
 		t.Fatalf("VideoCloudBaseURL = %q", cfg.VideoCloudBaseURL)
+	}
+	if cfg.VideoCloudAdminToken != "video-admin-token" {
+		t.Fatalf("VideoCloudAdminToken = %q", cfg.VideoCloudAdminToken)
 	}
 	if cfg.AdminBootstrapEmail != "admin@example.com" || cfg.AdminBootstrapPassword != "secret" {
 		t.Fatalf("admin bootstrap env not loaded")


### PR DESCRIPTION
## Summary
Document the production deployment profile for the admin dashboard and align the CI smoke checks with the expected private-cloud runtime.

## What changed
- Added a dedicated private-cloud deployment profile doc.
- Documented the `VIDEO_CLOUD_ADMIN_TOKEN` runtime variable in the README and spec.
- Expanded the CI smoke notes to cover service health and the bootstrap admin login/session flow.
- Added config coverage for `VIDEO_CLOUD_ADMIN_TOKEN`.
- Hardened the container smoke workflow to verify `/healthz`, `/api/service-health`, platform admin login, `/api/me`, `/api/summary`, and `/console`.

## Validation
- `go test ./internal/config ./internal/app`
- `git diff --check`

Closes #49
