### PR TITLE
[SSO] Add Platform Admin SSO provider settings

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -93,6 +93,9 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/admin/customers", s.apiAdminCustomers)
 	s.mux.HandleFunc("GET /api/devices", s.apiDevices)
 	s.mux.HandleFunc("GET /api/admin/devices", s.apiAdminDevices)
+	s.mux.HandleFunc("GET /api/admin/sso/providers", s.apiAdminSSOProviders)
+	s.mux.HandleFunc("GET /api/admin/orgs/{orgId}/sso-provider", s.apiAdminSSOProvider)
+	s.mux.HandleFunc("PUT /api/admin/orgs/{orgId}/sso-provider", s.apiAdminSSOProvider)
 	s.mux.HandleFunc("GET /api/devices/{id}", s.apiDevice)
 	s.mux.HandleFunc("GET /api/devices/{id}/telemetry", s.apiDeviceTelemetry)
 	s.mux.HandleFunc("GET /api/fleet/health-summary", s.apiFleetHealthSummary)
@@ -125,6 +128,7 @@ func (s *Server) routes() {
 		"/admin/ops",
 		"/admin/operations",
 		"/admin/audit",
+		"/admin/sso",
 	} {
 		s.mux.HandleFunc("GET "+path, s.shell)
 	}
@@ -2258,6 +2262,64 @@ func (s *Server) apiAdminCustomers(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, customers)
 }
 
