### PR TITLE
[codex] Complete backend API contracts

### DIFF
--- a/docs/backend-api-gap-audit.md
+++ b/docs/backend-api-gap-audit.md
@@ -1,0 +1,117 @@
+# Backend API Gap Audit
+
+Date: 2026-05-09
+
+Source documents:
+
+- `docs/SPEC.md`
+- `docs/ROLES.md`
+- `docs/admin-dashboard-redesign.md`
+
+Scope: backend API contracts needed by customer dashboard, platform dashboard,
+membership, quota, and device detail flows. WebUI-only entry points and visual
+design are called out separately.
+
+## Status Legend
+
+- `implemented`: API exists and has the fields/guards required for v0.1.
+- `partially implemented`: API exists but needs contract or authorization work.
+- `missing`: backend API does not exist.
+- `deferred / out of scope`: explicitly not part of this backend API batch.
+
+## Route Inventory
+
+| Area | Endpoint | Current status | Notes |
+| --- | --- | --- | --- |
+| Current user | `GET /api/me` | implemented | Stable response shape includes `user_id`, `email`, `name`, `kind`, `memberships`, `active_org_id`, `demo_mode`, and `authenticated`. Demo and platform sessions return `memberships` as an array. |
+| Current user | `POST /api/me/active-org` | implemented | Customer sessions can only switch to organizations in their membership set. Demo mode now uses the same membership guard. |
+| Quota | `POST /api/orgs/{orgId}/quota-raise-requests` | implemented | Requires customer session, targets only the active org, and maps upstream failures to stable gateway responses. |
+| Customer dashboard | `GET /api/summary` | implemented | Demo/cache mode and Account Manager customer mode are supported. |
+| Customer dashboard | `GET /api/customers` | implemented | Returns active customer organization summary for customer sessions; public demo fallback remains available without a customer session. |
+| Customer dashboard | `GET /api/devices` | implemented | Returns device organization, readiness, firmware version, source facts, health, and signal quality fields. Customer sessions are org-scoped. |
+| Device detail | `GET /api/devices/{id}` | implemented | Includes identity, readiness, firmware version, health, signal quality, timestamps, and readiness source facts. Customer sessions cannot read out-of-org devices. |
+| Device telemetry | `GET /api/devices/{id}/telemetry` | implemented | Supports demo and Video Cloud proxy mode. |
+| Fleet health | `GET /api/fleet/health-summary` | implemented | Covers dashboard health overview and trend needs from the redesign spec. |
+| Fleet stream | `GET /api/fleet/stream-stats` | implemented | Covers stream health summary and worst-device read model. |
+| Firmware | `GET /api/fleet/firmware-distribution` | implemented | Covers firmware distribution and rollout status summary. |
+| Platform dashboard | `GET /api/admin/summary` | implemented | Platform-admin protected. Returns cross-tenant customer/device/operation summary. |
+| Platform dashboard | `GET /api/admin/customers` | implemented | Platform-admin protected. Returns organization id/name, totals, readiness buckets, and last seen. |
+| Platform dashboard | `GET /api/admin/devices` | implemented | Platform-admin protected. Returns all device read models with organization, readiness, firmware, health, signal quality, and source facts. |
+| Platform operations | `GET /api/admin/operations` | implemented | Platform-admin protected. |
+| Platform audit | `GET /api/admin/audit` | implemented | Platform-admin protected. |
+| Service health | `GET /api/admin/service-health` | implemented | Platform-admin protected cross-service health. |
+
+## v0.1 Backend API Items
+
+### Membership and Quota Contract
+
+Status: implemented.
+
+The backend now stabilizes `/api/me` for unauthenticated demo users, customer
+sessions, and platform-admin sessions. Membership objects contain:
+
+- `organization_id`
+- `organization`
+- `role`
+- `tier`
+- `evaluation_device_quota`
+
+`POST /api/me/active-org` rejects organizations outside the current membership
+set in both Account Manager proxy mode and local demo mode.
+
+Quota raise requests are scoped to the active organization and return stable
+errors for non-active organizations and Account Manager failures.
+
+### Platform Admin Read Models
+
+Status: implemented.
+
+The platform admin dashboard can read:
+
+- `GET /api/admin/summary`
+- `GET /api/admin/customers`
+- `GET /api/admin/devices`
+
+These endpoints are guarded by `platform_admin` sessions. Customer sessions are
+rejected and unauthenticated requests return `401`.
+
+The device read model is additive and includes customer organization, readiness,
+firmware version, source facts, health, signal quality, last seen, and updated
+timestamps.
+
+### Device Detail Contract
+
+Status: implemented.
+
+`GET /api/devices/{id}` includes:
+
+- device identity: `id`, `name`, `serial_number`, `model`, `organization_id`,
+  `organization`
+- readiness state
+- firmware version
+- health and signal quality
+- `last_seen_at` and `updated_at`
+- source facts with `layer`, `state`, `detail`, `retryable`, `error_code`,
+  `operation_id`, and `updated_at` where available
+
+The contract is additive and does not remove existing fields. Customer sessions
+are scoped to the active organization.
+
+## Frontend-Only Gaps
+
+These items are not backend API gaps:
+
+- Missing navigation or UI affordances for already implemented endpoints.
+- WebUI redesign, Figma files, mockups, and visual layout work.
+- Any table column that can be rendered from existing backend DTO fields.
+
+## Deferred / Out of Scope
+
+These are intentionally not part of the v0.1 backend API batch:
+
+- Role assignment UI and write APIs.
+- Read-only Observer role model.
+- Tenant impersonation.
+- Device groups API.
+- WebUI redesign or design artifacts.
+- Tenant write actions from platform admin endpoints.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -243,10 +243,26 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if session.Kind == "platform_admin" {
-		writeJSON(w, contracts.Me{UserID: session.Subject, Email: session.Email, Name: session.Email, Kind: session.Kind, Authenticated: true})
+		writeJSON(w, contracts.Me{
+			UserID:        session.Subject,
+			Email:         session.Email,
+			Name:          session.Email,
+			Kind:          session.Kind,
+			Memberships:   []contracts.Membership{},
+			Authenticated: true,
+		})
 		return
 	}
