### PR TITLE
[SSO] Implement email-first SSO login UI

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -229,7 +229,7 @@ func (s *Server) apiAdminSummary(w http.ResponseWriter, r *http.Request) {
 func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 	session, ok := s.requestSession(r)
 	if !ok {
-		writeJSON(w, contracts.Me{
+		me := s.meAuthSettings(contracts.Me{
 			UserID:        "demo-user",
 			Email:         "demo@example.local",
 			Name:          "Demo User",
@@ -242,20 +242,21 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 				{OrganizationID: "org-nova", Organization: "Nova Home Labs", Role: "operator", Tier: "commercial"},
 			},
 		})
+		writeJSON(w, me)
 		return
 	}
 	if session.Kind == "platform_admin" {
-		writeJSON(w, contracts.Me{
+		writeJSON(w, s.meAuthSettings(contracts.Me{
 			UserID:        session.Subject,
 			Email:         session.Email,
 			Name:          session.Email,
 			Kind:          session.Kind,
 			Memberships:   []contracts.Membership{},
 			Authenticated: true,
-		})
+		}))
 		return
 	}
-	me := contracts.Me{
+	me := s.meAuthSettings(contracts.Me{
 		UserID:        session.Subject,
 		Email:         session.Email,
 		Name:          session.Email,
@@ -264,7 +265,7 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		ActiveOrgID:   session.ActiveOrgID,
 		DemoMode:      !s.accountClient.Enabled(),
 		Authenticated: true,
-	}
+	})
 	if s.accountClient.Enabled() {
 		upstream, tokens, err := s.resolveCustomerProfile(r.Context(), accountclient.Tokens{
 			AccessToken:  session.AccessToken,
@@ -298,6 +299,12 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	writeJSON(w, me)
+}
+
+func (s *Server) meAuthSettings(me contracts.Me) contracts.Me {
+	me.BreakGlassEnabled = s.cfg.AdminBreakGlassEnabled
+	me.LegacyCustomerPasswordLoginEnabled = s.cfg.LegacyCustomerPasswordLoginEnabled
+	return me
 }
 
 func (s *Server) apiActiveOrg(w http.ResponseWriter, r *http.Request) {

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -105,14 +105,16 @@ type Membership struct {
 }
 
 type Me struct {
-	UserID        string       `json:"user_id"`
-	Email         string       `json:"email"`
-	Name          string       `json:"name"`
-	Kind          string       `json:"kind"`
-	Memberships   []Membership `json:"memberships"`
-	ActiveOrgID   string       `json:"active_org_id"`
-	DemoMode      bool         `json:"demo_mode"`
-	Authenticated bool         `json:"authenticated"`
+	UserID                             string       `json:"user_id"`
+	Email                              string       `json:"email"`
+	Name                               string       `json:"name"`
+	Kind                               string       `json:"kind"`
+	Memberships                        []Membership `json:"memberships"`
+	ActiveOrgID                        string       `json:"active_org_id"`
+	DemoMode                           bool         `json:"demo_mode"`
+	Authenticated                      bool         `json:"authenticated"`
+	BreakGlassEnabled                  bool         `json:"break_glass_enabled"`
+	LegacyCustomerPasswordLoginEnabled bool         `json:"legacy_customer_password_login_enabled"`
 }
 
 type AuditEvent struct {

--- a/web/src/http.mjs
+++ b/web/src/http.mjs
@@ -13,3 +13,21 @@ export async function postJSON(url, body) {
   const text = await response.text();
   return text ? JSON.parse(text) : null;
 }
+
+export async function startSSOLogin(email, returnUrl) {
+  return postJSON('/api/auth/sso/start', {
+    email,
+    return_url: returnUrl,
+  });
+}
+
+export function userFacingSSOError(error) {
+  const message = error?.message || 'SSO sign-in could not be started.';
+  if (message.includes('ACCOUNT_MANAGER_BASE_URL') || message.includes('not configured')) {
+    return 'SSO is not configured for this environment.';
+  }
+  if (message.includes('invalid JSON')) {
+    return 'SSO is temporarily unavailable. Please try again later.';
+  }
+  return message;
+}

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { postJSON } from './http.mjs';
+import { postJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 
 test('postJSON throws on failed verification responses', async () => {
   const originalFetch = globalThis.fetch;
@@ -86,4 +86,44 @@ test('postJSON propagates network failures', async () => {
   );
 
   globalThis.fetch = originalFetch;
+});
+
+test('startSSOLogin posts email and return URL to SSO start endpoint', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    assert.equal(url, '/api/auth/sso/start');
+    assert.equal(init.method, 'POST');
+    assert.equal(init.headers['Content-Type'], 'application/json');
+    assert.equal(init.body, JSON.stringify({
+      email: 'owner@example.com',
+      return_url: 'https://admin.example.com/console',
+    }));
+    return {
+      ok: true,
+      status: 200,
+      text: async () => '{"redirect_url":"https://idp.example.com/authorize","state":"state-1"}',
+    };
+  };
+
+  assert.deepEqual(await startSSOLogin('owner@example.com', 'https://admin.example.com/console'), {
+    redirect_url: 'https://idp.example.com/authorize',
+    state: 'state-1',
+  });
+
+  globalThis.fetch = originalFetch;
+});
+
+test('userFacingSSOError hides internal SSO configuration details', () => {
+  assert.equal(
+    userFacingSSOError(new Error('ACCOUNT_MANAGER_BASE_URL is not configured')),
+    'SSO is not configured for this environment.',
+  );
+  assert.equal(
+    userFacingSSOError(new Error('invalid JSON response from Account Manager')),
+    'SSO is temporarily unavailable. Please try again later.',
+  );
+  assert.equal(
+    userFacingSSOError(new Error('SSO provider is disabled for this organization')),
+    'SSO provider is disabled for this organization',
+  );
 });

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { customerNavItems, devicesPathWithFilters, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
-import { postJSON } from './http.mjs';
+import { postJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -214,16 +214,31 @@ function App() {
     setRefreshTick((tick) => tick + 1);
   }
 
-  async function handleLogin(kind, credentials) {
+  async function handleSSOStart(email) {
     setError('');
-    const url = kind === 'platform' ? '/api/auth/platform/login' : '/api/auth/customer/login';
-    const response = await fetch(url, {
+    try {
+      const result = await startSSOLogin(email, window.location.href);
+      if (!result?.redirect_url) {
+        setError('SSO start did not return a redirect URL');
+        return;
+      }
+      window.location.assign(result.redirect_url);
+    } catch (err) {
+      setError(userFacingSSOError(err));
+      throw err;
+    }
+  }
+
+  async function handleBreakGlassLogin(credentials) {
+    setError('');
+    const response = await fetch('/api/auth/platform/login', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(credentials),
     });
     if (!response.ok) {
-      setError(`${kind} login failed with ${response.status}`);
+      const details = await response.text().catch(() => '');
+      setError(details || `break-glass login failed with ${response.status}`);
       return;
     }
     setRefreshTick((tick) => tick + 1);
@@ -387,7 +402,14 @@ function App() {
 
         {error ? <div className="error">{error}</div> : null}
 
-        {needsPlatformAccess ? <PlatformAccessGate active={active} onLogin={handleLogin} /> : null}
+        {needsPlatformAccess ? (
+          <PlatformAccessGate
+            active={active}
+            me={me}
+            onSSOStart={handleSSOStart}
+            onBreakGlassLogin={handleBreakGlassLogin}
+          />
+        ) : null}
         {!needsPlatformAccess && active === 'overview' ? (
           <Overview
             summary={summary}
@@ -399,7 +421,7 @@ function App() {
             me={me}
             loading={loading}
             devices={devices}
-            onLogin={handleLogin}
+            onSSOStart={handleSSOStart}
             onHealthFilter={filterDevicesByHealth}
             onRequestQuotaRaise={handleQuotaRaiseRequest}
           />
@@ -703,7 +725,7 @@ function Overview({
   me,
   loading,
   devices,
-  onLogin,
+  onSSOStart,
   onHealthFilter,
   onRequestQuotaRaise,
 }) {
@@ -725,7 +747,7 @@ function Overview({
 
   return (
     <div className="overview-layout">
-      {!me?.authenticated ? <LoginPanel mode="customer" title="Customer Account Manager login" onLogin={onLogin} /> : null}
+      {!me?.authenticated ? <SSOLoginPanel title="Sign in with SSO" onSSOStart={onSSOStart} /> : null}
 
       <section className="metrics overview-metrics">
         <MetricCard icon="ON" label="Online" value={summary ? `${onlineCount} / ${summary.total_devices ?? 0}` : onlineCount} hint="Devices online" tone="info" />
@@ -1182,10 +1204,13 @@ function GroupsPage() {
   );
 }
 
-function PlatformAccessGate({ active, onLogin }) {
+function PlatformAccessGate({ active, me, onSSOStart, onBreakGlassLogin }) {
   return (
     <>
-      <LoginPanel mode="platform" title="Platform admin login" onLogin={onLogin} />
+      <SSOLoginPanel title="Platform SSO sign in" onSSOStart={onSSOStart} />
+      {me?.break_glass_enabled ? (
+        <BreakGlassLoginPanel title="Break-glass platform access" onLogin={onBreakGlassLogin} />
+      ) : null}
       <section className="panel split-panel">
         <div>
           <h2>Platform access required</h2>
@@ -2160,11 +2185,18 @@ function OperationList({ operations, detailed = false }) {
   );
 }
 
-function PlatformAdmin({ summary, health, devices, customers, operations, audit, me, onLogin }) {
+function PlatformAdmin({ summary, health, devices, customers, operations, audit, me, onSSOStart, onBreakGlassLogin }) {
   const customerCount = summary?.customers ?? '-';
   return (
     <>
-      {me?.kind !== 'platform_admin' ? <LoginPanel mode="platform" title="Platform admin login" onLogin={onLogin} /> : null}
+      {me?.kind !== 'platform_admin' ? (
+        <>
+          <SSOLoginPanel title="Platform SSO sign in" onSSOStart={onSSOStart} />
+          {me?.break_glass_enabled ? (
+            <BreakGlassLoginPanel title="Break-glass platform access" onLogin={onBreakGlassLogin} />
+          ) : null}
+        </>
+      ) : null}
       <section className="panel split-panel">
         <div>
           <h2>Platform Operations</h2>
@@ -2392,22 +2424,48 @@ function ServiceHealth({ health, compact = false }) {
   );
 }
 
-function LoginPanel({ mode, title, onLogin }) {
+function SSOLoginPanel({ title, onSSOStart }) {
+  const [email, setEmail] = useState('');
+  const [busy, setBusy] = useState(false);
+  async function submit(event) {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      await onSSOStart(email);
+    } catch (_) {
+      setBusy(false);
+    }
+  }
+  return (
+    <section className="panel login-panel">
+      <div>
+        <h2>{title}</h2>
+        <p>Use your organization email to continue through Account Manager SSO.</p>
+      </div>
+      <form onSubmit={submit}>
+        <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="name@company.com" required />
+        <button type="submit" disabled={busy}>{busy ? 'Redirecting' : 'Continue with SSO'}</button>
+      </form>
+    </section>
+  );
+}
+
+function BreakGlassLoginPanel({ title, onLogin }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   return (
     <section className="panel login-panel">
       <div>
         <h2>{title}</h2>
-        <p>{mode === 'platform' ? 'Local SQLite platform admin session.' : 'Uses Account Manager when configured.'}</p>
+        <p>Emergency local admin access for SSO or Account Manager outage recovery.</p>
       </div>
       <form onSubmit={(event) => {
         event.preventDefault();
-        onLogin(mode, { email, password });
+        onLogin({ email, password });
       }}>
-        <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="Email" />
+        <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="Break-glass email" />
         <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="Password" />
-        <button type="submit">Login</button>
+        <button type="submit">Use break-glass</button>
       </form>
     </section>
   );


### PR DESCRIPTION
Closes #79.\n\n## Summary\n- Replace daily customer/platform login surfaces with email-first SSO start UI.\n- Expose backend auth policy flags through /api/me so break-glass UI only appears when enabled.\n- Add frontend SSO client helper and user-facing error normalization.\n\n## Validation\n- npm test --prefix web\n- npm run build --prefix web\n- go test ./internal/app ./internal/contracts\n- go test ./...\n- go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out\n- scripts/validate_test_report.sh docs/TEST_REPORT.md\n- Browser rendered check: /console and /admin show SSO entry, hide break-glass, and display friendly SSO error without internal config leak