+func (s *Server) apiAdminSSOProviders(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	if !s.accountClient.Enabled() {
+		http.Error(w, "Account Manager is not configured for SSO provider settings", http.StatusServiceUnavailable)
+		return
+	}
+	providers, err := s.accountClient.SSOProviderStatuses(r.Context(), session.AccessToken)
+	if err != nil {
+		writeSSOError(w, err)
+		return
+	}
+	writeJSON(w, map[string][]accountclient.SSOProviderStatus{"providers": providers})
+}
+
+func (s *Server) apiAdminSSOProvider(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	if !s.accountClient.Enabled() {
+		http.Error(w, "Account Manager is not configured for SSO provider settings", http.StatusServiceUnavailable)
+		return
+	}
+	orgID := strings.TrimSpace(r.PathValue("orgId"))
+	if orgID == "" {
+		http.Error(w, "organization id is required", http.StatusBadRequest)
+		return
+	}
+	if r.Method == http.MethodGet {
+		provider, err := s.accountClient.SSOProviderStatus(r.Context(), session.AccessToken, orgID)
+		if err != nil {
+			writeSSOError(w, err)
+			return
+		}
+		writeJSON(w, map[string]accountclient.SSOProviderStatus{"provider": provider})
+		return
+	}
+
+	var body accountclient.SSOProviderConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid SSO provider configuration", http.StatusBadRequest)
+		return
+	}
+	body.Issuer = strings.TrimSpace(body.Issuer)
+	body.ClientID = strings.TrimSpace(body.ClientID)
+	body.ClientSecret = strings.TrimSpace(body.ClientSecret)
+	body.VerifiedDomains = normalizeDomains(body.VerifiedDomains)
+	provider, err := s.accountClient.UpsertSSOProvider(r.Context(), session.AccessToken, orgID, body)
+	if err != nil {
+		writeSSOError(w, err)
+		return
+	}
+	writeJSON(w, map[string]accountclient.SSOProviderStatus{"provider": provider})
+}
+
 func (s *Server) apiOperations(w http.ResponseWriter, r *http.Request) {
 	if session, ok := s.customerSession(r); ok {
 		ops, err := s.customerOperations(r.Context(), session)
@@ -2805,6 +2867,20 @@ func writeSSOError(w http.ResponseWriter, err error) {
 		return
 	}
 	writeError(w, err)
+}
+
+func normalizeDomains(domains []string) []string {
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(domains))
+	for _, domain := range domains {
+		domain = strings.ToLower(strings.TrimSpace(domain))
+		if domain == "" || seen[domain] {
+			continue
+		}
+		seen[domain] = true
+		normalized = append(normalized, domain)
+	}
+	return normalized
 }
 
 func organizationAllowed(orgs []accountclient.Organization, orgID string) bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -57,6 +57,7 @@ func TestServerHealthAndHomeRedirect(t *testing.T) {
 		"/admin/ops",
 		"/admin/operations",
 		"/admin/audit",
+		"/admin/sso",
 	} {
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
@@ -366,6 +367,176 @@ func TestLegacyCustomerPasswordLoginDisabledByDefault(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "customer password login is disabled") {
 		t.Fatalf("customer login body = %s", rec.Body.String())
+	}
+}
+
+func TestAdminSSOProviderRoutesProxyAndRedactSecrets(t *testing.T) {
+	t.Parallel()
+
+	var receivedConfig accountclient.SSOProviderConfigRequest
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-access" {
+			t.Fatalf("%s Authorization = %q", r.URL.Path, got)
+		}
+		switch r.URL.Path {
+		case "/v1/admin/sso/providers/status":
+			if r.Method != http.MethodGet {
+				t.Fatalf("providers method = %s", r.Method)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"providers": []map[string]any{{
+					"organization_id":   "org-acme",
+					"organization":      "Acme Smart Camera",
+					"provider_id":       "provider-1",
+					"issuer":            "https://idp.example.com",
+					"client_id":         "client-1",
+					"verified_domains":  []string{"example.com"},
+					"enabled":           true,
+					"configured":        true,
+					"status":            "ready",
+					"last_validated_at": "2026-05-11T00:00:00Z",
+				}},
+			})
+		case "/v1/admin/orgs/org-acme/sso-provider":
+			switch r.Method {
+			case http.MethodGet:
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"provider": map[string]any{
+						"organization_id":  "org-acme",
+						"organization":     "Acme Smart Camera",
+						"provider_id":      "provider-1",
+						"issuer":           "https://idp.example.com",
+						"client_id":        "client-1",
+						"verified_domains": []string{"example.com"},
+						"enabled":          true,
+						"configured":       true,
+						"status":           "ready",
+					},
+				})
+			case http.MethodPut:
+				if err := json.NewDecoder(r.Body).Decode(&receivedConfig); err != nil {
+					t.Fatalf("decode provider config: %v", err)
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"provider": map[string]any{
+						"organization_id":  "org-acme",
+						"organization":     "Acme Smart Camera",
+						"provider_id":      "provider-1",
+						"issuer":           receivedConfig.Issuer,
+						"client_id":        receivedConfig.ClientID,
+						"verified_domains": receivedConfig.VerifiedDomains,
+						"enabled":          receivedConfig.Enabled,
+						"configured":       true,
+						"status":           "ready",
+					},
+				})
+			default:
+				http.NotFound(w, r)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st := mustOpenStore(t)
+	adminSession, err := st.CreateSession("platform_admin", "admin-1", "admin@example.com", "admin-access", "admin-refresh", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession admin returned error: %v", err)
+	}
+	customerSession, err := st.CreateSession("customer", "u1", "owner@example.com", "customer-access", "customer-refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession customer returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	unauth := httptest.NewRecorder()
+	srv.ServeHTTP(unauth, httptest.NewRequest(http.MethodGet, "/api/admin/sso/providers", nil))
+	if unauth.Code != http.StatusUnauthorized {
+		t.Fatalf("unauth providers status = %d", unauth.Code)
+	}
+
+	blocked := httptest.NewRecorder()
+	blockedReq := httptest.NewRequest(http.MethodGet, "/api/admin/sso/providers", nil)
+	blockedReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: customerSession.ID})
+	srv.ServeHTTP(blocked, blockedReq)
+	if blocked.Code != http.StatusForbidden {
+		t.Fatalf("customer providers status = %d", blocked.Code)
+	}
+
+	adminCookie := &http.Cookie{Name: "rtk_admin_session", Value: adminSession.ID}
+	providers := httptest.NewRecorder()
+	providersReq := httptest.NewRequest(http.MethodGet, "/api/admin/sso/providers", nil)
+	providersReq.AddCookie(adminCookie)
+	srv.ServeHTTP(providers, providersReq)
+	if providers.Code != http.StatusOK {
+		t.Fatalf("providers status = %d, body=%s", providers.Code, providers.Body.String())
+	}
+	if strings.Contains(providers.Body.String(), "client_secret") {
+		t.Fatalf("provider list leaked client_secret: %s", providers.Body.String())
+	}
+
+	provider := httptest.NewRecorder()
+	providerReq := httptest.NewRequest(http.MethodGet, "/api/admin/orgs/org-acme/sso-provider", nil)
+	providerReq.AddCookie(adminCookie)
+	srv.ServeHTTP(provider, providerReq)
+	if provider.Code != http.StatusOK {
+		t.Fatalf("provider status = %d, body=%s", provider.Code, provider.Body.String())
+	}
+	if strings.Contains(provider.Body.String(), "client_secret") {
+		t.Fatalf("provider detail leaked client_secret: %s", provider.Body.String())
+	}
+
+	badPayload := httptest.NewRecorder()
+	badPayloadReq := httptest.NewRequest(http.MethodPut, "/api/admin/orgs/org-acme/sso-provider", strings.NewReader(`{`))
+	badPayloadReq.AddCookie(adminCookie)
+	srv.ServeHTTP(badPayload, badPayloadReq)
+	if badPayload.Code != http.StatusBadRequest {
+		t.Fatalf("bad payload status = %d, body=%s", badPayload.Code, badPayload.Body.String())
+	}
+
+	updateBody := `{"issuer":" https://idp.example.com ","client_id":"client-1","client_secret":"secret-1","verified_domains":[" Example.COM ","example.com",""],"enabled":true}`
+	update := httptest.NewRecorder()
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/admin/orgs/org-acme/sso-provider", strings.NewReader(updateBody))
+	updateReq.AddCookie(adminCookie)
+	srv.ServeHTTP(update, updateReq)
+	if update.Code != http.StatusOK {
+		t.Fatalf("update status = %d, body=%s", update.Code, update.Body.String())
+	}
+	if receivedConfig.ClientSecret != "secret-1" {
+		t.Fatalf("upstream did not receive client secret: %#v", receivedConfig)
+	}
+	if receivedConfig.Issuer != "https://idp.example.com" || len(receivedConfig.VerifiedDomains) != 1 || receivedConfig.VerifiedDomains[0] != "example.com" {
+		t.Fatalf("normalized config = %#v", receivedConfig)
+	}
+	if strings.Contains(update.Body.String(), "secret-1") || strings.Contains(update.Body.String(), "client_secret") {
+		t.Fatalf("update response leaked secret: %s", update.Body.String())
+	}
+
+	auditEvents, err := st.ListAuditEvents()
+	if err != nil {
+		t.Fatalf("ListAuditEvents returned error: %v", err)
+	}
+	for _, event := range auditEvents {
+		eventJSON, err := json.Marshal(event)
+		if err != nil {
+			t.Fatalf("marshal audit event: %v", err)
+		}
+		if strings.Contains(string(eventJSON), "secret-1") || strings.Contains(string(eventJSON), "client_secret") {
+			t.Fatalf("audit leaked secret: %#v", event)
+		}
+	}
+
+	disabledServer := NewWithOptions(st, Options{})
+	disabled := httptest.NewRecorder()
+	disabledReq := httptest.NewRequest(http.MethodGet, "/api/admin/sso/providers", nil)
+	disabledReq.AddCookie(adminCookie)
+	disabledServer.ServeHTTP(disabled, disabledReq)
+	if disabled.Code != http.StatusServiceUnavailable {
+		t.Fatalf("disabled providers status = %d, body=%s", disabled.Code, disabled.Body.String())
 	}
 }
 