-	me := contracts.Me{UserID: session.Subject, Email: session.Email, Name: session.Email, Kind: session.Kind, ActiveOrgID: session.ActiveOrgID, Authenticated: true}
+	me := contracts.Me{
+		UserID:        session.Subject,
+		Email:         session.Email,
+		Name:          session.Email,
+		Kind:          session.Kind,
+		Memberships:   []contracts.Membership{},
+		ActiveOrgID:   session.ActiveOrgID,
+		DemoMode:      !s.accountClient.Enabled(),
+		Authenticated: true,
+	}
 	if s.accountClient.Enabled() {
 		upstream, tokens, err := s.resolveCustomerProfile(r.Context(), accountclient.Tokens{
 			AccessToken:  session.AccessToken,
@@ -267,6 +283,16 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		me.Name = fallback(upstream.User.Name, upstream.User.Email)
 		for _, org := range upstream.Organizations {
 			me.Memberships = append(me.Memberships, membershipFromOrganization(org))
+		}
+	} else {
+		memberships, err := s.demoMemberships()
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		me.Memberships = memberships
+		if me.ActiveOrgID == "" && len(memberships) > 0 {
+			me.ActiveOrgID = memberships[0].OrganizationID
 		}
 	}
 	writeJSON(w, me)
@@ -305,6 +331,16 @@ func (s *Server) apiActiveOrg(w http.ResponseWriter, r *http.Request) {
 			_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 		}
 		if !organizationAllowed(orgs, body.OrganizationID) {
+			http.Error(w, "organization is not part of the current customer memberships", http.StatusForbidden)
+			return
+		}
+	} else if !s.accountClient.Enabled() {
+		allowed, err := s.demoOrganizationAllowed(body.OrganizationID)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
+		if !allowed {
 			http.Error(w, "organization is not part of the current customer memberships", http.StatusForbidden)
 			return
 		}
@@ -2061,6 +2097,8 @@ func firmwareVersionFromDevice(device contracts.Device) string {
 
 func deviceWithFirmwareVersion(device contracts.Device) contracts.Device {
 	device.FirmwareVersion = firmwareVersionFromDevice(device)
+	device.Health = deviceHealthFromFacts(device)
+	device.SignalQuality = deviceSignalQuality(device)
 	return device
 }
 
@@ -2070,6 +2108,35 @@ func devicesWithFirmwareVersion(devices []contracts.Device) []contracts.Device {
 		out[i] = deviceWithFirmwareVersion(device)
 	}
 	return out
+}
+
+func deviceHealthFromFacts(device contracts.Device) string {
+	hasWarning := false
+	for _, fact := range device.SourceFacts {
+		switch strings.ToLower(strings.TrimSpace(fact.State)) {
+		case "failed":
+			return "critical"
+		case "missing", "pending", "stale":
+			hasWarning = true
+		}
+	}
+	if hasWarning {
+		return "warning"
+	}
+	return telemetryHealthFromReadiness(device.Readiness)
+}
+
+func deviceSignalQuality(device contracts.Device) string {
+	switch deviceHealthFromFacts(device) {
+	case "healthy":
+		return "Good"
+	case "warning":
+		return "Fair"
+	case "critical":
+		return "Poor"
+	default:
+		return "Unknown"
+	}
 }
 
 func (s *Server) apiCustomers(w http.ResponseWriter, r *http.Request) {
@@ -2188,7 +2255,7 @@ func (s *Server) requirePlatformAdmin(w http.ResponseWriter, r *http.Request) (s
 
 func (s *Server) customerSession(r *http.Request) (store.Session, bool) {
 	session, ok := s.requestSession(r)
-	if !ok || session.Kind != "customer" || !s.accountClient.Enabled() {
+	if !ok || session.Kind != "customer" {
 		return store.Session{}, false
 	}
 	return session, true
@@ -2208,6 +2275,23 @@ func (s *Server) serviceHealth(ctx context.Context) []contracts.ServiceHealth {
 }
 
 func (s *Server) customerDevices(ctx context.Context, session store.Session) ([]contracts.Device, error) {
+	if !s.accountClient.Enabled() {
+		orgID, err := s.demoActiveCustomerOrgID(session)
+		if err != nil {
+			return nil, err
+		}
+		devices, err := s.store.ListDevices()
+		if err != nil {
+			return nil, err
+		}
+		out := make([]contracts.Device, 0, len(devices))
+		for _, device := range devices {
+			if device.OrganizationID == orgID {
+				out = append(out, device)
+			}
+		}
+		return out, nil
+	}
 	org, tokens, err := s.activeCustomerOrg(ctx, session)
 	if err != nil {
 		return nil, err
@@ -2346,6 +2430,37 @@ func (s *Server) activeCustomerOrg(ctx context.Context, session store.Session) (
 	tokens := accountclient.Tokens{
 		AccessToken:  session.AccessToken,
 		RefreshToken: session.RefreshToken,
+	}
+	if !s.accountClient.Enabled() {
+		memberships, err := s.demoMemberships()
+		if err != nil {
+			return accountclient.Organization{}, tokens, err
+		}
+		if session.ActiveOrgID != "" {
+			for _, membership := range memberships {
+				if membership.OrganizationID == session.ActiveOrgID {
+					return accountclient.Organization{
+						ID:                    membership.OrganizationID,
+						Name:                  membership.Organization,
+						Role:                  membership.Role,
+						Tier:                  membership.Tier,
+						EvaluationDeviceQuota: membership.EvaluationDeviceQuota,
+					}, tokens, nil
+				}
+			}
+			return accountclient.Organization{}, tokens, errCustomerActiveOrgInvalid
+		}
+		if len(memberships) > 0 {
+			membership := memberships[0]
+			return accountclient.Organization{
+				ID:                    membership.OrganizationID,
+				Name:                  membership.Organization,
+				Role:                  membership.Role,
+				Tier:                  membership.Tier,
+				EvaluationDeviceQuota: membership.EvaluationDeviceQuota,
+			}, tokens, nil
+		}
+		return accountclient.Organization{}, tokens, fmt.Errorf("no accessible organizations available")
 	}
 	var me accountclient.MeResult
 	nextTokens, err := s.customerCall(ctx, tokens, func(token string) error {
@@ -2578,6 +2693,63 @@ func organizationAllowed(orgs []accountclient.Organization, orgID string) bool {
 		}
 	}
 	return false
+}
+
+func (s *Server) demoMemberships() ([]contracts.Membership, error) {
+	customers, err := s.store.ListCustomers()
+	if err != nil {
+		return nil, err
+	}
+	memberships := make([]contracts.Membership, 0, len(customers))
+	for _, customer := range customers {
+		membership := contracts.Membership{
+			OrganizationID: customer.OrganizationID,
+			Organization:   customer.Organization,
+			Role:           "operator",
+			Tier:           "commercial",
+		}
+		if customer.OrganizationID == "org-acme" {
+			membership.Role = "owner"
+			membership.Tier = "evaluation"
+			membership.EvaluationDeviceQuota = 5
+		}
+		memberships = append(memberships, membership)
+	}
+	return memberships, nil
+}
+
+func (s *Server) demoOrganizationAllowed(orgID string) (bool, error) {
+	memberships, err := s.demoMemberships()
+	if err != nil {
+		return false, err
+	}
+	for _, membership := range memberships {
+		if membership.OrganizationID == orgID {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (s *Server) demoActiveCustomerOrgID(session store.Session) (string, error) {
+	if session.ActiveOrgID != "" {
+		allowed, err := s.demoOrganizationAllowed(session.ActiveOrgID)
+		if err != nil {
+			return "", err
+		}
+		if !allowed {
+			return "", errCustomerActiveOrgInvalid
+		}
+		return session.ActiveOrgID, nil
+	}
+	memberships, err := s.demoMemberships()
+	if err != nil {
+		return "", err
+	}
+	if len(memberships) == 0 {
+		return "", fmt.Errorf("no accessible organizations available")
+	}
+	return memberships[0].OrganizationID, nil
 }
 
 func (s *Server) upstreamCustomers(w http.ResponseWriter, r *http.Request) ([]contracts.CustomerSummary, bool) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -625,6 +625,12 @@ func TestDevicesEndpointIncludesFirmwareVersion(t *testing.T) {
 	if devices[0].FirmwareVersion != "v1.2.1" {
 		t.Fatalf("device %q firmware_version = %q, want v1.2.1", devices[0].ID, devices[0].FirmwareVersion)
 	}
+	if devices[0].Health == "" {
+		t.Fatalf("device %q health is empty", devices[0].ID)
+	}
+	if devices[0].SignalQuality == "" {
+		t.Fatalf("device %q signal_quality is empty", devices[0].ID)
+	}
 }
 
 func TestCustomerDevicesInvalidSessionRefreshClearsStoredSession(t *testing.T) {
@@ -977,6 +983,57 @@ func TestDeviceAPIIncludesSourceFacts(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "\"failed\"") {
 		t.Fatalf("device body does not include failed source fact: %s", rec.Body.String())
+	}
+
+	var device contracts.Device
+	if err := json.NewDecoder(rec.Body).Decode(&device); err != nil {
+		t.Fatalf("decode device: %v", err)
+	}
+	if device.ID == "" || device.Name == "" || device.SerialNumber == "" || device.Model == "" || device.OrganizationID == "" || device.Organization == "" {
+		t.Fatalf("device identity is incomplete: %#v", device)
+	}
+	if device.Readiness == "" || device.FirmwareVersion == "" || device.LastSeenAt == "" || device.UpdatedAt == "" {
+		t.Fatalf("device runtime fields are incomplete: %#v", device)
+	}
+	if device.Health == "" || device.SignalQuality == "" {
+		t.Fatalf("device health/signal fields are incomplete: %#v", device)
+	}
+	if len(device.SourceFacts) == 0 {
+		t.Fatalf("device source_facts is empty: %#v", device)
+	}
+	for _, fact := range device.SourceFacts {
+		if fact.Layer == "" || fact.State == "" || fact.Detail == "" || fact.UpdatedAt == "" {
+			t.Fatalf("source fact is incomplete: %#v", fact)
+		}
+	}
+}
+
+func TestCustomerDeviceDetailRejectsOutOfOrgDevice(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u1", "user@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := New(st)
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices/dev-003", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("out-of-org device status = %d, want %d; body=%s", rec.Code, http.StatusNotFound, rec.Body.String())
 	}
 }
 
@@ -2233,6 +2290,215 @@ func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 	srv.ServeHTTP(audit, req)
 	if !strings.Contains(audit.Body.String(), "DeviceProvisionRequested") {
 		t.Fatalf("admin audit body does not contain demo audit events: %s", audit.Body.String())
+	}
+}
+
+func TestPlatformAdminReadModelsIncludeDashboardFields(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession platform_admin returned error: %v", err)
+	}
+	srv := New(st)
+
+	adminRequest := func(path string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d; body=%s", path, rec.Code, http.StatusOK, rec.Body.String())
+		}
+		return rec
+	}
+
+	var summary contracts.Summary
+	if err := json.NewDecoder(adminRequest("/api/admin/summary").Body).Decode(&summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.Customers == 0 || summary.TotalDevices == 0 {
+		t.Fatalf("admin summary missing customer/device counts: %#v", summary)
+	}
+
+	var customers []contracts.CustomerSummary
+	if err := json.NewDecoder(adminRequest("/api/admin/customers").Body).Decode(&customers); err != nil {
+		t.Fatalf("decode customers: %v", err)
+	}
+	if len(customers) == 0 {
+		t.Fatal("admin customers response is empty")
+	}
+	if customers[0].OrganizationID == "" || customers[0].Organization == "" || customers[0].TotalDevices == 0 || customers[0].LastSeenAt == "" {
+		t.Fatalf("admin customer summary is incomplete: %#v", customers[0])
+	}
+
+	var devices []contracts.Device
+	if err := json.NewDecoder(adminRequest("/api/admin/devices").Body).Decode(&devices); err != nil {
+		t.Fatalf("decode devices: %v", err)
+	}
+	if len(devices) == 0 {
+		t.Fatal("admin devices response is empty")
+	}
+	if devices[0].OrganizationID == "" || devices[0].Organization == "" || devices[0].Readiness == "" || devices[0].FirmwareVersion == "" {
+		t.Fatalf("admin device read model is incomplete: %#v", devices[0])
+	}
+	if devices[0].Health == "" || devices[0].SignalQuality == "" || len(devices[0].SourceFacts) == 0 {
+		t.Fatalf("admin device runtime facts are incomplete: %#v", devices[0])
+	}
+}
+
+func TestMeContractStabilizesMembershipShape(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	customerSession, err := st.CreateSession("customer", "u1", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession customer returned error: %v", err)
+	}
+	adminSession, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession platform_admin returned error: %v", err)
+	}
+	srv := New(st)
+
+	checkMe := func(cookie *http.Cookie, wantAuthenticated bool) contracts.Me {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+		if cookie != nil {
+			req.AddCookie(cookie)
+		}
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("/api/me status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+		}
+		var raw map[string]json.RawMessage
+		if err := json.Unmarshal(rec.Body.Bytes(), &raw); err != nil {
+			t.Fatalf("decode raw /api/me: %v", err)
+		}
+		if _, ok := raw["memberships"]; !ok {
+			t.Fatalf("/api/me missing memberships: %s", rec.Body.String())
+		}
+		if len(raw["memberships"]) == 0 || raw["memberships"][0] != '[' {
+			t.Fatalf("/api/me memberships must be an array: %s", rec.Body.String())
+		}
+		var me contracts.Me
+		if err := json.Unmarshal(rec.Body.Bytes(), &me); err != nil {
+			t.Fatalf("decode /api/me: %v", err)
+		}
+		if me.Authenticated != wantAuthenticated {
+			t.Fatalf("authenticated = %v, want %v in %#v", me.Authenticated, wantAuthenticated, me)
+		}
+		return me
+	}
+
+	demo := checkMe(nil, false)
+	if demo.UserID == "" || demo.Email == "" || demo.Name == "" || demo.Kind == "" || demo.ActiveOrgID == "" || len(demo.Memberships) == 0 {
+		t.Fatalf("unauthenticated demo me is incomplete: %#v", demo)
+	}
+	if demo.Memberships[0].OrganizationID == "" || demo.Memberships[0].Organization == "" || demo.Memberships[0].Role == "" || demo.Memberships[0].Tier == "" || demo.Memberships[0].EvaluationDeviceQuota == 0 {
+		t.Fatalf("demo membership is incomplete: %#v", demo.Memberships[0])
+	}
+
+	customer := checkMe(&http.Cookie{Name: "rtk_admin_session", Value: customerSession.ID}, true)
+	if customer.ActiveOrgID != "org-acme" || len(customer.Memberships) == 0 {
+		t.Fatalf("customer me contract is incomplete: %#v", customer)
+	}
+
+	admin := checkMe(&http.Cookie{Name: "rtk_admin_session", Value: adminSession.ID}, true)
+	if admin.Kind != "platform_admin" || admin.Memberships == nil {
+		t.Fatalf("platform admin me contract is incomplete: %#v", admin)
+	}
+}
+
+func TestActiveOrgAndQuotaContractsRejectInvalidOrganizations(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u1", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession customer returned error: %v", err)
+	}
+	srv := New(st)
+
+	switchRec := httptest.NewRecorder()
+	switchReq := httptest.NewRequest(http.MethodPost, "/api/me/active-org", strings.NewReader(`{"organization_id":"org-nova"}`))
+	switchReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(switchRec, switchReq)
+	if switchRec.Code != http.StatusOK {
+		t.Fatalf("active-org valid switch status = %d, want %d; body=%s", switchRec.Code, http.StatusOK, switchRec.Body.String())
+	}
+
+	blockedSwitch := httptest.NewRecorder()
+	blockedReq := httptest.NewRequest(http.MethodPost, "/api/me/active-org", strings.NewReader(`{"organization_id":"org-missing"}`))
+	blockedReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(blockedSwitch, blockedReq)
+	if blockedSwitch.Code != http.StatusForbidden {
+		t.Fatalf("active-org invalid switch status = %d, want %d; body=%s", blockedSwitch.Code, http.StatusForbidden, blockedSwitch.Body.String())
+	}
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/orgs/org-nova/quota-raise-requests" {
+			http.Error(w, "upstream unavailable", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer upstream.Close()
+	proxySrv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	wrongOrg := httptest.NewRecorder()
+	wrongOrgReq := httptest.NewRequest(http.MethodPost, "/api/orgs/org-acme/quota-raise-requests", strings.NewReader(`{"requested_quota":10}`))
+	wrongOrgReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	proxySrv.ServeHTTP(wrongOrg, wrongOrgReq)
+	if wrongOrg.Code != http.StatusForbidden {
+		t.Fatalf("quota wrong org status = %d, want %d; body=%s", wrongOrg.Code, http.StatusForbidden, wrongOrg.Body.String())
+	}
+
+	upstreamFailure := httptest.NewRecorder()
+	upstreamReq := httptest.NewRequest(http.MethodPost, "/api/orgs/org-nova/quota-raise-requests", strings.NewReader(`{"requested_quota":10}`))
+	upstreamReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	proxySrv.ServeHTTP(upstreamFailure, upstreamReq)
+	if upstreamFailure.Code != http.StatusBadGateway {
+		t.Fatalf("quota upstream failure status = %d, want %d; body=%s", upstreamFailure.Code, http.StatusBadGateway, upstreamFailure.Body.String())
+	}
+	if !strings.Contains(upstreamFailure.Body.String(), "Account Manager request failed") {
+		t.Fatalf("quota upstream failure body = %s", upstreamFailure.Body.String())
 	}
 }
 

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -35,6 +35,8 @@ type Device struct {
 	SerialNumber    string         `json:"serial_number"`
 	VideoCloudDevID string         `json:"video_cloud_devid"`
 	FirmwareVersion string         `json:"firmware_version"`
+	Health          string         `json:"health,omitempty"`
+	SignalQuality   string         `json:"signal_quality,omitempty"`
 	Status          string         `json:"status"`
 	Readiness       ReadinessState `json:"readiness"`
 	SourceFacts     []SourceFact   `json:"source_facts"`


### PR DESCRIPTION
## Summary

- Adds a backend API gap audit against SPEC/ROLES/admin dashboard requirements.
- Stabilizes `/api/me`, active-org switching, quota raise scoping, and demo membership behavior.
- Completes device/admin read models with readiness source facts, health, signal quality, and runtime contract tests.

## Validation

- `go test ./...`
- `npm test --prefix web`
- `npm run build --prefix web`
