### PR TITLE
[SSO] Enforce SSO-only login policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,7 @@ jobs:
             -e DATABASE_PATH=/data/ci.db \
             -e ADMIN_BOOTSTRAP_EMAIL=admin@example.com \
             -e ADMIN_BOOTSTRAP_PASSWORD=secret \
+            -e ADMIN_BREAK_GLASS_ENABLED=true \
             -v "$smoke_dir:/data" \
             "$ci_image_tag")"
 

--- a/README.md
+++ b/README.md
@@ -160,11 +160,16 @@ Environment variables:
 - `VIDEO_CLOUD_ADMIN_TOKEN`: optional upstream Video Cloud admin token
 - `ADMIN_BOOTSTRAP_EMAIL`: optional local platform admin break-glass email
 - `ADMIN_BOOTSTRAP_PASSWORD`: optional local platform admin break-glass password
+- `ADMIN_BREAK_GLASS_ENABLED`: set to `true` to enable local Platform Admin break-glass login; default `false`
+- `LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED`: set to `true` to enable legacy customer password login; default `false`
 
 If both admin bootstrap variables are set, startup creates the first local
 platform admin break-glass account if it does not already exist. Passwords are
 stored as bcrypt hashes. Session rows store metadata and upstream
 bearer/refresh tokens, never plaintext credentials.
+Break-glass login is rejected unless `ADMIN_BREAK_GLASS_ENABLED=true`, and
+customer password login is rejected unless
+`LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED=true`.
 
 SQLite schema changes are applied through versioned migrations. Existing local
 databases are upgraded in place and applied versions are stored in
@@ -191,6 +196,7 @@ docker run --rm -p 18081:8080 \
   -e VIDEO_CLOUD_ADMIN_TOKEN="replace-me" \
   -e ADMIN_BOOTSTRAP_EMAIL="admin@example.com" \
   -e ADMIN_BOOTSTRAP_PASSWORD="change-me" \
+  -e ADMIN_BREAK_GLASS_ENABLED="true" \
   rtk-cloud-admin
 ```
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -147,8 +147,8 @@ Manager completes SSO. The design is documented in
 
 Customer sessions:
 
-- customer password login is legacy; daily production login should use Account
-  Manager-backed SSO
+- customer password login is legacy and disabled by default; daily production
+  login should use Account Manager-backed SSO
 - while legacy login is enabled, customer credentials are posted only to Account Manager login
 - the BFF stores session metadata plus upstream access/refresh tokens
 - plaintext passwords are never stored
@@ -160,6 +160,7 @@ Platform admin sessions:
 
 - Platform Admin daily login should use Account Manager-backed SSO
 - local platform admin users are stored in SQLite only for controlled break-glass access
+- break-glass login is disabled by default and must be explicitly enabled by deployment configuration
 - `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD` create the first break-glass admin on startup
 - passwords are bcrypt hashed
 - platform-only API routes require a `platform_admin` session
@@ -229,8 +230,10 @@ Environment variables:
 - `ACCOUNT_MANAGER_BASE_URL`: optional upstream Account Manager URL.
 - `VIDEO_CLOUD_BASE_URL`: optional upstream Video Cloud URL.
 - `VIDEO_CLOUD_ADMIN_TOKEN`: optional upstream Video Cloud admin token.
-- `ADMIN_BOOTSTRAP_EMAIL`: optional first local platform admin email.
-- `ADMIN_BOOTSTRAP_PASSWORD`: optional first local platform admin password for development.
+- `ADMIN_BOOTSTRAP_EMAIL`: optional first local platform admin break-glass email.
+- `ADMIN_BOOTSTRAP_PASSWORD`: optional first local platform admin break-glass password for development.
+- `ADMIN_BREAK_GLASS_ENABLED`: enables local Platform Admin break-glass login when set to `true`; default `false`.
+- `LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED`: enables legacy customer password login when set to `true`; default `false`.
 
 ## Test Plan
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.0% |
+| Go total coverage | 80.1% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,7 +28,7 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 91.2% |
-| `rtk_cloud_admin/internal/app` | 79.6% |
+| `rtk_cloud_admin/internal/app` | 79.8% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -46,7 +46,8 @@ If the runner gets stuck or disk usage climbs too high:
    - `curl http://127.0.0.1:18080/healthz`
    - `curl http://127.0.0.1:18080/api/service-health`
    - `curl -X POST http://127.0.0.1:18080/api/auth/platform/login` after