--- a/web/src/http.mjs
+++ b/web/src/http.mjs
@@ -1,6 +1,14 @@
 export async function postJSON(url, body) {
+  return sendJSON('POST', url, body);
+}
+
+export async function putJSON(url, body) {
+  return sendJSON('PUT', url, body);
+}
+
+async function sendJSON(method, url, body) {
   const response = await fetch(url, {
-    method: 'POST',
+    method,
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   });

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { postJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
+import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 
 test('postJSON throws on failed verification responses', async () => {
   const originalFetch = globalThis.fetch;
@@ -108,6 +108,27 @@ test('startSSOLogin posts email and return URL to SSO start endpoint', async () 
   assert.deepEqual(await startSSOLogin('owner@example.com', 'https://admin.example.com/console'), {
     redirect_url: 'https://idp.example.com/authorize',
     state: 'state-1',
+  });
+
+  globalThis.fetch = originalFetch;
+});
+
+test('putJSON sends JSON using PUT', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    assert.equal(url, '/api/admin/orgs/org-1/sso-provider');
+    assert.equal(init.method, 'PUT');
+    assert.equal(init.headers['Content-Type'], 'application/json');
+    assert.equal(init.body, JSON.stringify({ enabled: true }));
+    return {
+      ok: true,
+      status: 200,
+      text: async () => '{"provider":{"organization_id":"org-1","enabled":true}}',
+    };
+  };
+
+  assert.deepEqual(await putJSON('/api/admin/orgs/org-1/sso-provider', { enabled: true }), {
+    provider: { organization_id: 'org-1', enabled: true },
   });
 
   globalThis.fetch = originalFetch;

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { customerNavItems, devicesPathWithFilters, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
-import { postJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
+import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -18,6 +18,7 @@ function App() {
   const [operations, setOperations] = useState([]);
   const [health, setHealth] = useState([]);
   const [audit, setAudit] = useState([]);
+  const [ssoProviders, setSSOProviders] = useState([]);
   const [firmwareDistribution, setFirmwareDistribution] = useState(null);
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
   const [deviceDrawerOpen, setDeviceDrawerOpen] = useState(false);
@@ -58,6 +59,7 @@ function App() {
           setOperations([]);
           setHealth([]);
           setAudit([]);
+          setSSOProviders([]);
           setLoading(false);
           return;
         }
@@ -79,6 +81,13 @@ function App() {
         setOperations(nextOperations);
         setHealth(nextHealth);
         setAudit(nextAudit);
+        if (useAdminApi && active === 'platform-sso') {
+          const nextSSOProviders = await fetchJSON('/api/admin/sso/providers');
+          if (!alive) return;
+          setSSOProviders(nextSSOProviders.providers || []);
+        } else {
+          setSSOProviders([]);
+        }
         if (active === 'firmware-ota' && nextMe.kind !== 'platform_admin') {
           const nextFirmwareDistribution = await fetchJSON('/api/fleet/firmware-distribution');
           if (!alive) return;
@@ -121,6 +130,7 @@ function App() {
           setOperations([]);
           setHealth([]);
           setAudit([]);
+          setSSOProviders([]);
           setFirmwareDistribution(null);
           setFleetHealth(null);
           setStreamStats(null);
@@ -147,6 +157,7 @@ function App() {
     setOperations([]);
     setHealth([]);
     setAudit([]);
+    setSSOProviders([]);
     setFirmwareDistribution(null);
     setFleetHealth(null);
     setStreamStats(null);
@@ -212,6 +223,17 @@ function App() {
       return;
     }
     setRefreshTick((tick) => tick + 1);
+  }
+
+  async function handleSSOProviderSave(orgID, config) {
+    setError('');
+    try {
+      const result = await putJSON(`/api/admin/orgs/${encodeURIComponent(orgID)}/sso-provider`, config);
+      setSSOProviders((providers) => upsertProvider(providers, result.provider));
+    } catch (err) {
+      setError(userFacingSSOError(err));
+      throw err;
+    }
   }
 
   async function handleSSOStart(email) {
@@ -456,6 +478,9 @@ function App() {
         ) : null}
         {!needsPlatformAccess && active === 'groups' ? <GroupsPage /> : null}
         {!needsPlatformAccess && active === 'platform-health' ? <PlatformHealth summary={summary} health={health} /> : null}
+        {!needsPlatformAccess && active === 'platform-sso' ? (
+          <PlatformSSOProviders providers={ssoProviders} customers={customers} onSave={handleSSOProviderSave} />
+        ) : null}
         {!needsPlatformAccess && active === 'platform-operations' ? <Operations operations={operations} /> : null}
         {!needsPlatformAccess && active === 'platform-audit' ? <AuditLog audit={audit} /> : null}
       </main>
@@ -1240,6 +1265,135 @@ function PlatformHealth({ summary, health }) {
       </section>
       {hasDemo ? <section className="panel demo-banner"><p>{`Demo services active: ${demoServices.map((service) => service.name).join(', ')}`}</p></section> : null}
     </>
+  );
+}
+
+function PlatformSSOProviders({ providers, customers, onSave }) {
+  const providerByOrg = useMemo(() => {
+    const byOrg = new Map();
+    for (const provider of providers || []) {
+      byOrg.set(provider.organization_id, provider);
+    }
+    return byOrg;
+  }, [providers]);
+  const rows = (customers || []).map((customer) => providerByOrg.get(customer.organization_id) || {
+    organization_id: customer.organization_id,
+    organization: customer.organization,
+    enabled: false,
+    configured: false,
+    status: 'not_configured',
+    verified_domains: [],
+  });
+
+  return (
+    <>
+      <section className="panel split-panel">
+        <div>
+          <h2>SSO Providers</h2>
+          <p>Platform Admin-managed customer organization identity provider settings.</p>
+          <div className="admin-kpis">
+            <div><strong>{rows.filter((provider) => provider.configured).length}</strong><span>Configured</span></div>
+            <div><strong>{rows.filter((provider) => provider.enabled).length}</strong><span>Enabled</span></div>
+          </div>
+        </div>
+        <div className="sso-note">
+          <strong>Secret handling</strong>
+          <span>Client secrets are sent only to Account Manager and are never returned by this console.</span>
+        </div>
+      </section>
+      <section className="panel">
+        <div className="panel-head">
+          <div>
+            <h2>Organization SSO status</h2>
+            <p>Review setup state, verified domains, issuer, and client identifier by customer organization.</p>
+          </div>
+        </div>
+        <div className="sso-provider-list">
+          {rows.map((provider) => (
+            <SSOProviderCard
+              key={provider.organization_id}
+              provider={provider}
+              onSave={onSave}
+            />
+          ))}
+          {!rows.length ? <p className="empty-state">No customer organizations are available.</p> : null}
+        </div>
+      </section>
+    </>
+  );
+}
+
+function SSOProviderCard({ provider, onSave }) {
+  const [issuer, setIssuer] = useState(provider.issuer || '');
+  const [clientID, setClientID] = useState(provider.client_id || '');
+  const [clientSecret, setClientSecret] = useState('');
+  const [domains, setDomains] = useState((provider.verified_domains || []).join(', '));
+  const [enabled, setEnabled] = useState(Boolean(provider.enabled));
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    setIssuer(provider.issuer || '');
+    setClientID(provider.client_id || '');
+    setDomains((provider.verified_domains || []).join(', '));
+    setEnabled(Boolean(provider.enabled));
+    setClientSecret('');
+  }, [provider]);
+
+  async function submit(event) {
+    event.preventDefault();
+    setBusy(true);
+    try {
+      await onSave(provider.organization_id, {
+        issuer,
+        client_id: clientID,
+        client_secret: clientSecret,
+        verified_domains: domains.split(',').map((domain) => domain.trim()).filter(Boolean),
+        enabled,
+      });
+      setClientSecret('');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form className="sso-provider-card" onSubmit={submit}>
+      <div className="sso-provider-head">
+        <div>
+          <strong>{provider.organization || provider.organization_id}</strong>
+          <small>{provider.organization_id}</small>
+        </div>
+        <span className={`status-pill ${provider.enabled ? 'ok' : provider.configured ? 'warn' : 'neutral'}`}>
+          {provider.enabled ? 'Enabled' : provider.configured ? 'Configured' : 'Not configured'}
+        </span>
+      </div>
+      <div className="sso-provider-grid">
+        <label>
+          <span>Issuer</span>
+          <input value={issuer} onChange={(event) => setIssuer(event.target.value)} placeholder="https://idp.example.com" />
+        </label>
+        <label>
+          <span>Client ID</span>
+          <input value={clientID} onChange={(event) => setClientID(event.target.value)} placeholder="oidc-client-id" />
+        </label>
+        <label>
+          <span>Verified domains</span>
+          <input value={domains} onChange={(event) => setDomains(event.target.value)} placeholder="example.com, example.co.jp" />
+        </label>
+        <label>
+          <span>Client secret</span>
+          <input type="password" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} placeholder="Only sent to Account Manager" autoComplete="new-password" />
+        </label>
+      </div>
+      <div className="sso-provider-foot">
+        <label className="toggle-row">
+          <input type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />
+          <span>Enable provider</span>
+        </label>
+        <span className="muted">{provider.status || 'not_configured'}{provider.last_validated_at ? ` · validated ${formatRelativeTime(provider.last_validated_at)}` : ''}</span>
+        <button type="submit" disabled={busy}>{busy ? 'Saving' : 'Save provider'}</button>
+      </div>
+    </form>
   );
 }
 
@@ -2498,6 +2652,18 @@ function getActiveMembership(me) {
   const memberships = me.memberships || [];
   if (!memberships.length) return null;
   return memberships.find((membership) => membership.organization_id === me.active_org_id) || memberships[0];
+}
+
+function upsertProvider(providers, provider) {
+  if (!provider?.organization_id) return providers;
+  const next = [...providers];
+  const index = next.findIndex((item) => item.organization_id === provider.organization_id);
+  if (index >= 0) {
+    next[index] = provider;
+  } else {
+    next.push(provider);
+  }
+  return next;
 }
 
 function initialsForEmail(email) {

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -8,6 +8,7 @@ export const customerNavItems = [
 
 export const platformNavItems = [
   { id: 'platform-health', label: 'Service Health', path: '/admin' },
+  { id: 'platform-sso', label: 'SSO Providers', path: '/admin/sso' },
   { id: 'platform-operations', label: 'Operations Log', path: '/admin/ops' },
   { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
 ];
@@ -23,6 +24,7 @@ export function titleFor(active) {
     'stream-health': 'Stream Health',
     groups: 'Groups',
     'platform-health': 'Service Health',
+    'platform-sso': 'SSO Providers',
     'platform-operations': 'Operations',
     'platform-audit': 'Audit Log',
   }[active];
@@ -33,6 +35,7 @@ export function routeFromPath(path) {
   if (path === '/signup/check-email' || path.startsWith('/signup/check-email/')) return 'signup-check-email';
   if (path === '/verify' || path.startsWith('/verify/')) return 'verify';
   if (path === '/admin' || path === '/admin/') return 'platform-health';
+  if (path === '/admin/sso' || path.startsWith('/admin/sso/')) return 'platform-sso';
   if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
   if (path === '/admin/operations' || path.startsWith('/admin/operations/')) return 'platform-operations';
   if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -4,6 +4,7 @@ import { customerNavItems, devicesPathWithFilters, routeFromPath, titleFor } fro
 
 test('maps platform shell paths to platform routes', () => {
   assert.equal(routeFromPath('/admin'), 'platform-health');
+  assert.equal(routeFromPath('/admin/sso'), 'platform-sso');
   assert.equal(routeFromPath('/admin/ops'), 'platform-operations');
   assert.equal(routeFromPath('/admin/operations'), 'platform-operations');
   assert.equal(routeFromPath('/admin/audit'), 'platform-audit');
@@ -65,6 +66,7 @@ test('provides titles for all public shell routes', () => {
     'stream-health',
     'groups',
     'platform-health',
+    'platform-sso',
     'platform-operations',
     'platform-audit',
   ]) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2103,6 +2103,104 @@ th {
   color: var(--muted);
 }
 
+.sso-note {
+  align-self: center;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--brand-soft);
+  color: var(--brand-dark);
+  display: grid;
+  gap: 4px;
+  padding: 16px;
+  max-width: 360px;
+}
+
+.sso-note span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.sso-provider-list {
+  display: grid;
+  gap: 14px;
+}
+
+.sso-provider-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--bg-panel);
+  display: grid;
+  gap: 16px;
+  padding: 16px;
+}
+
+.sso-provider-head,
+.sso-provider-foot {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.sso-provider-head small {
+  color: var(--muted);
+  display: block;
+  margin-top: 2px;
+}
+
+.sso-provider-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.sso-provider-grid label {
+  display: grid;
+  gap: 6px;
+}
+
+.sso-provider-grid span,
+.toggle-row span {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.toggle-row {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+}
+
+.sso-provider-foot .muted {
+  color: var(--muted);
+  flex: 1;
+  font-size: 13px;
+}
+
+.status-pill {
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 6px 10px;
+}
+
+.status-pill.ok {
+  background: #e7f6f7;
+  color: var(--brand-dark);
+}
+
+.status-pill.warn {
+  background: rgba(109, 206, 221, 0.16);
+  color: var(--navy);
+}
+
+.status-pill.neutral {
+  background: rgba(37, 56, 76, 0.08);
+  color: var(--muted);
+}
+
 .status-online,
 .status-healthy,
 .status-ok,
@@ -2227,8 +2325,15 @@ th {
 
   .stream-health-layout,
   .stream-health-metrics,
-  .stream-mode-summary {
+  .stream-mode-summary,
+  .sso-provider-grid {
     grid-template-columns: 1fr;
+  }
+
+  .sso-provider-head,
+  .sso-provider-foot {
+    align-items: stretch;
+    display: grid;
   }
 
   .firmware-version-row,


### PR DESCRIPTION
Closes #80.\n\n## Summary\n- Add Platform Admin-protected BFF routes for listing and updating customer SSO provider settings through Account Manager.\n- Add Platform View SSO Providers page with issuer, client ID, verified domains, enablement, setup status, and secret submission.\n- Keep client secrets out of Admin Console responses and audit data; secrets are only forwarded to Account Manager.\n\n## Validation\n- go test ./internal/app ./internal/accountclient\n- go test ./...\n- go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out\n- npm test --prefix web\n- npm run build --prefix web\n- scripts/validate_test_report.sh docs/TEST_REPORT.md\n- Browser rendered check with mock Account Manager: /admin/sso shows provider settings and does not expose client_secret or secret value