### PR TITLE
[SSO] Add rollout audit and regression coverage

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.1% |
+| Go total coverage | 80.3% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,7 +28,7 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 91.2% |
-| `rtk_cloud_admin/internal/app` | 79.8% |
+| `rtk_cloud_admin/internal/app` | 80.1% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -483,6 +483,10 @@ func (s *Server) apiSSOCallback(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+	if err := s.auditSSOSession(result.User.Email, result.Kind, activeOrgID, "accepted"); err != nil {
+		writeError(w, err)
+		return
+	}
 	setSessionCookie(w, session.ID)
 	if result.Kind == "platform_admin" {
 		http.Redirect(w, r, "/admin", http.StatusFound)
@@ -608,7 +612,11 @@ func (s *Server) apiPlatformLogin(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) apiLogout(w http.ResponseWriter, r *http.Request) {
 	if cookie, err := r.Cookie("rtk_admin_session"); err == nil {
+		session, sessionErr := s.store.GetSession(cookie.Value)
 		_ = s.store.DeleteSession(cookie.Value)
+		if sessionErr == nil {
+			_ = s.auditSessionLogout(session)
+		}
 	}
 	http.SetCookie(w, &http.Cookie{Name: "rtk_admin_session", Value: "", Path: "/", MaxAge: -1, HttpOnly: true, SameSite: http.SameSiteLaxMode})
 	writeJSON(w, map[string]string{"status": "ok"})
@@ -2844,6 +2852,28 @@ func (s *Server) auditPlatformBreakGlassLogin(email, result string) error {
 		Action:    "PlatformBreakGlassLogin",
 		Target:    "platform_admin",
 		Result:    result,
+	})
+}
+
+func (s *Server) auditSSOSession(email, kind, orgID, result string) error {
+	return s.store.CreateAuditEventWithMetadata(store.AuditEventInput{
+		Actor:          fallback(email, "unknown-sso-user"),
+		ActorKind:      fallback(kind, "sso"),
+		Action:         "SSOLogin",
+		Target:         fallback(kind, "sso_session"),
+		OrganizationID: orgID,
+		Result:         result,
+	})
+}
+
+func (s *Server) auditSessionLogout(session store.Session) error {
+	return s.store.CreateAuditEventWithMetadata(store.AuditEventInput{
+		Actor:          fallback(session.Email, session.Subject),
+		ActorKind:      fallback(session.Kind, "session"),
+		Action:         "SessionLogout",
+		Target:         fallback(session.Kind, "session"),
+		OrganizationID: session.ActiveOrgID,
+		Result:         "accepted",
 	})
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -252,8 +252,15 @@ func TestSSOStartAndCallbackCreateSessions(t *testing.T) {
 	meReq.AddCookie(customerCallback.Result().Cookies()[0])
 	meRec := httptest.NewRecorder()
 	srv.ServeHTTP(meRec, meReq)
-	if meRec.Code != http.StatusOK || !strings.Contains(meRec.Body.String(), `"kind":"customer"`) || !strings.Contains(meRec.Body.String(), `"active_org_id":"org-1"`) {
+	if meRec.Code != http.StatusOK {
 		t.Fatalf("me status = %d, body=%s", meRec.Code, meRec.Body.String())
+	}
+	var customerMe contracts.Me
+	if err := json.NewDecoder(meRec.Body).Decode(&customerMe); err != nil {
+		t.Fatalf("decode customer me: %v", err)
+	}
+	if customerMe.Kind != "customer" || customerMe.ActiveOrgID != "org-1" || !customerMe.Authenticated || customerMe.DemoMode || len(customerMe.Memberships) != 1 {
+		t.Fatalf("customer me = %#v", customerMe)
 	}
 
 	adminCallback := httptest.NewRecorder()
@@ -271,6 +278,36 @@ func TestSSOStartAndCallbackCreateSessions(t *testing.T) {
 	if adminSession.Kind != "platform_admin" || adminSession.Subject != "admin-1" || adminSession.AccessToken != "admin-access" {
 		t.Fatalf("admin session = %#v", adminSession)
 	}
+
+	adminMeReq := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	adminMeReq.AddCookie(adminCallback.Result().Cookies()[0])
+	adminMeRec := httptest.NewRecorder()
+	srv.ServeHTTP(adminMeRec, adminMeReq)
+	if adminMeRec.Code != http.StatusOK {
+		t.Fatalf("admin me status = %d, body=%s", adminMeRec.Code, adminMeRec.Body.String())
+	}
+	var adminMe contracts.Me
+	if err := json.NewDecoder(adminMeRec.Body).Decode(&adminMe); err != nil {
+		t.Fatalf("decode admin me: %v", err)
+	}
+	if adminMe.Kind != "platform_admin" || !adminMe.Authenticated || adminMe.DemoMode || adminMe.Memberships == nil || len(adminMe.Memberships) != 0 {
+		t.Fatalf("admin me = %#v", adminMe)
+	}
+
+	logout := httptest.NewRecorder()
+	logoutReq := httptest.NewRequest(http.MethodPost, "/api/auth/logout", nil)
+	logoutReq.AddCookie(customerCallback.Result().Cookies()[0])
+	srv.ServeHTTP(logout, logoutReq)
+	if logout.Code != http.StatusOK {
+		t.Fatalf("logout status = %d, body=%s", logout.Code, logout.Body.String())
+	}
+	events, err := st.ListAuditEvents()
+	if err != nil {
+		t.Fatalf("ListAuditEvents returned error: %v", err)
+	}
+	assertAuditEvent(t, events, "SSOLogin", "owner@example.com", "customer", "accepted")
+	assertAuditEvent(t, events, "SSOLogin", "admin@example.com", "platform_admin", "accepted")
+	assertAuditEvent(t, events, "SessionLogout", "owner@example.com", "customer", "accepted")
 }
 
 func TestSSOEndpointsMapStableErrors(t *testing.T) {
@@ -345,6 +382,24 @@ func TestSSOEndpointsMapStableErrors(t *testing.T) {
 	if missing.Code != http.StatusBadRequest {
 		t.Fatalf("missing callback status = %d, body=%s", missing.Code, missing.Body.String())
 	}
+
+	disabled := httptest.NewRecorder()
+	NewWithOptions(mustOpenStore(t), Options{}).ServeHTTP(disabled, httptest.NewRequest(http.MethodPost, "/api/auth/sso/start", strings.NewReader(`{"email":"owner@example.com"}`)))
+	if disabled.Code != http.StatusServiceUnavailable {
+		t.Fatalf("disabled sso start status = %d, body=%s", disabled.Code, disabled.Body.String())
+	}
+
+	invalidStart := httptest.NewRecorder()
+	srv.ServeHTTP(invalidStart, httptest.NewRequest(http.MethodPost, "/api/auth/sso/start", strings.NewReader(`{`)))
+	if invalidStart.Code != http.StatusBadRequest {
+		t.Fatalf("invalid sso start status = %d, body=%s", invalidStart.Code, invalidStart.Body.String())
+	}
+
+	missingEmail := httptest.NewRecorder()
+	srv.ServeHTTP(missingEmail, httptest.NewRequest(http.MethodPost, "/api/auth/sso/start", strings.NewReader(`{"email":" "}`)))
+	if missingEmail.Code != http.StatusBadRequest {
+		t.Fatalf("missing email status = %d, body=%s", missingEmail.Code, missingEmail.Body.String())
+	}
 }
 
 func TestLegacyCustomerPasswordLoginDisabledByDefault(t *testing.T) {
@@ -367,6 +422,65 @@ func TestLegacyCustomerPasswordLoginDisabledByDefault(t *testing.T) {
 	}
 	if !strings.Contains(rec.Body.String(), "customer password login is disabled") {
 		t.Fatalf("customer login body = %s", rec.Body.String())
+	}
+}
+
+func TestSSOCustomerMeAllowsMissingMemberships(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/sso/callback":
+			_ = json.NewEncoder(w).Encode(accountclient.SSOCallbackResult{
+				User:   accountclient.User{ID: "u-empty", Email: "empty@example.com", Name: "Empty"},
+				Kind:   "customer",
+				Tokens: accountclient.Tokens{AccessToken: "empty-access", RefreshToken: "empty-refresh", ExpiresIn: 3600},
+			})
+		case "/v1/me":
+			if got := r.Header.Get("Authorization"); got != "Bearer empty-access" {
+				t.Fatalf("me Authorization = %q", got)
+			}
+			_ = json.NewEncoder(w).Encode(accountclient.MeResult{
+				User:          accountclient.User{ID: "u-empty", Email: "empty@example.com", Name: "Empty"},
+				Organizations: []accountclient.Organization{},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st := mustOpenStore(t)
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+	callback := httptest.NewRecorder()
+	srv.ServeHTTP(callback, httptest.NewRequest(http.MethodGet, "/api/auth/sso/callback?code=no-org-code&state=state-1", nil))
+	if callback.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, body=%s", callback.Code, callback.Body.String())
+	}
+	session, err := st.GetSession(callback.Result().Cookies()[0].Value)
+	if err != nil {
+		t.Fatalf("GetSession returned error: %v", err)
+	}
+	if session.ActiveOrgID != "" {
+		t.Fatalf("active org = %q, want empty", session.ActiveOrgID)
+	}
+
+	meReq := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	meReq.AddCookie(callback.Result().Cookies()[0])
+	meRec := httptest.NewRecorder()
+	srv.ServeHTTP(meRec, meReq)
+	if meRec.Code != http.StatusOK {
+		t.Fatalf("me status = %d, body=%s", meRec.Code, meRec.Body.String())
+	}
+	var me contracts.Me
+	if err := json.NewDecoder(meRec.Body).Decode(&me); err != nil {
+		t.Fatalf("decode me: %v", err)
+	}
+	if me.Kind != "customer" || me.ActiveOrgID != "" || me.Memberships == nil || len(me.Memberships) != 0 {
+		t.Fatalf("me missing memberships contract = %#v", me)
 	}
 }
 
@@ -618,6 +732,16 @@ func legacyCustomerLoginConfig(baseURL string) config.Config {
 		AccountManagerBaseURL:              baseURL,
 		LegacyCustomerPasswordLoginEnabled: true,
 	}
+}
+
+func assertAuditEvent(t *testing.T, events []contracts.AuditEvent, action, actor, actorKind, result string) {
+	t.Helper()
+	for _, event := range events {
+		if event.Action == action && event.Actor == actor && event.ActorKind == actorKind && event.Result == result {
+			return
+		}
+	}
+	t.Fatalf("missing audit event action=%q actor=%q actorKind=%q result=%q in %#v", action, actor, actorKind, result, events)
 }
 
 func TestProvisionActionPublishesOperation(t *testing.T) {

--- a/web/src/auth-state.mjs
+++ b/web/src/auth-state.mjs
@@ -1,0 +1,7 @@
+export function shouldShowBreakGlass(me) {
+  return Boolean(me?.break_glass_enabled);
+}
+
+export function isPlatformOnlySSOSettingsRoute(route) {
+  return route === 'platform-sso';
+}

--- a/web/src/auth-state.test.mjs
+++ b/web/src/auth-state.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { isPlatformOnlySSOSettingsRoute, shouldShowBreakGlass } from './auth-state.mjs';
+import { customerNavItems, platformNavItems } from './routes.mjs';
+
+test('break-glass UI is visible only when backend policy enables it', () => {
+  assert.equal(shouldShowBreakGlass(null), false);
+  assert.equal(shouldShowBreakGlass({ break_glass_enabled: false }), false);
+  assert.equal(shouldShowBreakGlass({ break_glass_enabled: true }), true);
+});
+
+test('customer navigation does not expose platform SSO provider controls', () => {
+  assert.equal(customerNavItems.some((item) => isPlatformOnlySSOSettingsRoute(item.id)), false);
+  assert.equal(platformNavItems.some((item) => isPlatformOnlySSOSettingsRoute(item.id)), true);
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { customerNavItems, devicesPathWithFilters, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
 import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
+import { shouldShowBreakGlass } from './auth-state.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -1233,7 +1234,7 @@ function PlatformAccessGate({ active, me, onSSOStart, onBreakGlassLogin }) {
   return (
     <>
       <SSOLoginPanel title="Platform SSO sign in" onSSOStart={onSSOStart} />
-      {me?.break_glass_enabled ? (
+      {shouldShowBreakGlass(me) ? (
         <BreakGlassLoginPanel title="Break-glass platform access" onLogin={onBreakGlassLogin} />
       ) : null}
       <section className="panel split-panel">
@@ -2346,7 +2347,7 @@ function PlatformAdmin({ summary, health, devices, customers, operations, audit,
       {me?.kind !== 'platform_admin' ? (
         <>
           <SSOLoginPanel title="Platform SSO sign in" onSSOStart={onSSOStart} />
-          {me?.break_glass_enabled ? (
+          {shouldShowBreakGlass(me) ? (
             <BreakGlassLoginPanel title="Break-glass platform access" onLogin={onBreakGlassLogin} />
           ) : null}
         </>


### PR DESCRIPTION
Closes #81.\n\n## Summary\n- Add audit rows for successful SSO session creation and local session logout.\n- Expand SSO regression tests for /api/me customer/platform contracts, missing memberships, disabled/invalid SSO start cases, callback errors, logout audit, and break-glass audit.\n- Add frontend regression helpers/tests for break-glass visibility policy and keeping SSO provider controls out of Customer View navigation.\n\n## Validation\n- go test ./internal/app\n- go test ./...\n- go test ./... -coverprofile=coverage.out && go tool cover -func=coverage.out (total 80.3%)\n- npm test --prefix web\n- npm run build --prefix web\n- scripts/validate_test_report.sh docs/TEST_REPORT.md