### PR TITLE
[Docs] Define SSO OIDC architecture for Admin Console

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Implemented in this first version:
 - audit log for local lifecycle actions
 - service health summary
 - customer login/session endpoint backed by Account Manager when configured
-- local platform admin login/session endpoint backed by SQLite
+- legacy local platform admin login/session endpoint backed by SQLite for controlled break-glass access
+- SSO/OIDC architecture documented for the next authentication milestone
 - Account Manager proxy mode for organizations, devices, provision, and deactivate
 - explicit SQLite schema migrations tracked in `schema_migrations`
 - URL routes for `/console`, `/console/customers`, `/console/devices`,
@@ -41,6 +42,13 @@ Implemented in this first version:
 When `ACCOUNT_MANAGER_BASE_URL` is unset, the app runs from SQLite demo/cache
 data. When it is set and a customer signs in, customer, device, and lifecycle
 actions proxy through Account Manager while preserving the current frontend DTOs.
+
+The planned production authentication direction is SSO-only daily login for both
+Customer users and Platform Admins, with Account Manager acting as the OIDC
+identity broker and authorization source. See
+[`docs/sso-oidc-design.md`](docs/sso-oidc-design.md). Existing password login
+paths are legacy compatibility or controlled break-glass surfaces, not the
+long-term production target.
 
 ## Requirements
 
@@ -150,13 +158,13 @@ Environment variables:
 - `ACCOUNT_MANAGER_BASE_URL`: optional upstream Account Manager URL
 - `VIDEO_CLOUD_BASE_URL`: optional upstream Video Cloud URL
 - `VIDEO_CLOUD_ADMIN_TOKEN`: optional upstream Video Cloud admin token
-- `ADMIN_BOOTSTRAP_EMAIL`: optional local platform admin email
-- `ADMIN_BOOTSTRAP_PASSWORD`: optional local platform admin password
+- `ADMIN_BOOTSTRAP_EMAIL`: optional local platform admin break-glass email
+- `ADMIN_BOOTSTRAP_PASSWORD`: optional local platform admin break-glass password
 
 If both admin bootstrap variables are set, startup creates the first local
-platform admin if it does not already exist. Passwords are stored as bcrypt
-hashes. Session rows store metadata and upstream bearer/refresh tokens, never
-plaintext credentials.
+platform admin break-glass account if it does not already exist. Passwords are
+stored as bcrypt hashes. Session rows store metadata and upstream
+bearer/refresh tokens, never plaintext credentials.
 
 SQLite schema changes are applied through versioned migrations. Existing local
 databases are upgraded in place and applied versions are stored in

--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -56,11 +56,13 @@ The remainder of this document covers only Tier 1 and Tier 2 roles.
 
 ## Tier 1 — Realtek Internal Roles
 
-These roles belong to Realtek employees operating the platform. Tier 1
-authenticates via the `/admin` login endpoint (bootstrapped by
-`ADMIN_BOOTSTRAP_EMAIL` / `ADMIN_BOOTSTRAP_PASSWORD` on first run; subsequent
-admins are managed via SQLite). The session cookie is `rtk_admin_session` with
-session kind `platform_admin`. Passwords are stored as bcrypt hashes.
+These roles belong to Realtek employees operating the platform. The long-term
+daily authentication path is Account Manager-backed SSO, where Account Manager
+authorizes the user as `platform_admin` and Admin Console creates the local
+`rtk_admin_session` cookie. The legacy `/admin` password login is retained only
+as controlled break-glass access when explicitly enabled by deployment
+configuration. Break-glass admins are bootstrapped by `ADMIN_BOOTSTRAP_EMAIL` /
+`ADMIN_BOOTSTRAP_PASSWORD`, stored in SQLite, and protected with bcrypt hashes.
 
 ### Platform Admin
 
@@ -97,11 +99,13 @@ These roles belong to the licensed tenant operating their own branded IoT
 product. Tier 2 sessions are org-scoped — users can only see and act on devices
 within their own organization.
 
-Tier 2 authenticates via the customer login endpoint (backed by Account Manager
-when `ACCOUNT_MANAGER_BASE_URL` is set, or local SQLite seed data in demo mode).
-The session cookie is `rtk_admin_session`; the session row carries the upstream
-Bearer / refresh token pair when in proxy mode. Plaintext credentials are never
-persisted.
+Tier 2 daily authentication should use Account Manager-backed SSO. Account
+Manager is responsible for external identity provider discovery, OIDC token
+exchange, user mapping, organization membership, and role authorization. Admin
+Console keeps the existing `rtk_admin_session` cookie; the session row carries
+the upstream Bearer / refresh token pair when in proxy mode. The legacy customer
+password login endpoint is a compatibility path, not the long-term production
+login direction. Plaintext credentials are never persisted.
 
 ### Fleet Manager
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -107,6 +107,9 @@ Data ownership:
 - SQLite is authoritative only for console-local data: platform admins, sessions, audit, settings, preferences, and demo projections.
 - SQLite cache tables for upstream organizations, devices, operations, and readiness facts are non-authoritative mirrors that can be refreshed from Account Manager and Video Cloud.
 - Account Manager remains authoritative for customer users, organizations, membership, and registry devices.
