### PR TITLE
[TestReport] Add CI report candidate import workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,16 +24,25 @@ jobs:
           cache: npm
           cache-dependency-path: web/package-lock.json
 
+      - name: Prepare CI artifacts
+        run: mkdir -p .artifacts/logs .artifacts/report-candidates/docs
+
       - name: Go tests with coverage
-        run: go test ./... -coverprofile=coverage.out
+        run: |
+          set -euo pipefail
+          go test ./... -coverprofile=coverage.out 2>&1 | tee .artifacts/logs/go-test.log
+          echo PASS > .artifacts/logs/go-test.status
 
       - name: Go build
-        run: go build ./cmd/server
+        run: |
+          set -euo pipefail
+          go build ./cmd/server 2>&1 | tee .artifacts/logs/go-build.log
+          echo PASS > .artifacts/logs/go-build.status
 
       - name: Go coverage gate
         run: |
           set -euo pipefail
-          go tool cover -func=coverage.out
+          go tool cover -func=coverage.out 2>&1 | tee .artifacts/logs/go-coverage-gate.log
           total="$(go tool cover -func=coverage.out | awk '/^total:/ { gsub("%", "", $3); print $3 }')"
           awk -v total="$total" -v min="80.0" 'BEGIN {
             if (total < min) {
@@ -41,30 +50,42 @@ jobs:
               exit 1
             }
             printf("Go total coverage %.1f%% meets %.1f%% baseline\n", total, min)
-          }'
+          }' | tee -a .artifacts/logs/go-coverage-gate.log
+          echo PASS > .artifacts/logs/go-coverage-gate.status
 
       - name: Frontend install
         working-directory: web
-        run: npm ci
+        run: |
+          set -euo pipefail
+          npm ci 2>&1 | tee ../.artifacts/logs/frontend-install.log
+          echo PASS > ../.artifacts/logs/frontend-install.status
 
       - name: Frontend tests
         working-directory: web
-        run: npm test
+        run: |
+          set -euo pipefail
+          npm test 2>&1 | tee ../.artifacts/logs/frontend-test.log
+          echo PASS > ../.artifacts/logs/frontend-test.status
 
       - name: Frontend build
         working-directory: web
-        run: npm run build
+        run: |
+          set -euo pipefail
+          npm run build 2>&1 | tee ../.artifacts/logs/frontend-build.log
+          echo PASS > ../.artifacts/logs/frontend-build.status
 
       - name: Docker build
         id: docker_build
         run: |
           image_tag="rtk-cloud-admin:${GITHUB_SHA}"
-          docker build -t "${image_tag}" -t rtk-cloud-admin:ci .
+          docker build -t "${image_tag}" -t rtk-cloud-admin:ci . 2>&1 | tee .artifacts/logs/docker-build.log
           echo "ci_image_tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo PASS > .artifacts/logs/docker-build.status
 
       - name: Container smoke
         run: |
           set -euo pipefail
+          exec > >(tee .artifacts/logs/container-smoke.log) 2>&1
 
           ci_image_tag="${{ steps.docker_build.outputs.ci_image_tag }}"
           if [ -z "${ci_image_tag}" ]; then
@@ -127,6 +148,39 @@ jobs:
 
           docker exec "$container_id" wget -qO- http://127.0.0.1:8080/api/summary | grep -q '"total_devices"'
           docker exec "$container_id" wget -qO- http://127.0.0.1:8080/console | grep -q 'id="root"'
+          echo PASS > .artifacts/logs/container-smoke.status
+
+      - name: Generate test report candidate
+        if: always()
+        run: |
+          set -euo pipefail
+          scripts/generate_test_report.sh coverage.out .artifacts/logs .artifacts/report-candidates/docs/TEST_REPORT.md
+          scripts/validate_test_report.sh .artifacts/report-candidates/docs/TEST_REPORT.md
+
+      - name: Upload test report candidate
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report-candidate
+          path: .artifacts/report-candidates/
+
+      - name: Upload CI diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-diagnostics
+          path: |
+            .artifacts/logs/
+            coverage.out
+
+      - name: Check tracked test report drift
+        run: |
+          set -euo pipefail
+          cmp -s docs/TEST_REPORT.md .artifacts/report-candidates/docs/TEST_REPORT.md || {
+            echo "docs/TEST_REPORT.md is stale. Import the test-report-candidate artifact or update the tracked report." >&2
+            diff -u docs/TEST_REPORT.md .artifacts/report-candidates/docs/TEST_REPORT.md >&2 || true
+            exit 1
+          }
 
       - name: Docker cleanup
         if: always()

