### PR TITLE
[Testing] Improve CI and regression coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,32 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
-      - name: Go tests
-        run: go test ./...
+      - name: Go tests with coverage
+        run: go test ./... -coverprofile=coverage.out
 
       - name: Go build
         run: go build ./cmd/server
 
+      - name: Go coverage gate
+        run: |
+          set -euo pipefail
+          go tool cover -func=coverage.out
+          total="$(go tool cover -func=coverage.out | awk '/^total:/ { gsub("%", "", $3); print $3 }')"
+          awk -v total="$total" -v min="65.0" 'BEGIN {
+            if (total < min) {
+              printf("Go total coverage %.1f%% is below %.1f%%\n", total, min)
+              exit 1
+            }
+            printf("Go total coverage %.1f%% meets %.1f%% baseline\n", total, min)
+          }'
+
       - name: Frontend install
         working-directory: web
         run: npm ci
+
+      - name: Frontend tests
+        working-directory: web
+        run: npm test
 
       - name: Frontend build
         working-directory: web

--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Backend tests:
 go test ./...
 ```
 
+Backend coverage:
+
+```sh
+go test ./... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
 Backend build:
 
 ```sh
@@ -95,8 +102,17 @@ Frontend build:
 
 ```sh
 cd web
+npm test
 npm run build
 ```
+
+Testing policy:
+
+- API handler behavior changes need focused Go tests with `httptest`.
+- Account Manager and Video Cloud integrations must be tested with local
+  `httptest` upstreams, never real services.
+- Frontend route or API helper changes need Node test coverage in
+  `web/src/*.test.mjs`.
 
 Run a persistent local server through tmux:
 

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -1,8 +1,10 @@
 package accountclient
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -127,5 +129,132 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 	}
 	if raise.QuotaRaiseRequest.Status != "pending" {
 		t.Fatalf("quota raise status = %q", raise.QuotaRaiseRequest.Status)
+	}
+}
+
+func TestClientOrganizationsAndDevices(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer access" {
+			t.Fatalf("Authorization = %q, want Bearer access", got)
+		}
+		switch r.URL.Path {
+		case "/v1/orgs":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"organizations": []map[string]any{
+					{"id": "org-1", "name": "Acme", "role": "owner", "tier": "evaluation", "evaluation_device_quota": 5},
+				},
+			})
+		case "/v1/orgs/org-1/devices":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"devices": []map[string]any{
+					{
+						"id":                "dev-1",
+						"organization_id":   "org-1",
+						"organization":      "Acme",
+						"name":              "Front Door",
+						"model":             "RTK-CAM-A",
+						"serial_number":     "ACME-001",
+						"video_cloud_devid": "vc-1",
+						"status":            "online",
+						"readiness":         "activated",
+						"metadata":          map[string]any{"video_cloud_devid": "vc-1"},
+					},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL)
+	orgs, err := client.Organizations(t.Context(), "access")
+	if err != nil {
+		t.Fatalf("Organizations returned error: %v", err)
+	}
+	if len(orgs) != 1 || orgs[0].ID != "org-1" || orgs[0].EvaluationDeviceQuota != 5 {
+		t.Fatalf("organizations = %#v", orgs)
+	}
+
+	devices, err := client.Devices(t.Context(), "access", "org-1")
+	if err != nil {
+		t.Fatalf("Devices returned error: %v", err)
+	}
+	if len(devices) != 1 || devices[0].ID != "dev-1" || devices[0].VideoCloudDevID != "vc-1" {
+		t.Fatalf("devices = %#v", devices)
+	}
+}
+
+func TestClientLifecycleOperationsAcceptNestedAndFlatResponses(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer access" {
+			t.Fatalf("Authorization = %q, want Bearer access", got)
+		}
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		switch r.URL.Path {
+		case "/v1/orgs/org-1/devices/dev-1/provision":
+			_, _ = w.Write([]byte(`{"operation":{"id":"op-provision","state":"published","message":"accepted","updated_at":"2026-05-07T00:00:00Z"}}`))
+		case "/v1/orgs/org-1/devices/dev-1/deactivate":
+			_, _ = w.Write([]byte(`{"id":"op-deactivate","state":"completed","message":"disabled","updated_at":"2026-05-07T00:01:00Z"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL)
+	provision, err := client.Provision(t.Context(), "access", "org-1", "dev-1")
+	if err != nil {
+		t.Fatalf("Provision returned error: %v", err)
+	}
+	if provision.ID != "op-provision" || provision.State != "published" {
+		t.Fatalf("provision operation = %#v", provision)
+	}
+
+	deactivate, err := client.Deactivate(t.Context(), "access", "org-1", "dev-1")
+	if err != nil {
+		t.Fatalf("Deactivate returned error: %v", err)
+	}
+	if deactivate.ID != "op-deactivate" || deactivate.State != "completed" {
+		t.Fatalf("deactivate operation = %#v", deactivate)
+	}
+}
+
+func TestClientHealthAndHTTPErrorBody(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/healthz":
+			_, _ = w.Write([]byte("ok"))
+		case "/v1/orgs/org-1/devices":
+			http.Error(w, "forbidden org", http.StatusForbidden)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL + "/")
+	if err := client.Health(t.Context()); err != nil {
+		t.Fatalf("Health returned error: %v", err)
+	}
+
+	_, err := client.Devices(t.Context(), "access", "org-1")
+	if err == nil {
+		t.Fatal("expected Devices error")
+	}
+	httpErr, ok := err.(*HTTPError)
+	if !ok {
+		t.Fatalf("error type = %T, want *HTTPError", err)
+	}
+	if httpErr.StatusCode != http.StatusForbidden || !strings.Contains(httpErr.Body, "forbidden org") {
+		t.Fatalf("HTTPError = %#v", httpErr)
 	}
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1626,7 +1626,7 @@ func (s *Server) proxyTelemetryForDevice(ctx context.Context, orgID string, devi
 	}
 	upstream, err := s.videoClient.DeviceTelemetry(ctx, s.cfg.VideoCloudAdminToken, device.VideoCloudDevID, orgID)
 	if err != nil {
-		return contracts.DeviceTelemetry{}, true, err
+		return contracts.DeviceTelemetry{}, true, fmt.Errorf("%w: %v", errVideoCloudRequestFailed, err)
 	}
 	info, err := s.videoClient.GetDeviceInfo(ctx, s.cfg.VideoCloudAdminToken, device.VideoCloudDevID)
 	firmwareVersion := firmwareVersionFromDevice(device)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2060,6 +2060,82 @@ func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 	}
 }
 
+func TestDeviceTelemetryProxyModeMapsVideoCloudFailure(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"customer@example.com","name":"Customer"},"organizations":[{"id":"org-acme","name":"Acme Smart Camera","role":"owner"}]}`))
+		case "/v1/orgs/org-acme/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"activated","status":"online","video_cloud_devid":"device-2"}]}`))
+		default:
+			t.Fatalf("unexpected account path: %s", r.URL.Path)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/query_camera_activate":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":  "ok",
+				"devices": []string{"1"},
+			})
+		case "/api/devices/device-2/telemetry":
+			http.Error(w, "telemetry unavailable", http.StatusServiceUnavailable)
+		case "/get_camera_info":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"info": map[string]any{
+					"firmware_version":  "v1.2.3",
+					"current_transport": "websocket",
+				},
+			})
+		default:
+			t.Fatalf("unexpected video path: %s", r.URL.Path)
+		}
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := NewWithOptions(st, Options{
+		Config: config.Config{
+			AccountManagerBaseURL: accountUpstream.URL,
+			VideoCloudBaseURL:     videoUpstream.URL,
+			VideoCloudAdminToken:  "vc-secret",
+		},
+		AccountClient: accountclient.New(accountUpstream.URL),
+		VideoClient:   videoclient.New(videoUpstream.URL),
+	})
+	session, err := st.CreateSession("customer", "u1", "customer@example.com", "access", "refresh", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/dev-002/telemetry", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("proxy telemetry status = %d, want %d; body=%s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Video Cloud request failed") {
+		t.Fatalf("proxy telemetry body = %s", rec.Body.String())
+	}
+}
+
 func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -83,6 +83,9 @@ func TestDisabledClient(t *testing.T) {
 	if _, err := client.QueryFirmwareCampaigns(t.Context(), "tok", "cam-a", false); err == nil {
 		t.Fatal("expected disabled QueryFirmwareCampaigns error")
 	}
+	if _, err := client.DeviceTelemetry(t.Context(), "tok", "d1", "org-1"); err == nil {
+		t.Fatal("expected disabled DeviceTelemetry error")
+	}
 }
 
 func TestQueryActivation(t *testing.T) {
@@ -212,6 +215,26 @@ func TestGetDeviceInfo(t *testing.T) {
 	}
 	if info.FirmwareVersion != "v1.2.3" {
 		t.Fatalf("FirmwareVersion = %q, want v1.2.3", info.FirmwareVersion)
+	}
+}
+
+func TestGetDeviceInfoMissingInfoReturnsEmptyValues(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/get_camera_info" {
+			t.Fatalf("path = %q, want /get_camera_info", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+	}))
+	defer upstream.Close()
+
+	info, err := New(upstream.URL).GetDeviceInfo(t.Context(), "secret", "cam-1")
+	if err != nil {
+		t.Fatalf("GetDeviceInfo error: %v", err)
+	}
+	if info.CurrentTransport != "" || info.FirmwareVersion != "" {
+		t.Fatalf("info = %+v, want empty values", info)
 	}
 }
 
@@ -375,6 +398,36 @@ func TestDeviceTelemetry(t *testing.T) {
 	}
 	if len(response.RSSIHistory) != 1 || len(response.UptimeHistory) != 1 || len(response.RecentEvents) != 1 {
 		t.Fatalf("unexpected telemetry lengths: rssi=%d uptime=%d events=%d", len(response.RSSIHistory), len(response.UptimeHistory), len(response.RecentEvents))
+	}
+}
+
+func TestDeviceTelemetryOmitsEmptyOrgQuery(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/devices/cam-1/telemetry" {
+			t.Fatalf("path = %q, want /api/devices/cam-1/telemetry", r.URL.Path)
+		}
+		if got := r.URL.RawQuery; got != "" {
+			t.Fatalf("raw query = %q, want empty", got)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q, want Bearer secret", got)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status":      "ok",
+			"device_id":   "cam-1",
+			"device_name": "Front Door",
+		})
+	}))
+	defer upstream.Close()
+
+	response, err := New(upstream.URL).DeviceTelemetry(t.Context(), "secret", "cam-1", "")
+	if err != nil {
+		t.Fatalf("DeviceTelemetry error: %v", err)
+	}
+	if response.DeviceID != "cam-1" {
+		t.Fatalf("DeviceID = %q, want cam-1", response.DeviceID)
 	}
 }
 

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -37,3 +37,53 @@ test('postJSON throws on failed quota raise responses', async () => {
 
   globalThis.fetch = originalFetch;
 });
+
+test('postJSON returns parsed JSON for successful responses', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    assert.equal(url, '/api/auth/customer/login');
+    assert.equal(init.method, 'POST');
+    assert.equal(init.headers['Content-Type'], 'application/json');
+    assert.equal(init.body, JSON.stringify({ email: 'owner@example.com' }));
+    return {
+      ok: true,
+      status: 200,
+      text: async () => '{"status":"ok","user":{"email":"owner@example.com"}}',
+    };
+  };
+
+  const payload = await postJSON('/api/auth/customer/login', { email: 'owner@example.com' });
+  assert.deepEqual(payload, {
+    status: 'ok',
+    user: { email: 'owner@example.com' },
+  });
+
+  globalThis.fetch = originalFetch;
+});
+
+test('postJSON returns null for successful empty responses', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({
+    ok: true,
+    status: 204,
+    text: async () => '',
+  });
+
+  assert.equal(await postJSON('/api/auth/customer/resend-verification', { email: 'owner@example.com' }), null);
+
+  globalThis.fetch = originalFetch;
+});
+
+test('postJSON propagates network failures', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new TypeError('network unavailable');
+  };
+
+  await assert.rejects(
+    () => postJSON('/api/auth/customer/login', { email: 'owner@example.com' }),
+    /network unavailable/,
+  );
+
+  globalThis.fetch = originalFetch;
+});

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -12,7 +12,9 @@ test('maps platform shell paths to platform routes', () => {
 test('maps public signup paths to auth routes', () => {
   assert.equal(routeFromPath('/signup'), 'signup');
   assert.equal(routeFromPath('/signup/check-email'), 'signup-check-email');
+  assert.equal(routeFromPath('/signup/check-email/inbox'), 'signup-check-email');
   assert.equal(routeFromPath('/verify'), 'verify');
+  assert.equal(routeFromPath('/verify/token-1'), 'verify');
 });
 
 test('maps customer shell paths to customer routes', () => {
@@ -28,4 +30,30 @@ test('maps customer shell paths to customer routes', () => {
 
 test('uses fleet health overview title for the customer landing page', () => {
   assert.equal(titleFor('overview'), 'Fleet Health Overview');
+});
+
+test('falls back unknown paths to the customer overview route', () => {
+  assert.equal(routeFromPath('/'), 'overview');
+  assert.equal(routeFromPath('/console/unknown'), 'overview');
+  assert.equal(routeFromPath('/admin/unknown'), 'overview');
+});
+
+test('provides titles for all public shell routes', () => {
+  for (const route of [
+    'signup',
+    'signup-check-email',
+    'verify',
+    'overview',
+    'devices',
+    'operations',
+    'firmware-ota',
+    'stream-health',
+    'groups',
+    'platform-health',
+    'platform-operations',
+    'platform-audit',
+  ]) {
+    assert.equal(typeof titleFor(route), 'string', route);
+    assert.notEqual(titleFor(route), '');
+  }
 });


### PR DESCRIPTION
## Summary\n- run frontend tests in CI and add a Go total coverage gate at 65%\n- expand Account Manager, Video Cloud, telemetry, route, and postJSON regression coverage\n- map Video Cloud telemetry upstream failures to the existing 502 customer error response\n- document coverage commands and test policy in README\n\n## Validation\n- go test ./...\n- go build ./cmd/server\n- go test ./... -coverprofile=/tmp/rtk_cloud_admin_coverage.out, total coverage 66.8%\n- npm test --prefix web\n- npm run build --prefix web\n- git diff --check