-     setting `ADMIN_BOOTSTRAP_EMAIL` and `ADMIN_BOOTSTRAP_PASSWORD`
+     setting `ADMIN_BOOTSTRAP_EMAIL`, `ADMIN_BOOTSTRAP_PASSWORD`, and
+     `ADMIN_BREAK_GLASS_ENABLED=true`
    - `curl http://127.0.0.1:18080/api/me` after replaying the login cookie
    - `curl http://127.0.0.1:18080/api/summary`
    - `curl http://127.0.0.1:18080/console`

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -93,11 +93,11 @@ checks after startup:
 
 - `GET /healthz` returns `ok`
 - `GET /api/service-health` returns the upstream status summary
-- `POST /api/auth/platform/login` accepts the bootstrap admin credentials
+- `POST /api/auth/platform/login` accepts the bootstrap admin credentials only
+  when `ADMIN_BREAK_GLASS_ENABLED=true`
 - `GET /api/me` succeeds when the login cookie is replayed
 - `GET /api/summary` returns the dashboard summary payload
 - `GET /console` renders the dashboard shell
 
 The CI workflow in this repository mirrors that profile and should be kept in
 sync with any future runtime or auth changes.
-

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -513,6 +513,10 @@ func (s *Server) apiQuotaRaiseRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
+	if !s.cfg.LegacyCustomerPasswordLoginEnabled {
+		http.Error(w, "customer password login is disabled; use SSO", http.StatusForbidden)
+		return
+	}
 	if !s.accountClient.Enabled() {
 		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
 		return
@@ -566,13 +570,24 @@ func (s *Server) apiPlatformLogin(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid login request", http.StatusBadRequest)
 		return
 	}
+	body.Email = strings.TrimSpace(body.Email)
+	if !s.cfg.AdminBreakGlassEnabled {
+		_ = s.auditPlatformBreakGlassLogin(body.Email, "disabled")
+		http.Error(w, "platform break-glass login is disabled; use SSO", http.StatusForbidden)
+		return
+	}
 	admin, err := s.store.VerifyPlatformAdmin(body.Email, body.Password)
 	if err != nil {
+		_ = s.auditPlatformBreakGlassLogin(body.Email, "failed")
 		http.Error(w, "invalid credentials", http.StatusUnauthorized)
 		return
 	}
 	session, err := s.store.CreateSession("platform_admin", admin.ID, admin.Email, "", "", "", 12*time.Hour)
 	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if err := s.auditPlatformBreakGlassLogin(admin.Email, "accepted"); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -2751,6 +2766,16 @@ func (s *Server) writeCustomerError(w http.ResponseWriter, err error) {
 		return
 	}
 	writeError(w, err)
+}
+
+func (s *Server) auditPlatformBreakGlassLogin(email, result string) error {
+	return s.store.CreateAuditEventWithMetadata(store.AuditEventInput{
+		Actor:     fallback(email, "unknown-platform-admin"),
+		ActorKind: "platform_admin",
+		Action:    "PlatformBreakGlassLogin",
+		Target:    "platform_admin",
+		Result:    result,
+	})
 }
 
 func writeSSOError(w http.ResponseWriter, err error) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -215,7 +215,7 @@ func TestSSOStartAndCallbackCreateSessions(t *testing.T) {
 
 	st := mustOpenStore(t)
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -346,6 +346,84 @@ func TestSSOEndpointsMapStableErrors(t *testing.T) {
 	}
 }
 
+func TestLegacyCustomerPasswordLoginDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Fatalf("legacy customer login should not call upstream when disabled: %s", r.URL.Path)
+	}))
+	defer upstream.Close()
+
+	srv := NewWithOptions(mustOpenStore(t), Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("customer login status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "customer password login is disabled") {
+		t.Fatalf("customer login body = %s", rec.Body.String())
+	}
+}
+
+func TestPlatformBreakGlassLoginPolicyAndAudit(t *testing.T) {
+	t.Parallel()
+
+	st := mustOpenStore(t)
+	if err := st.BootstrapPlatformAdmin("admin@example.com", "secret"); err != nil {
+		t.Fatalf("BootstrapPlatformAdmin returned error: %v", err)
+	}
+
+	disabledSrv := NewWithOptions(st, Options{Config: config.Config{}})
+	disabled := httptest.NewRecorder()
+	disabledSrv.ServeHTTP(disabled, httptest.NewRequest(http.MethodPost, "/api/auth/platform/login", strings.NewReader(`{"email":"admin@example.com","password":"secret"}`)))
+	if disabled.Code != http.StatusForbidden {
+		t.Fatalf("disabled break-glass status = %d, body=%s", disabled.Code, disabled.Body.String())
+	}
+
+	failed := httptest.NewRecorder()
+	enabledSrv := NewWithOptions(st, Options{Config: config.Config{AdminBreakGlassEnabled: true}})
+	enabledSrv.ServeHTTP(failed, httptest.NewRequest(http.MethodPost, "/api/auth/platform/login", strings.NewReader(`{"email":"admin@example.com","password":"wrong"}`)))
+	if failed.Code != http.StatusUnauthorized {
+		t.Fatalf("failed break-glass status = %d, body=%s", failed.Code, failed.Body.String())
+	}
+
+	success := httptest.NewRecorder()
+	enabledSrv.ServeHTTP(success, httptest.NewRequest(http.MethodPost, "/api/auth/platform/login", strings.NewReader(`{"email":"admin@example.com","password":"secret"}`)))
+	if success.Code != http.StatusOK {
+		t.Fatalf("break-glass success status = %d, body=%s", success.Code, success.Body.String())
+	}
+	if len(success.Result().Cookies()) == 0 {
+		t.Fatalf("break-glass success did not set session cookie")
+	}
+	session, err := st.GetSession(success.Result().Cookies()[0].Value)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if session.Kind != "platform_admin" {
+		t.Fatalf("session kind = %q, want platform_admin", session.Kind)
+	}
+
+	events, err := st.ListAuditEvents()
+	if err != nil {
+		t.Fatalf("ListAuditEvents returned error: %v", err)
+	}
+	results := map[string]bool{}
+	for _, event := range events {
+		if event.Action == "PlatformBreakGlassLogin" && event.Actor == "admin@example.com" && event.ActorKind == "platform_admin" {
+			results[event.Result] = true
+		}
+	}
+	for _, want := range []string{"disabled", "failed", "accepted"} {
+		if !results[want] {
+			t.Fatalf("missing break-glass audit result %q in %#v", want, events)
+		}
+	}
+}
+
 func mustOpenStore(t *testing.T) *store.Store {
 	t.Helper()
 	st, err := store.Open(t.TempDir() + "/admin.db")
@@ -362,6 +440,13 @@ func mustOpenStore(t *testing.T) *store.Store {
 		_ = st.Close()
 	})
 	return st