+- Account Manager is also the planned identity broker and authorization source
+  for standards-based SSO; see
+  [`docs/sso-oidc-design.md`](sso-oidc-design.md).
 - Video Cloud remains authoritative for activation, transport, streaming, media, firmware, and device runtime facts.
 
 ## HTTP Interface
@@ -114,8 +117,8 @@ Data ownership:
 Public and shared routes:
 
 - `GET /healthz`: plain health check.
-- `POST /api/auth/customer/login`: customer login through Account Manager when configured.
-- `POST /api/auth/platform/login`: local SQLite platform admin login.
+- `POST /api/auth/customer/login`: legacy customer password login through Account Manager when configured.
+- `POST /api/auth/platform/login`: legacy local SQLite platform admin login for controlled break-glass access.
 - `POST /api/auth/logout`: deletes local session metadata.
 - `GET /api/me`: current user, memberships, active organization, and demo/auth state.
 - `POST /api/me/active-org`: switches active organization for the current session.
@@ -135,9 +138,18 @@ The v0.1 implementation may run without configured upstream services. In that mo
 
 ## Authentication And Sessions
 
+Long-term production authentication is SSO-first. The planned SSO architecture
+uses Account Manager as the OIDC identity broker and role authorization source
+for both Customer users and Platform Admins. Admin Console remains the BFF and
+session owner, creating the existing `rtk_admin_session` cookie after Account
+Manager completes SSO. The design is documented in
+[`docs/sso-oidc-design.md`](sso-oidc-design.md).
+
 Customer sessions:
 
-- customer credentials are posted only to Account Manager login
+- customer password login is legacy; daily production login should use Account
+  Manager-backed SSO
+- while legacy login is enabled, customer credentials are posted only to Account Manager login
 - the BFF stores session metadata plus upstream access/refresh tokens
 - plaintext passwords are never stored
 - `/api/me` returns user, memberships, active organization, and auth state
@@ -146,8 +158,9 @@ Customer sessions:
 
 Platform admin sessions:
 
-- local platform admin users are stored in SQLite
-- `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` create the first admin on startup
+- Platform Admin daily login should use Account Manager-backed SSO
+- local platform admin users are stored in SQLite only for controlled break-glass access
+- `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` create the first break-glass admin on startup
 - passwords are bcrypt hashed
 - platform-only API routes require a `platform_admin` session
 