--- a/.github/workflows/import-test-report.yml
+++ b/.github/workflows/import-test-report.yml
@@ -1,0 +1,86 @@
+name: import-test-report
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number whose branch should receive the report
+        required: true
+      run_id:
+        description: GitHub Actions run ID that produced the candidate artifact
+        required: true
+      artifact_name:
+        description: Candidate artifact name
+        required: true
+        default: test-report-candidate
+
+permissions:
+  actions: read
+  contents: write
+  pull-requests: read
+
+jobs:
+  import:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve PR branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          set -euo pipefail
+          branch="$(gh pr view "$PR_NUMBER" --json headRefName --jq .headRefName)"
+          owner="$(gh pr view "$PR_NUMBER" --json headRepositoryOwner --jq .headRepositoryOwner.login)"
+          repo_owner="${GITHUB_REPOSITORY_OWNER}"
+          if [ "$owner" != "$repo_owner" ]; then
+            echo "only same-repository PR branches are supported; got owner $owner" >&2
+            exit 1
+          fi
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          git fetch origin "$branch"
+          git checkout "$branch"
+
+      - name: Download candidate artifact
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.run_id }}
+          ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        run: |
+          set -euo pipefail
+          rm -rf .artifacts/imported
+          mkdir -p .artifacts/imported
+          gh run download "$RUN_ID" --name "$ARTIFACT_NAME" --dir .artifacts/imported
+          test -s .artifacts/imported/docs/TEST_REPORT.md
+
+      - name: Import and validate report
+        run: |
+          set -euo pipefail
+          cp .artifacts/imported/docs/TEST_REPORT.md docs/TEST_REPORT.md
+          scripts/validate_test_report.sh docs/TEST_REPORT.md
+          changed="$(git status --short -- docs/TEST_REPORT.md)"
+          extra="$(git status --short --untracked-files=no | awk '$2 != "docs/TEST_REPORT.md" { print }')"
+          if [ -n "$extra" ]; then
+            echo "import workflow would modify files other than docs/TEST_REPORT.md:" >&2
+            echo "$extra" >&2
+            exit 1
+          fi
+          if [ -z "$changed" ]; then
+            echo "docs/TEST_REPORT.md already matches candidate"
+          fi
+
+      - name: Commit and push report
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- docs/TEST_REPORT.md; then
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add docs/TEST_REPORT.md
+          git commit -m "Import CI test report candidate"
+          git push origin "HEAD:${{ steps.pr.outputs.branch }}"

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -1,0 +1,49 @@
+# Test Report
+
+## Summary
+
+| Item | Result |
+|---|---|
+| Go total coverage | 80.1% |
+| Go coverage gate | >= 80.0% |
+| Raw logs | GitHub Actions artifact only |
+| Coverage profile | GitHub Actions artifact only |
+
+## CI Test Matrix
+
+| Area | Command / Check | Result |
+|---|---|---|
+| Backend | `go test ./... -coverprofile=coverage.out` | PASS |
+| Backend | `go build ./cmd/server` | PASS |
+| Backend | Go total coverage >= 80.0% | PASS |
+| Frontend | `npm ci` | PASS |
+| Frontend | `npm test` | PASS |
+| Frontend | `npm run build` | PASS |
+| Docker | Docker image build | PASS |
+| Docker | Container smoke test | PASS |
+
+## Coverage By Package
+
+| Package | Coverage |
+|---|---:|
+| `rtk_cloud_admin/cmd/server` | 0.0% |
+| `rtk_cloud_admin/internal/accountclient` | 91.5% |
+| `rtk_cloud_admin/internal/app` | 79.9% |
+| `rtk_cloud_admin/internal/config` | 100.0% |
+| `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
+| `rtk_cloud_admin/internal/store` | 80.1% |
+| `rtk_cloud_admin/internal/videoclient` | 86.8% |
+
+## Artifact Policy
+
+- Raw command logs are uploaded as CI artifacts and are not committed.
+- Docker output and container smoke diagnostics are uploaded as CI artifacts and are not committed.
+- `coverage.out` is uploaded as a CI artifact and is not committed.
+- This report contains only sanitized summaries and pass/fail outcomes.
+
+## Required Headings
+
+- Summary
+- CI Test Matrix
+- Coverage By Package
+- Artifact Policy

--- a/scripts/generate_test_report.sh
+++ b/scripts/generate_test_report.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+coverage_file="${1:-coverage.out}"
+logs_dir="${2:-.artifacts/logs}"
+output="${3:-.artifacts/report-candidates/docs/TEST_REPORT.md}"
+coverage_min="${COVERAGE_MIN:-80.0}"
+
+status_for_log() {
+  local file="$1"
+  local status_file="${file%.log}.status"
+  if [ -s "$status_file" ]; then
+    cat "$status_file"
+  elif [ -s "$file" ]; then
+    printf "UNKNOWN"
+  else
+    printf "UNKNOWN"
+  fi
+}
+
+total_coverage="unknown"
+if [ -s "$coverage_file" ]; then
+  total_coverage="$(go tool cover -func="$coverage_file" | awk '/^total:/ { print $3 }')"
+fi
+
+mkdir -p "$(dirname "$output")"
+cat > "$output" <<EOF
+# Test Report
+
+## Summary
+
+| Item | Result |
+|---|---|
+| Go total coverage | ${total_coverage} |
+| Go coverage gate | >= ${coverage_min}% |
+| Raw logs | GitHub Actions artifact only |
+| Coverage profile | GitHub Actions artifact only |
+
+## CI Test Matrix
+
+| Area | Command / Check | Result |
+|---|---|---|
+| Backend | \`go test ./... -coverprofile=coverage.out\` | $(status_for_log "$logs_dir/go-test.log") |
+| Backend | \`go build ./cmd/server\` | $(status_for_log "$logs_dir/go-build.log") |
+| Backend | Go total coverage >= ${coverage_min}% | $(status_for_log "$logs_dir/go-coverage-gate.log") |
+| Frontend | \`npm ci\` | $(status_for_log "$logs_dir/frontend-install.log") |
+| Frontend | \`npm test\` | $(status_for_log "$logs_dir/frontend-test.log") |
+| Frontend | \`npm run build\` | $(status_for_log "$logs_dir/frontend-build.log") |
+| Docker | Docker image build | $(status_for_log "$logs_dir/docker-build.log") |
+| Docker | Container smoke test | $(status_for_log "$logs_dir/container-smoke.log") |
+
+## Coverage By Package
+
+| Package | Coverage |
+|---|---:|
+EOF
+
+if [ -s "$logs_dir/go-test.log" ]; then
+  awk '
+    /coverage: [0-9.]+% of statements/ {
+      pkg=""
+      pct=""
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^rtk_cloud_admin\//) pkg=$i
+        if ($i ~ /^[0-9.]+%$/) pct=$i
+      }
+      if (pkg == "" || pct == "") next
+      printf "| `%s` | %s |\n", pkg, pct
+    }
+  ' "$logs_dir/go-test.log" | sort >> "$output"
+fi
+
+cat >> "$output" <<'EOF'
+
+## Artifact Policy
+
+- Raw command logs are uploaded as CI artifacts and are not committed.
+- Docker output and container smoke diagnostics are uploaded as CI artifacts and are not committed.
+- `coverage.out` is uploaded as a CI artifact and is not committed.
+- This report contains only sanitized summaries and pass/fail outcomes.
+
+## Required Headings
+
+- Summary
+- CI Test Matrix
+- Coverage By Package
+- Artifact Policy
+EOF

--- a/scripts/validate_test_report.sh
+++ b/scripts/validate_test_report.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+report="${1:-docs/TEST_REPORT.md}"
+
+if [ ! -s "$report" ]; then
+  echo "test report is missing or empty: $report" >&2
+  exit 1
+fi
+
+for heading in "## Summary" "## CI Test Matrix" "## Coverage By Package" "## Artifact Policy"; do
+  if ! grep -qx "$heading" "$report"; then
+    echo "missing required heading: $heading" >&2
+    exit 1
+  fi
+done
+
+if grep -Eiq '(access_token|refresh_token|authorization: bearer|rtk_admin_session=|password=|password":|secret=|video_cloud_admin_token|admin_bootstrap_password)' "$report"; then
+  echo "test report contains a redaction-sensitive token pattern" >&2
+  exit 1
+fi
+
+if grep -Eq '^\+\+\+|^---|^Step [0-9]+/|docker buildx|Sending build context|Successfully built|coverage mode:|^mode: ' "$report"; then
+  echo "test report appears to contain raw logs or raw coverage data" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- generate sanitized `docs/TEST_REPORT.md` candidates under `.artifacts/report-candidates/docs/`
- upload candidate and raw diagnostics artifacts from CI while keeping raw logs and coverage profile untracked
- check tracked `docs/TEST_REPORT.md` for drift against the generated candidate
- add manual `import-test-report` workflow to import a selected candidate artifact into a PR branch as `github-actions[bot]`

## Verification
- bash -n scripts/generate_test_report.sh scripts/validate_test_report.sh
- ruby YAML parse for `.github/workflows/ci.yml` and `.github/workflows/import-test-report.yml`
- generated candidate from local coverage/log fixtures and diffed against `docs/TEST_REPORT.md`
- scripts/validate_test_report.sh for candidate and tracked report
- go test ./...
- go build ./cmd/server
- npm test --prefix web
- npm ci --prefix web
- npm run build --prefix web

Closes #73
