### PR TITLE
[Streaming] Align admin dashboard with WebRTC-only stream stats

### DIFF
--- a/docs/admin-dashboard-redesign.md
+++ b/docs/admin-dashboard-redesign.md
@@ -307,9 +307,7 @@ Answer: "Are my devices' video streams actually working for end users?"
 
 ### Stream Success Rate Trend
 
-7d / 30d line chart: daily stream request count vs. success rate (%).
-
-Break down by mode: RTSP / Relay / WebRTC on the same chart using three lines.
+7d / 30d line chart: daily WebRTC stream request count vs. success rate (%).
 
 ### Per-Device Stream Table
 
@@ -318,7 +316,7 @@ Devices sorted by stream failure rate descending (worst first):
 | Column | Content |
 |---|---|
 | Device | name |
-| Mode Used | most common stream mode |
+| Mode Used | WebRTC |
 | Success Rate (7d) | % |
 | Total Requests (7d) | count |
 | Last Stream | timestamp |
@@ -472,9 +470,7 @@ Response:
   "active_sessions": 3,
   "never_streamed_count": 2,
   "by_mode": {
-    "rtsp":   { "requests": 120, "success_rate_pct": 96.7 },
-    "relay":  { "requests": 45,  "success_rate_pct": 91.1 },
-    "webrtc": { "requests": 18,  "success_rate_pct": 88.9 }
+    "webrtc": { "requests": 183, "success_rate_pct": 94.1 }
   },
   "trend": [
     {
@@ -494,10 +490,10 @@ Response:
 }
 ```
 
-Data source: new stream session event log in rtk_video_cloud, recording each
-`/request_stream` and `/api/request_webrtc` call outcome (success/failure,
-mode, duration). rtk_video_cloud must expose a query API or push aggregated
-facts to rtk_cloud_admin.
+Data source: new WebRTC session event log in rtk_video_cloud, recording each
+`/api/request_webrtc` call outcome (success/failure and duration).
+rtk_video_cloud must expose a query API or push aggregated facts to
+rtk_cloud_admin.
 
 ### `GET /api/devices/{id}/telemetry`
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -129,8 +129,6 @@ func (s *Server) routes() {
 }
 
 const (
-	streamModeRTSP   = "rtsp"
-	streamModeRelay  = "relay"
 	streamModeWebRTC = "webrtc"
 )
 
@@ -1194,18 +1192,12 @@ func parseFleetWindow(raw string) (string, int, error) {
 
 func fleetStreamStats(orgID string, devices []contracts.Device, days int, window string) contracts.FleetStreamStats {
 	byMode := map[string]contracts.FleetStreamStatsMode{
-		streamModeRTSP:   {Requests: 0, SuccessRatePct: 0},
-		streamModeRelay:  {Requests: 0, SuccessRatePct: 0},
 		streamModeWebRTC: {Requests: 0, SuccessRatePct: 0},
 	}
 	modeTrendRequests := map[string][]int{
-		streamModeRTSP:   make([]int, days),
-		streamModeRelay:  make([]int, days),
 		streamModeWebRTC: make([]int, days),
 	}
 	modeTrendSuccesses := map[string][]int{
-		streamModeRTSP:   make([]int, days),
-		streamModeRelay:  make([]int, days),
 		streamModeWebRTC: make([]int, days),
 	}
 	type modeAccumulator struct {
@@ -1223,8 +1215,6 @@ func fleetStreamStats(orgID string, devices []contracts.Device, days int, window
 		never        bool
 	}
 	modeStats := map[string]modeAccumulator{
-		streamModeRTSP:   {},
-		streamModeRelay:  {},
 		streamModeWebRTC: {},
 	}
 	deviceStats := make(map[string]*deviceAccumulator, len(devices))
@@ -1294,8 +1284,8 @@ func fleetStreamStats(orgID string, devices []contracts.Device, days int, window
 			SuccessRatePct: streamRate(stats.successes, stats.requests),
 		}
 	}
-	modeTrendSeries := make([]contracts.FleetStreamModeTrend, 0, 3)
-	for _, mode := range []string{streamModeRTSP, streamModeRelay, streamModeWebRTC} {
+	modeTrendSeries := make([]contracts.FleetStreamModeTrend, 0, 1)
+	for _, mode := range []string{streamModeWebRTC} {
 		series := make([]contracts.FleetStreamTrendPoint, 0, days)
 		for day := 0; day < days; day++ {
 			requests := modeTrendRequests[mode][day]
@@ -1382,14 +1372,7 @@ func streamProfile(index int, device contracts.Device) streamProfileData {
 		baseRequests = 2
 		baseSuccess = 55
 	}
-	switch index % 3 {
-	case 0:
-		return streamProfileData{mode: streamModeRTSP, baseRequest: baseRequests, successRate: baseSuccess, never: never}
-	case 1:
-		return streamProfileData{mode: streamModeRelay, baseRequest: baseRequests - 1, successRate: math.Min(baseSuccess+4, 100), never: never}
-	default:
-		return streamProfileData{mode: streamModeWebRTC, baseRequest: baseRequests - 2, successRate: math.Max(baseSuccess-8, 0), never: never}
-	}
+	return streamProfileData{mode: streamModeWebRTC, baseRequest: baseRequests, successRate: baseSuccess, never: never}
 }
 
 func streamDevicesForDay(day, totalDevices, index int, device contracts.Device, _ bool) (int, int, int) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1353,22 +1353,26 @@ func TestFleetStreamStatsDemoDefaultsTo7d(t *testing.T) {
 	if len(payload.Trend) != 7 {
 		t.Fatalf("trend length = %d, want %d", len(payload.Trend), 7)
 	}
-	for _, mode := range []string{"rtsp", "relay", "webrtc"} {
-		stats, ok := payload.ByMode[mode]
-		if !ok {
-			t.Fatalf("by_mode is missing key %q", mode)
-		}
-		if stats.Requests < 0 {
-			t.Fatalf("by_mode.%s.requests = %d, want >=0", mode, stats.Requests)
-		}
-		if stats.SuccessRatePct < 0 || stats.SuccessRatePct > 100 {
-			t.Fatalf("by_mode.%s.success_rate_pct = %f, want 0..100", mode, stats.SuccessRatePct)
-		}
+	if len(payload.ByMode) != 1 {
+		t.Fatalf("by_mode length = %d, want only webrtc: %+v", len(payload.ByMode), payload.ByMode)
 	}
-	if len(payload.TrendByMode) != 3 {
-		t.Fatalf("trend_by_mode length = %d, want %d", len(payload.TrendByMode), 3)
+	stats, ok := payload.ByMode["webrtc"]
+	if !ok {
+		t.Fatalf("by_mode is missing webrtc: %+v", payload.ByMode)
+	}
+	if stats.Requests < 0 {
+		t.Fatalf("by_mode.webrtc.requests = %d, want >=0", stats.Requests)
+	}
+	if stats.SuccessRatePct < 0 || stats.SuccessRatePct > 100 {
+		t.Fatalf("by_mode.webrtc.success_rate_pct = %f, want 0..100", stats.SuccessRatePct)
+	}
+	if len(payload.TrendByMode) != 1 {
+		t.Fatalf("trend_by_mode length = %d, want only webrtc", len(payload.TrendByMode))
 	}
 	for _, series := range payload.TrendByMode {
+		if series.Mode != "webrtc" {
+			t.Fatalf("trend_by_mode mode = %q, want webrtc", series.Mode)
+		}
 		if len(series.Points) != 7 {
 			t.Fatalf("trend_by_mode[%s] length = %d, want %d", series.Mode, len(series.Points), 7)
 		}
@@ -1432,10 +1436,13 @@ func TestFleetStreamStatsWindow30dAndOrgScope(t *testing.T) {
 	if len(payload.Trend) != 30 {
 		t.Fatalf("trend length = %d, want %d", len(payload.Trend), 30)
 	}
-	if len(payload.TrendByMode) != 3 {
-		t.Fatalf("trend_by_mode length = %d, want %d", len(payload.TrendByMode), 3)
+	if len(payload.TrendByMode) != 1 {
+		t.Fatalf("trend_by_mode length = %d, want only webrtc", len(payload.TrendByMode))
 	}
 	for _, series := range payload.TrendByMode {
+		if series.Mode != "webrtc" {
+			t.Fatalf("trend_by_mode mode = %q, want webrtc", series.Mode)
+		}
 		if len(series.Points) != 30 {
 			t.Fatalf("trend_by_mode[%s] length = %d, want %d", series.Mode, len(series.Points), 30)
 		}
@@ -1444,8 +1451,8 @@ func TestFleetStreamStatsWindow30dAndOrgScope(t *testing.T) {
 		if dev.DeviceID == "dev-003" || dev.DeviceID == "dev-004" {
 			t.Fatalf("worst_devices includes out-of-org device %q", dev.DeviceID)
 		}
-		if dev.ModeUsed == "" {
-			t.Fatalf("worst device %q missing mode_used", dev.DeviceID)
+		if dev.ModeUsed != "webrtc" {
+			t.Fatalf("worst device %q mode_used = %q, want webrtc", dev.DeviceID, dev.ModeUsed)
 		}
 	}
 }
@@ -1488,6 +1495,11 @@ func TestFleetStreamStatsWorstDevicesSortedAsc(t *testing.T) {
 	for i := 1; i < len(payload.WorstDevices); i++ {
 		if payload.WorstDevices[i-1].SuccessRatePct > payload.WorstDevices[i].SuccessRatePct {
 			t.Fatalf("worst_devices not sorted asc at index %d: %f > %f", i, payload.WorstDevices[i-1].SuccessRatePct, payload.WorstDevices[i].SuccessRatePct)
+		}
+	}
+	for _, dev := range payload.WorstDevices {
+		if dev.ModeUsed != "webrtc" {
+			t.Fatalf("worst device %q mode_used = %q, want webrtc", dev.DeviceID, dev.ModeUsed)
 		}
 	}
 }
@@ -1857,6 +1869,12 @@ func TestFleetFirmwareDistributionProxyModeUsesAlternateRolloutKeys(t *testing.T
 func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 	t.Parallel()
 
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	uptimeSampleDay1 := today.AddDate(0, 0, -2)
+	uptimeSampleDay2 := today.AddDate(0, 0, -1)
+	uptimeSampleDate1 := uptimeSampleDay1.Format("2006-01-02")
+	uptimeSampleDate2 := uptimeSampleDay2.Format("2006-01-02")
+
 	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/v1/me":
@@ -1914,12 +1932,12 @@ func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 					},
 				},
 				"rssi_history": []map[string]any{
-					{"occurred_at": "2026-05-01T10:00:00Z", "rssi_dbm": -68, "quality": "fair"},
-					{"occurred_at": "2026-05-02T10:00:00Z", "rssi_dbm": -72, "quality": "fair"},
+					{"occurred_at": uptimeSampleDay1.Add(10 * time.Hour).Format(time.RFC3339), "rssi_dbm": -68, "quality": "fair"},
+					{"occurred_at": uptimeSampleDay2.Add(10 * time.Hour).Format(time.RFC3339), "rssi_dbm": -72, "quality": "fair"},
 				},
 				"uptime_history": []map[string]any{
-					{"occurred_at": "2026-05-01T10:00:00Z", "uptime_seconds": 3600},
-					{"occurred_at": "2026-05-02T10:00:00Z", "uptime_seconds": 7200},
+					{"occurred_at": uptimeSampleDay1.Add(10 * time.Hour).Format(time.RFC3339), "uptime_seconds": 3600},
+					{"occurred_at": uptimeSampleDay2.Add(10 * time.Hour).Format(time.RFC3339), "uptime_seconds": 7200},
 				},
 				"recent_events": []map[string]any{
 					{
@@ -2049,11 +2067,11 @@ func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 		}
 		uptimeByDate[sample.Date] = sample.OnlinePct
 	}
-	if got := uptimeByDate["2026-05-01"]; got != 4.2 {
-		t.Fatalf("online_pct for 2026-05-01 = %.1f, want 4.2", got)
+	if got := uptimeByDate[uptimeSampleDate1]; got != 4.2 {
+		t.Fatalf("online_pct for %s = %.1f, want 4.2", uptimeSampleDate1, got)
 	}
-	if got := uptimeByDate["2026-05-02"]; got != 8.3 {
-		t.Fatalf("online_pct for 2026-05-02 = %.1f, want 8.3", got)
+	if got := uptimeByDate[uptimeSampleDate2]; got != 8.3 {
+		t.Fatalf("online_pct for %s = %.1f, want 8.3", uptimeSampleDate2, got)
 	}
 	if len(payload.RecentEvents) != 2 || payload.RecentEvents[0].EventType != "device.reboot.reported" {
 		t.Fatalf("recent_events = %+v", payload.RecentEvents)

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1023,7 +1023,7 @@ function StreamHealthPage({ loading, stats, streamWindow, setWindow }) {
             <div className="panel-head">
               <div>
                 <h3>Success trend</h3>
-                <p>Daily request volume with overall and per-mode success-rate lines.</p>
+                <p>Daily WebRTC request volume and success-rate lines.</p>
               </div>
             </div>
 
@@ -1032,8 +1032,6 @@ function StreamHealthPage({ loading, stats, streamWindow, setWindow }) {
                 <div className="stream-chart-legend">
                   <span><i className="legend-bar legend-requests" /> Requests</span>
                   <span><i className="legend-line legend-overall" /> Overall</span>
-                  <span><i className="legend-line legend-rtsp" /> RTSP</span>
-                  <span><i className="legend-line legend-relay" /> Relay</span>
                   <span><i className="legend-line legend-webrtc" /> WebRTC</span>
                 </div>
                 <svg viewBox="0 0 720 300" className="trend-chart stream-trend-chart" role="img" aria-label="Stream success trend chart">
@@ -1077,14 +1075,14 @@ function StreamHealthPage({ loading, stats, streamWindow, setWindow }) {
                   <text x="700" y="34" textAnchor="end" className="chart-axis-label">{chart.maxRequests}</text>
                   <text x="700" y="228" textAnchor="end" className="chart-axis-label">0</text>
                 </svg>
-                <p className="chart-footnote">Bars show request volume; lines show the overall and mode-level success rate for the selected window.</p>
+                <p className="chart-footnote">Bars show WebRTC request volume; lines show the overall and WebRTC success rate for the selected window.</p>
               </>
             ) : (
               <p className="empty-state">No stream data yet.</p>
             )}
 
             <div className="stream-mode-summary">
-              {['rtsp', 'relay', 'webrtc'].map((mode) => {
+              {['webrtc'].map((mode) => {
                 const statsForMode = byMode[mode] || {};
                 return (
                   <div key={mode} className="stream-mode-summary__item">
@@ -2514,7 +2512,7 @@ function buildStreamHealthChart(trend, modeTrends) {
       requestBarHeight: barHeight,
     };
   });
-  const modeOrder = ['rtsp', 'relay', 'webrtc'];
+  const modeOrder = ['webrtc'];
   const modeSeries = modeOrder.map((mode) => {
     const series = modeTrends.find((item) => String(item.mode || item.Mode || '').toLowerCase() === mode);
     const pointsForMode = (series?.points || series?.Points || []).map((point, index) => {
@@ -2549,8 +2547,6 @@ function buildStreamHealthChart(trend, modeTrends) {
 function streamModeLabel(mode) {
   const key = String(mode || '').toLowerCase();
   const map = {
-    rtsp: 'RTSP',
-    relay: 'Relay',
     webrtc: 'WebRTC',
   };
   return map[key] || toTitleCase(String(mode || '').replaceAll('_', ' '));

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -463,14 +463,6 @@ p {
   background: var(--brand);
 }
 
-.legend-rtsp {
-  background: #0b7285;
-}
-
-.legend-relay {
-  background: #9c36b5;
-}
-
 .legend-webrtc {
   background: #f08c00;
 }
@@ -481,14 +473,6 @@ p {
 
 .chart-line-overall {
   stroke: var(--brand);
-}
-
-.chart-line-rtsp {
-  stroke: #0b7285;
-}
-
-.chart-line-relay {
-  stroke: #9c36b5;
 }
 
 .chart-line-webrtc {


### PR DESCRIPTION
## Summary
- remove RTSP/Relay stream stats modes from backend demo aggregation
- show only WebRTC stream trend and mode summary in the admin dashboard
- update admin dashboard docs so active stream stats are WebRTC-only
- stabilize telemetry proxy test dates inside the rolling 7-day window

Closes #54

## Validation
- go test ./internal/app -run 'TestFleetStreamStatsDemoDefaultsTo7d|TestFleetStreamStatsWindow30dAndOrgScope|TestFleetStreamStatsWorstDevicesSortedAsc' -count=1
- go test ./...
- go build ./cmd/server
- npm test --prefix web
- npm run build --prefix web
- git diff --check
- rg active RTSP/Relay references in internal, web/src, docs, README: no matches