--- a/docs/sso-oidc-design.md
+++ b/docs/sso-oidc-design.md
@@ -1,0 +1,166 @@
+# RTK Cloud Admin SSO / OIDC Design
+
+Status: proposed source of truth.
+
+Audience:
+
+- `rtk_cloud_admin` frontend and backend developers
+- `rtk_account_manager` backend developers
+- PM / QA
+
+## Summary
+
+RTK Cloud Admin should use standards-based single sign-on for daily
+authentication. The first SSO version covers both Customer users and Platform
+Admins, uses OIDC Authorization Code with PKCE, and treats SAML as a deferred
+enterprise bridge.
+
+Account Manager is the identity broker and authorization source. Admin Console
+does not connect directly to external identity providers and does not trust raw
+IdP claims for product roles. Admin Console consumes Account Manager SSO
+results, creates the existing local `rtk_admin_session` cookie, and continues to
+serve the React BFF APIs from that session.
+
+## Goals
+
+- Customer users and Platform Admins use SSO for daily login.
+- OIDC Authorization Code with PKCE is the first supported protocol.
+- Account Manager owns identity provider discovery, OIDC token exchange,
+  external claim normalization, platform role authorization, customer
+  memberships, and organization context.
+- Admin Console owns the BFF-facing SSO contract, local session creation,
+  WebUI login entry, Platform Admin SSO settings surface, and regression tests.
+- Each customer organization can bring its own OIDC provider.
+- Login uses email domain discovery to find the right organization provider.
+- Platform Admin permissions are granted by Account Manager, not by directly
+  trusting external IdP groups or claims in Admin Console.
+- Daily login is SSO only.
+- Local Platform Admin break-glass access is preserved but disabled by default.
+
+## Non-Goals
+
+- Do not implement OIDC provider configuration, authorization redirects, token
+  exchange, or SAML handling directly in Admin Console.
+- Do not make Admin Console authoritative for users, external identities,
+  organization memberships, or platform role assignment.
+- Do not store external IdP client secrets in the Admin Console SQLite
+  database.
+- Do not implement Customer self-service IdP setup in the first version.
+- Do not implement SAML 2.0 in the first version.
+
+## Ownership Boundaries
+
+Account Manager owns:
+
+- email domain discovery
+- organization-level OIDC provider configuration
+- OIDC Authorization Code with PKCE flow
+- external identity to RTK user mapping
+- organization memberships, roles, tiers, and quota metadata
+- Platform Admin authorization
+- refresh token lifecycle for upstream API access
+- optional future SAML bridge or external identity broker integration
+
+Admin Console owns:
+
+- an email-first SSO login UI
+- BFF endpoints that start and complete the Account Manager SSO flow
+- the local `rtk_admin_session` cookie and session row
+- `/api/me` projection for frontend routing and authorization display
+- Platform Admin UI/API surfaces for viewing and managing customer SSO settings
+- audit records for local session and break-glass events
+- regression tests for the BFF contract and UI behavior
+
+## Login Flow
+
+1. The user opens Admin Console and enters an email address.
+2. Admin Console calls Account Manager to start SSO discovery.
+3. Account Manager maps the verified email domain to an organization OIDC
+   provider and returns an authorization redirect.
+4. The browser completes OIDC login through Account Manager.
+5. Account Manager validates the callback, maps the external identity, resolves
+   roles and memberships, and returns an Admin Console session result.
+6. Admin Console creates the existing `rtk_admin_session` cookie and stores
+   local session metadata plus upstream access and refresh tokens.
+7. The frontend calls `/api/me` and renders either Customer View or Platform
+   View based on the Account Manager-authorized `kind`.
+
+The session kind remains either `customer` or `platform_admin`. Customer
+sessions continue to use `memberships` and `active_org_id`. Platform Admin
+sessions continue to gate platform-only routes through the existing
+`platform_admin` session kind.
+
+## Protocol Strategy
+
+First version:
+
+- OIDC Authorization Code with PKCE.
+- Multi-tenant bring-your-own IdP at the customer organization level.
+- Email domain discovery as the primary routing mechanism.
+- Platform Admin-managed customer SSO settings.
+
+Deferred:
+
+- SAML 2.0 support.
+- Customer self-service IdP setup.
+- Tenant impersonation.
+- Direct trust of external IdP group claims in Admin Console.
+
+SAML should be handled by Account Manager or an external identity broker that
+normalizes SAML into the Account Manager identity model before Admin Console
+sees the login result.
+
+## Admin Console API Contract
+
+Admin Console should add BFF endpoints for the frontend, backed by Account
+Manager APIs:
+
+- `POST /api/auth/sso/start`: accepts an email address, asks Account Manager to
+  start SSO discovery, and returns the authorization redirect details.
+- `GET /api/auth/sso/callback`: accepts Account Manager callback parameters,
+  exchanges them with Account Manager, creates `rtk_admin_session`, and
+  redirects the browser back to the console.
+- `GET /api/auth/sso/providers/status`: lets Platform Admins inspect customer
+  organization SSO status.
+
+Platform Admin provider management endpoints may be added in Admin Console, but
+secrets must be written through Account Manager and must not be stored in the
+Admin Console SQLite database.
+
+The existing `/api/me` shape remains stable:
+
+- `user_id`
+- `email`
+- `name`
+- `kind`
+- `memberships`
+- `active_org_id`
+- `demo_mode`
+- `authenticated`
+
+## Legacy Login And Break-Glass
+
+Daily customer and platform login should move to SSO only. Existing password
+login endpoints are legacy compatibility surfaces and should be disabled by
+default once the SSO flow is implemented.
+
+Local Platform Admin break-glass access remains available for operational
+recovery, but it must be explicitly enabled by deployment configuration. When
+disabled, local platform password login is rejected. When enabled, successful
+and failed break-glass login attempts must be written to audit.
+
+Customer password login should not be used as the long-term production login
+path. Account Manager remains responsible for any migration period or emergency
+customer-account recovery policy.
+
+## Implementation Issues After This Document
+
+After this document is merged, implementation should be split into developer
+issues:
+
+1. Add Account Manager SSO client contract to Admin Console.
+2. Add Console BFF SSO start and callback endpoints.
+3. Enforce SSO-only login with controlled break-glass admin access.
+4. Implement email-first SSO login UI.
+5. Add Platform Admin SSO provider settings view.
+6. Add SSO rollout, audit, and regression coverage.


### PR DESCRIPTION
## Summary
- add docs/sso-oidc-design.md as the SSO/OIDC source of truth
- mark customer/platform password login as legacy or controlled break-glass
- link README, SPEC, and ROLES to the SSO direction

## Validation
- go test ./...
- npm test --prefix web
- npm run build --prefix web