+}
+
+func legacyCustomerLoginConfig(baseURL string) config.Config {
+	return config.Config{
+		AccountManagerBaseURL:              baseURL,
+		LegacyCustomerPasswordLoginEnabled: true,
+	}
 }
 
 func TestProvisionActionPublishesOperation(t *testing.T) {
@@ -526,7 +611,7 @@ func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 		t.Fatalf("SeedDemoData returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -664,9 +749,10 @@ func TestCustomerDevicesReportVideoCloudActivationFailures(t *testing.T) {
 
 	srv := NewWithOptions(st, Options{
 		Config: config.Config{
-			AccountManagerBaseURL: accountUpstream.URL,
-			VideoCloudBaseURL:     videoUpstream.URL,
-			VideoCloudAdminToken:  "vc-secret",
+			AccountManagerBaseURL:              accountUpstream.URL,
+			LegacyCustomerPasswordLoginEnabled: true,
+			VideoCloudBaseURL:                  videoUpstream.URL,
+			VideoCloudAdminToken:               "vc-secret",
 		},
 		AccountClient: accountclient.New(accountUpstream.URL),
 		VideoClient:   videoclient.New(videoUpstream.URL),
@@ -724,7 +810,7 @@ func TestCustomerLoginSurvivesProfileRetryFailure(t *testing.T) {
 		t.Fatalf("Migrate returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -781,7 +867,7 @@ func TestCustomerSessionInvalidRefreshClearsStoredSession(t *testing.T) {
 		t.Fatalf("CreateSession returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -855,7 +941,7 @@ func TestCustomerDevicesInvalidSessionRefreshClearsStoredSession(t *testing.T) {
 		t.Fatalf("CreateSession returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -907,7 +993,7 @@ func TestCustomerMePersistsRotatedTokensOnRetryFailure(t *testing.T) {
 		t.Fatalf("CreateSession returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -948,7 +1034,7 @@ func TestCustomerLoginMapsUpstreamFailures(t *testing.T) {
 			t.Fatalf("Migrate returned error: %v", err)
 		}
 		srv := NewWithOptions(st, Options{
-			Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+			Config:        legacyCustomerLoginConfig(upstream.URL),
 			AccountClient: accountclient.New(upstream.URL),
 		})
 
@@ -977,7 +1063,7 @@ func TestCustomerLoginMapsUpstreamFailures(t *testing.T) {
 			t.Fatalf("Migrate returned error: %v", err)
 		}
 		srv := NewWithOptions(st, Options{
-			Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+			Config:        legacyCustomerLoginConfig(upstream.URL),
 			AccountClient: accountclient.New(upstream.URL),
 		})
 
@@ -1010,7 +1096,7 @@ func TestCustomerLoginMapsUpstreamFailures(t *testing.T) {
 			t.Fatalf("Migrate returned error: %v", err)
 		}
 		srv := NewWithOptions(st, Options{
-			Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+			Config:        legacyCustomerLoginConfig(upstream.URL),
 			AccountClient: accountclient.NewWithHTTPClient(upstream.URL, &http.Client{Timeout: 40 * time.Millisecond}),
 		})
 
@@ -1056,7 +1142,7 @@ func TestCustomerDevicesRefreshesExpiredAccessAndRejectsInvalidActiveOrg(t *test
 		t.Fatalf("Migrate returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 	session, err := st.CreateSession("customer", "u1", "user@example.com", "access", "refresh", "org-up", time.Hour)
@@ -1127,7 +1213,7 @@ func TestCustomerUpstreamErrorsMapDeterministically(t *testing.T) {
 		t.Fatalf("SeedDemoData returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.NewWithHTTPClient(upstream.URL, &http.Client{Timeout: 50 * time.Millisecond}),
 	})
 
@@ -1952,9 +2038,10 @@ func TestFleetFirmwareDistributionProxyMode(t *testing.T) {
 
 	srv := NewWithOptions(st, Options{
 		Config: config.Config{
-			AccountManagerBaseURL: accountUpstream.URL,
-			VideoCloudBaseURL:     videoUpstream.URL,
-			VideoCloudAdminToken:  "vc-secret",
+			AccountManagerBaseURL:              accountUpstream.URL,
+			LegacyCustomerPasswordLoginEnabled: true,
+			VideoCloudBaseURL:                  videoUpstream.URL,
+			VideoCloudAdminToken:               "vc-secret",
 		},
 		AccountClient: accountclient.New(accountUpstream.URL),
 		VideoClient:   videoclient.New(videoUpstream.URL),
@@ -2071,9 +2158,10 @@ func TestFleetFirmwareDistributionProxyModeUsesAlternateRolloutKeys(t *testing.T
 	}
 	srv := NewWithOptions(st, Options{
 		Config: config.Config{
-			AccountManagerBaseURL: accountUpstream.URL,
-			VideoCloudBaseURL:     videoUpstream.URL,
-			VideoCloudAdminToken:  "vc-secret",
+			AccountManagerBaseURL:              accountUpstream.URL,
+			LegacyCustomerPasswordLoginEnabled: true,
+			VideoCloudBaseURL:                  videoUpstream.URL,
+			VideoCloudAdminToken:               "vc-secret",
 		},
 		AccountClient: accountclient.New(accountUpstream.URL),
 		VideoClient:   videoclient.New(videoUpstream.URL),
@@ -2250,9 +2338,10 @@ func TestDeviceTelemetryProxyModeUsesVideoCloud(t *testing.T) {
 
 	srv := NewWithOptions(st, Options{
 		Config: config.Config{
-			AccountManagerBaseURL: accountUpstream.URL,
-			VideoCloudBaseURL:     videoUpstream.URL,
-			VideoCloudAdminToken:  "vc-secret",
+			AccountManagerBaseURL:              accountUpstream.URL,
+			LegacyCustomerPasswordLoginEnabled: true,
+			VideoCloudBaseURL:                  videoUpstream.URL,
+			VideoCloudAdminToken:               "vc-secret",
 		},
 		AccountClient: accountclient.New(accountUpstream.URL),
 		VideoClient:   videoclient.New(videoUpstream.URL),
@@ -2377,9 +2466,10 @@ func TestDeviceTelemetryProxyModeMapsVideoCloudFailure(t *testing.T) {
 
 	srv := NewWithOptions(st, Options{
 		Config: config.Config{
-			AccountManagerBaseURL: accountUpstream.URL,
-			VideoCloudBaseURL:     videoUpstream.URL,
-			VideoCloudAdminToken:  "vc-secret",
+			AccountManagerBaseURL:              accountUpstream.URL,
+			LegacyCustomerPasswordLoginEnabled: true,
+			VideoCloudBaseURL:                  videoUpstream.URL,
+			VideoCloudAdminToken:               "vc-secret",
 		},
 		AccountClient: accountclient.New(accountUpstream.URL),
 		VideoClient:   videoclient.New(videoUpstream.URL),
@@ -2421,7 +2511,7 @@ func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 	if err := st.BootstrapPlatformAdmin("admin@example.com", "secret"); err != nil {
 		t.Fatalf("BootstrapPlatformAdmin returned error: %v", err)
 	}
-	srv := New(st)
+	srv := NewWithOptions(st, Options{Config: config.Config{AdminBreakGlassEnabled: true}})
 
 	adminPaths := []string{
 		"/api/admin/summary",
@@ -2668,7 +2758,7 @@ func TestActiveOrgAndQuotaContractsRejectInvalidOrganizations(t *testing.T) {
 	}))
 	defer upstream.Close()
 	proxySrv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -2773,7 +2863,7 @@ func TestCustomerUpstreamLifecycleIsIdempotentAndDurable(t *testing.T) {
 		t.Fatalf("SeedDemoData returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -2864,7 +2954,7 @@ func TestDeactivateDoesNotReturnOpenProvisionOperation(t *testing.T) {
 		t.Fatalf("SeedDemoData returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -2936,7 +3026,7 @@ func TestCustomerUpstreamLifecycleFailurePersistsFailedOperation(t *testing.T) {
 		t.Fatalf("SeedDemoData returned error: %v", err)
 	}
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        legacyCustomerLoginConfig(upstream.URL),
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
@@ -3003,7 +3093,7 @@ func TestPlatformAdminLogin(t *testing.T) {
 	if err := st.BootstrapPlatformAdmin("admin@example.com", "secret"); err != nil {
 		t.Fatalf("BootstrapPlatformAdmin returned error: %v", err)
 	}
-	srv := New(st)
+	srv := NewWithOptions(st, Options{Config: config.Config{AdminBreakGlassEnabled: true}})
 	blocked := httptest.NewRecorder()
 	srv.ServeHTTP(blocked, httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil))
 	if blocked.Code != http.StatusUnauthorized {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,27 +3,32 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 type Config struct {
-	Port                   string
-	DatabasePath           string
-	AccountManagerBaseURL  string
-	VideoCloudBaseURL      string
-	VideoCloudAdminToken   string
-	AdminBootstrapEmail    string
-	AdminBootstrapPassword string
+	Port                               string
+	DatabasePath                       string
+	AccountManagerBaseURL              string
+	VideoCloudBaseURL                  string
+	VideoCloudAdminToken               string
+	AdminBootstrapEmail                string
+	AdminBootstrapPassword             string
+	AdminBreakGlassEnabled             bool
+	LegacyCustomerPasswordLoginEnabled bool
 }
 
 func FromEnv() Config {
 	return Config{
-		Port:                   getenv("PORT", "8080"),
-		DatabasePath:           getenv("DATABASE_PATH", filepath.Join("data", "rtk-cloud-admin.db")),
-		AccountManagerBaseURL:  os.Getenv("ACCOUNT_MANAGER_BASE_URL"),
-		VideoCloudBaseURL:      os.Getenv("VIDEO_CLOUD_BASE_URL"),
-		VideoCloudAdminToken:   os.Getenv("VIDEO_CLOUD_ADMIN_TOKEN"),
-		AdminBootstrapEmail:    os.Getenv("ADMIN_BOOTSTRAP_EMAIL"),
-		AdminBootstrapPassword: os.Getenv("ADMIN_BOOTSTRAP_PASSWORD"),
+		Port:                               getenv("PORT", "8080"),
+		DatabasePath:                       getenv("DATABASE_PATH", filepath.Join("data", "rtk-cloud-admin.db")),
+		AccountManagerBaseURL:              os.Getenv("ACCOUNT_MANAGER_BASE_URL"),
+		VideoCloudBaseURL:                  os.Getenv("VIDEO_CLOUD_BASE_URL"),
+		VideoCloudAdminToken:               os.Getenv("VIDEO_CLOUD_ADMIN_TOKEN"),
+		AdminBootstrapEmail:                os.Getenv("ADMIN_BOOTSTRAP_EMAIL"),
+		AdminBootstrapPassword:             os.Getenv("ADMIN_BOOTSTRAP_PASSWORD"),
+		AdminBreakGlassEnabled:             truthy(os.Getenv("ADMIN_BREAK_GLASS_ENABLED")),
+		LegacyCustomerPasswordLoginEnabled: truthy(os.Getenv("LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED")),
 	}
 }
 
@@ -32,4 +37,13 @@ func getenv(key, fallback string) string {
 		return value
 	}
 	return fallback
+}
+
+func truthy(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "t", "yes", "y", "on":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -10,6 +10,8 @@ func TestFromEnvDefaultsAndOverrides(t *testing.T) {
 	t.Setenv("VIDEO_CLOUD_ADMIN_TOKEN", "video-admin-token")
 	t.Setenv("ADMIN_BOOTSTRAP_EMAIL", "admin@example.com")
 	t.Setenv("ADMIN_BOOTSTRAP_PASSWORD", "secret")
+	t.Setenv("ADMIN_BREAK_GLASS_ENABLED", "true")
+	t.Setenv("LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED", "true")
 
 	cfg := FromEnv()
 	if cfg.Port != "18081" {
@@ -30,6 +32,12 @@ func TestFromEnvDefaultsAndOverrides(t *testing.T) {
 	if cfg.AdminBootstrapEmail != "admin@example.com" || cfg.AdminBootstrapPassword != "secret" {
 		t.Fatalf("admin bootstrap env not loaded")
 	}
+	if !cfg.AdminBreakGlassEnabled {
+		t.Fatalf("AdminBreakGlassEnabled = false, want true")
+	}
+	if !cfg.LegacyCustomerPasswordLoginEnabled {
+		t.Fatalf("LegacyCustomerPasswordLoginEnabled = false, want true")
+	}
 }
 
 func TestFromEnvDefaults(t *testing.T) {
@@ -39,5 +47,11 @@ func TestFromEnvDefaults(t *testing.T) {
 	}
 	if cfg.DatabasePath != "data/rtk-cloud-admin.db" {
 		t.Fatalf("DatabasePath default = %q", cfg.DatabasePath)
+	}
+	if cfg.AdminBreakGlassEnabled {
+		t.Fatalf("AdminBreakGlassEnabled default = true, want false")
+	}
+	if cfg.LegacyCustomerPasswordLoginEnabled {
+		t.Fatalf("LegacyCustomerPasswordLoginEnabled default = true, want false")
 	}
 }


### PR DESCRIPTION
## Summary
- add SSO-only login policy flags for break-glass admin and legacy customer password login
- gate local Platform Admin password login behind `ADMIN_BREAK_GLASS_ENABLED`
- gate customer password login behind `LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED`
- audit break-glass disabled, failed, and accepted attempts
- update docs, CI smoke env, and tracked test report coverage

Closes #78

## Validation
- go test ./internal/app ./internal/config ./internal/store
- go test ./...
- go test ./... -coverprofile=coverage.out
- scripts/validate_test_report.sh docs/TEST_REPORT.md
