### PR TITLE
Implement upstream-backed API read models

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.3% |
+| Go total coverage | 80.7% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -27,12 +27,12 @@
 | Package | Coverage |
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 91.2% |
-| `rtk_cloud_admin/internal/app` | 80.1% |
+| `rtk_cloud_admin/internal/accountclient` | 89.5% |
+| `rtk_cloud_admin/internal/app` | 80.5% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |
-| `rtk_cloud_admin/internal/videoclient` | 86.8% |
+| `rtk_cloud_admin/internal/videoclient` | 87.4% |
 
 ## Artifact Policy
 

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -48,10 +48,17 @@ type Device struct {
 }
 
 type Operation struct {
-	ID        string `json:"id"`
-	State     string `json:"state"`
-	Message   string `json:"message"`
-	UpdatedAt string `json:"updated_at"`
+	ID                  string `json:"id"`
+	DeviceID            string `json:"device_id,omitempty"`
+	DeviceName          string `json:"device_name,omitempty"`
+	OrganizationID      string `json:"organization_id,omitempty"`
+	Organization        string `json:"organization,omitempty"`
+	Type                string `json:"type,omitempty"`
+	State               string `json:"state"`
+	UpstreamOperationID string `json:"upstream_operation_id,omitempty"`
+	UpstreamState       string `json:"upstream_state,omitempty"`
+	Message             string `json:"message"`
+	UpdatedAt           string `json:"updated_at"`
 }
 
 type Tokens struct {
@@ -301,6 +308,16 @@ func (c *Client) Organizations(ctx context.Context, accessToken string) ([]Organ
 	return body.Organizations, nil
 }
 
+func (c *Client) AdminOrganizations(ctx context.Context, accessToken string) ([]Organization, error) {
+	var body struct {
+		Organizations []Organization `json:"organizations"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/admin/orgs", accessToken, nil, &body); err != nil {
+		return nil, err
+	}
+	return body.Organizations, nil
+}
+
 func (c *Client) Devices(ctx context.Context, accessToken, orgID string) ([]Device, error) {
 	var body struct {
 		Devices []Device `json:"devices"`
@@ -309,6 +326,26 @@ func (c *Client) Devices(ctx context.Context, accessToken, orgID string) ([]Devi
 		return nil, err
 	}
 	return body.Devices, nil
+}
+
+func (c *Client) AdminDevices(ctx context.Context, accessToken string) ([]Device, error) {
+	var body struct {
+		Devices []Device `json:"devices"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/admin/devices", accessToken, nil, &body); err != nil {
+		return nil, err
+	}
+	return body.Devices, nil
+}
+
+func (c *Client) AdminOperations(ctx context.Context, accessToken string) ([]Operation, error) {
+	var body struct {
+		Operations []Operation `json:"operations"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/admin/operations", accessToken, nil, &body); err != nil {
+		return nil, err
+	}
+	return body.Operations, nil
 }
 
 func (c *Client) CreateQuotaRaiseRequest(ctx context.Context, accessToken, orgID string, req QuotaRaiseRequest) (QuotaRaiseRequestResult, error) {

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -73,6 +73,63 @@ func TestClientRefresh(t *testing.T) {
 	}
 }
 
+func TestClientAdminInventory(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-access" {
+			t.Fatalf("%s Authorization = %q, want Bearer admin-access", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/admin/orgs":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"organizations": []map[string]any{
+					{"id": "org-admin", "name": "Admin Org", "role": "owner", "tier": "commercial"},
+				},
+			})
+		case "/v1/admin/devices":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"devices": []map[string]any{
+					{"id": "dev-admin", "organization_id": "org-admin", "organization": "Admin Org", "name": "Admin Camera", "category": "ip_camera", "model": "RTK-CAM-A", "serial_number": "ADMIN-001", "video_cloud_devid": "vc-admin", "status": "online", "readiness": "online", "last_seen_at": "2026-05-11T00:00:00Z", "updated_at": "2026-05-11T00:00:00Z"},
+				},
+			})
+		case "/v1/admin/operations":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"operations": []map[string]any{
+					{"id": "op-admin", "device_id": "dev-admin", "device_name": "Admin Camera", "organization_id": "org-admin", "organization": "Admin Org", "type": "DeviceProvisionRequested", "state": "published", "message": "queued", "updated_at": "2026-05-11T00:00:00Z"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL)
+	orgs, err := client.AdminOrganizations(t.Context(), "admin-access")
+	if err != nil {
+		t.Fatalf("AdminOrganizations returned error: %v", err)
+	}
+	if len(orgs) != 1 || orgs[0].ID != "org-admin" || orgs[0].Tier != "commercial" {
+		t.Fatalf("orgs = %#v", orgs)
+	}
+	devices, err := client.AdminDevices(t.Context(), "admin-access")
+	if err != nil {
+		t.Fatalf("AdminDevices returned error: %v", err)
+	}
+	if len(devices) != 1 || devices[0].ID != "dev-admin" || devices[0].OrganizationID != "org-admin" {
+		t.Fatalf("devices = %#v", devices)
+	}
+	ops, err := client.AdminOperations(t.Context(), "admin-access")
+	if err != nil {
+		t.Fatalf("AdminOperations returned error: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "op-admin" || ops[0].DeviceID != "dev-admin" || ops[0].Type != "DeviceProvisionRequested" {
+		t.Fatalf("operations = %#v", ops)
+	}
+}
+
 func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -219,7 +220,17 @@ func (s *Server) apiSummary(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiAdminSummary(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	if s.usePlatformAdminUpstream(session) {
+		summary, err := s.platformAdminSummary(r.Context(), session)
+		if err != nil {
+			s.writeUpstreamReadError(w, err)
+			return
+		}
+		writeJSON(w, summary)
 		return
 	}
 	summary, err := s.store.Summary()
@@ -641,7 +652,17 @@ func (s *Server) apiDevices(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiAdminDevices(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	if s.usePlatformAdminUpstream(session) {
+		devices, err := s.platformAdminDevices(r.Context(), session)
+		if err != nil {
+			s.writeUpstreamReadError(w, err)
+			return
+		}
+		writeJSON(w, devicesWithFirmwareVersion(devices))
 		return
 	}
 	devices, err := s.store.ListDevices()
@@ -739,25 +760,20 @@ func (s *Server) apiFleetStreamStats(w http.ResponseWriter, r *http.Request) {
 		s.writeCustomerErrorForSession(w, session.ID, err)
 		return
 	}
-	var devices []contracts.Device
-	if s.accountClient.Enabled() {
-		allDevices, err := s.customerDevices(r.Context(), session)
+	devices, err := s.customerStreamDevices(r.Context(), session, orgID)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	devices = filterDevicesByOrg(devices, orgID)
+	if s.videoClient.Enabled() && strings.TrimSpace(s.cfg.VideoCloudAdminToken) != "" {
+		stats, err := s.videoClient.FleetStreamStats(r.Context(), s.cfg.VideoCloudAdminToken, orgID, window, videoCloudDeviceIDs(devices))
 		if err != nil {
-			s.writeCustomerErrorForSession(w, session.ID, err)
+			s.writeVideoCloudGatewayError(w, fmt.Errorf("%w: %w", errVideoCloudRequestFailed, err))
 			return
 		}
-		devices = append(devices, allDevices...)
-	} else {
-		allDevices, err := s.store.ListDevices()
-		if err != nil {
-			writeError(w, err)
-			return
-		}
-		for _, device := range allDevices {
-			if device.OrganizationID == orgID {
-				devices = append(devices, device)
-			}
-		}
+		writeJSON(w, mapVideoCloudFleetStreamStats(stats, orgID, window))
+		return
 	}
 	writeJSON(w, fleetStreamStats(orgID, devices, days, window))
 }
@@ -1476,6 +1492,80 @@ func fleetStreamStats(orgID string, devices []contracts.Device, days int, window
 		TrendByMode:        modeTrendSeries,
 		WorstDevices:       worst,
 	}
+}
+
+func filterDevicesByOrg(devices []contracts.Device, orgID string) []contracts.Device {
+	filtered := make([]contracts.Device, 0, len(devices))
+	for _, device := range devices {
+		if device.OrganizationID == orgID {
+			filtered = append(filtered, device)
+		}
+	}
+	return filtered
+}
+
+func videoCloudDeviceIDs(devices []contracts.Device) []string {
+	ids := make([]string, 0, len(devices))
+	for _, device := range devices {
+		if id := strings.TrimSpace(device.VideoCloudDevID); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func mapVideoCloudFleetStreamStats(stats videoclient.FleetStreamStats, orgID, window string) contracts.FleetStreamStats {
+	out := contracts.FleetStreamStats{
+		OrgID:              fallback(stats.OrgID, orgID),
+		Window:             fallback(stats.Window, window),
+		SuccessRatePct:     stats.SuccessRatePct,
+		AvgDurationSeconds: stats.AvgDurationSeconds,
+		ActiveSessions:     stats.ActiveSessions,
+		NeverStreamedCount: stats.NeverStreamedCount,
+		ByMode:             make(map[string]contracts.FleetStreamStatsMode, len(stats.ByMode)),
+		Trend:              make([]contracts.FleetStreamTrendPoint, 0, len(stats.Trend)),
+		TrendByMode:        make([]contracts.FleetStreamModeTrend, 0, len(stats.TrendByMode)),
+		WorstDevices:       make([]contracts.FleetStreamWorstDevice, 0, len(stats.WorstDevices)),
+	}
+	for mode, modeStats := range stats.ByMode {
+		out.ByMode[mode] = contracts.FleetStreamStatsMode{
+			Requests:       modeStats.Requests,
+			SuccessRatePct: modeStats.SuccessRatePct,
+		}
+	}
+	for _, point := range stats.Trend {
+		out.Trend = append(out.Trend, contracts.FleetStreamTrendPoint{
+			Date:           point.Date,
+			Requests:       point.Requests,
+			SuccessRatePct: point.SuccessRatePct,
+		})
+	}
+	for _, series := range stats.TrendByMode {
+		mapped := contracts.FleetStreamModeTrend{
+			Mode:   series.Mode,
+			Points: make([]contracts.FleetStreamTrendPoint, 0, len(series.Points)),
+		}
+		for _, point := range series.Points {
+			mapped.Points = append(mapped.Points, contracts.FleetStreamTrendPoint{
+				Date:           point.Date,
+				Requests:       point.Requests,
+				SuccessRatePct: point.SuccessRatePct,
+			})
+		}
+		out.TrendByMode = append(out.TrendByMode, mapped)
+	}
+	for _, device := range stats.WorstDevices {
+		out.WorstDevices = append(out.WorstDevices, contracts.FleetStreamWorstDevice{
+			DeviceID:       device.DeviceID,
+			DeviceName:     device.DeviceName,
+			ModeUsed:       device.ModeUsed,
+			Readiness:      device.Readiness,
+			SuccessRatePct: device.SuccessRatePct,
+			Requests:       device.Requests,
+			LastStreamAt:   device.LastStreamAt,
+		})
+	}
+	return out
 }
 
 type streamProfileData struct {
@@ -2259,7 +2349,17 @@ func (s *Server) apiCustomers(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiAdminCustomers(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	if s.usePlatformAdminUpstream(session) {
+		customers, err := s.platformAdminCustomers(r.Context(), session)
+		if err != nil {
+			s.writeUpstreamReadError(w, err)
+			return
+		}
+		writeJSON(w, customers)
 		return
 	}
 	customers, err := s.store.ListCustomers()
@@ -2347,7 +2447,17 @@ func (s *Server) apiOperations(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiAdminOperations(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	if s.usePlatformAdminUpstream(session) {
+		ops, err := s.platformAdminOperations(r.Context(), session)
+		if err != nil {
+			s.writeUpstreamReadError(w, err)
+			return
+		}
+		writeJSON(w, ops)
 		return
 	}
 	ops, err := s.store.ListOperations()
@@ -2558,6 +2668,176 @@ func (s *Server) customerOperations(ctx context.Context, session store.Session) 
 		}
 	}
 	return filtered, nil
+}
+
+func (s *Server) customerStreamDevices(ctx context.Context, session store.Session, orgID string) ([]contracts.Device, error) {
+	if !s.accountClient.Enabled() {
+		allDevices, err := s.store.ListDevices()
+		if err != nil {
+			return nil, err
+		}
+		return filterDevicesByOrg(allDevices, orgID), nil
+	}
+	org, tokens, err := s.activeCustomerOrg(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	var upstreamDevices []accountclient.Device
+	tokens, err = s.customerCall(ctx, tokens, func(token string) error {
+		var callErr error
+		upstreamDevices, callErr = s.accountClient.Devices(ctx, token, org.ID)
+		return callErr
+	})
+	if err != nil {
+		return nil, err
+	}
+	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
+		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
+	}
+	devices := make([]contracts.Device, 0, len(upstreamDevices))
+	for _, device := range upstreamDevices {
+		devices = append(devices, mapUpstreamDevice(org, device, nil))
+	}
+	return devices, nil
+}
+
+func (s *Server) usePlatformAdminUpstream(session store.Session) bool {
+	return s.accountClient.Enabled() && strings.TrimSpace(session.AccessToken) != ""
+}
+
+func (s *Server) platformAdminSummary(ctx context.Context, session store.Session) (contracts.Summary, error) {
+	devices, err := s.platformAdminDevices(ctx, session)
+	if err != nil {
+		return contracts.Summary{}, err
+	}
+	ops, err := s.platformAdminOperations(ctx, session)
+	if err != nil {
+		return contracts.Summary{}, err
+	}
+	return summaryFromReadModels(devices, ops), nil
+}
+
+func (s *Server) platformAdminCustomers(ctx context.Context, session store.Session) ([]contracts.CustomerSummary, error) {
+	devices, err := s.platformAdminDevices(ctx, session)
+	if err != nil {
+		return nil, err
+	}
+	return customerSummariesFromDevices(devices), nil
+}
+
+func (s *Server) platformAdminDevices(ctx context.Context, session store.Session) ([]contracts.Device, error) {
+	orgs, err := s.accountClient.AdminOrganizations(ctx, session.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+	upstreamDevices, err := s.accountClient.AdminDevices(ctx, session.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+	vcFacts, err := s.videoCloudFacts(ctx, upstreamDevices)
+	if err != nil {
+		return nil, err
+	}
+	orgByID := make(map[string]accountclient.Organization, len(orgs))
+	for _, org := range orgs {
+		orgByID[org.ID] = org
+	}
+	devices := make([]contracts.Device, 0, len(upstreamDevices))
+	for _, device := range upstreamDevices {
+		org := orgByID[device.OrganizationID]
+		if org.ID == "" {
+			org = accountclient.Organization{ID: device.OrganizationID, Name: device.Organization}
+		}
+		vid := fallback(device.VideoCloudDevID, metadataString(device.Metadata, "video_cloud_devid", ""))
+		devices = append(devices, mapUpstreamDevice(org, device, vcFacts[vid]))
+	}
+	return devices, nil
+}
+
+func (s *Server) platformAdminOperations(ctx context.Context, session store.Session) ([]contracts.Operation, error) {
+	upstreamOps, err := s.accountClient.AdminOperations(ctx, session.AccessToken)
+	if err != nil {
+		return nil, err
+	}
+	ops := make([]contracts.Operation, 0, len(upstreamOps))
+	for _, op := range upstreamOps {
+		state := mapOperationState(op.State)
+		ops = append(ops, contracts.Operation{
+			ID:                  op.ID,
+			DeviceID:            op.DeviceID,
+			DeviceName:          op.DeviceName,
+			Organization:        fallback(op.Organization, op.OrganizationID),
+			Type:                fallback(op.Type, "DeviceProvisionRequested"),
+			State:               state,
+			UpstreamOperationID: fallback(op.UpstreamOperationID, op.ID),
+			UpstreamState:       fallback(op.UpstreamState, op.State),
+			Message:             op.Message,
+			UpdatedAt:           op.UpdatedAt,
+		})
+	}
+	return ops, nil
+}
+
+func summaryFromReadModels(devices []contracts.Device, ops []contracts.Operation) contracts.Summary {
+	seenOrgs := map[string]bool{}
+	summary := contracts.Summary{TotalDevices: len(devices)}
+	for _, device := range devices {
+		seenOrgs[device.OrganizationID] = true
+		switch device.Readiness {
+		case contracts.ReadinessOnline:
+			summary.OnlineDevices++
+			summary.ActivatedDevices++
+		case contracts.ReadinessActivated:
+			summary.ActivatedDevices++
+		case contracts.ReadinessCloudActivationPending, contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending, contracts.ReadinessDeactivationPending:
+			summary.PendingDevices++
+		case contracts.ReadinessFailed:
+			summary.FailedDevices++
+		}
+	}
+	for _, op := range ops {
+		if op.State != contracts.OperationSucceeded {
+			summary.OpenOperations++
+		}
+	}
+	summary.Customers = len(seenOrgs)
+	return summary
+}
+
+func customerSummariesFromDevices(devices []contracts.Device) []contracts.CustomerSummary {
+	byOrg := map[string]*contracts.CustomerSummary{}
+	order := []string{}
+	for _, device := range devices {
+		customer, ok := byOrg[device.OrganizationID]
+		if !ok {
+			customer = &contracts.CustomerSummary{
+				OrganizationID: device.OrganizationID,
+				Organization:   device.Organization,
+			}
+			byOrg[device.OrganizationID] = customer
+			order = append(order, device.OrganizationID)
+		}
+		customer.TotalDevices++
+		switch device.Readiness {
+		case contracts.ReadinessOnline:
+			customer.OnlineDevices++
+			customer.ActivatedDevices++
+		case contracts.ReadinessActivated:
+			customer.ActivatedDevices++
+		case contracts.ReadinessCloudActivationPending, contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending, contracts.ReadinessDeactivationPending:
+			customer.PendingDevices++
+		case contracts.ReadinessFailed:
+			customer.FailedDevices++
+		}
+		if device.LastSeenAt > customer.LastSeenAt {
+			customer.LastSeenAt = device.LastSeenAt
+		}
+	}
+	customers := make([]contracts.CustomerSummary, 0, len(order))
+	for _, orgID := range order {
+		customers = append(customers, *byOrg[orgID])
+	}
+	return customers
 }
 
 func (s *Server) customerAudit(ctx context.Context, session store.Session) ([]contracts.AuditEvent, error) {
@@ -2843,6 +3123,47 @@ func (s *Server) writeCustomerError(w http.ResponseWriter, err error) {
 		return
 	}
 	writeError(w, err)
+}
+
+func (s *Server) writeUpstreamReadError(w http.ResponseWriter, err error) {
+	if errors.Is(err, errVideoCloudRequestFailed) {
+		s.writeVideoCloudGatewayError(w, err)
+		return
+	}
+	if status, ok := customerUpstreamStatus(err); ok {
+		switch status {
+		case http.StatusUnauthorized:
+			http.Error(w, "platform admin upstream session expired; please sign in again", http.StatusUnauthorized)
+		case http.StatusForbidden:
+			http.Error(w, "Account Manager denied access to the requested resource", http.StatusForbidden)
+		case http.StatusGatewayTimeout:
+			http.Error(w, "Account Manager request timed out", http.StatusGatewayTimeout)
+		default:
+			http.Error(w, "Account Manager request failed", http.StatusBadGateway)
+		}
+		return
+	}
+	writeError(w, err)
+}
+
+func (s *Server) writeVideoCloudGatewayError(w http.ResponseWriter, err error) {
+	if isTimeoutError(err) {
+		http.Error(w, "Video Cloud request timed out", http.StatusGatewayTimeout)
+		return
+	}
+	if errors.Is(err, errVideoCloudRequestFailed) {
+		http.Error(w, "Video Cloud request failed", http.StatusBadGateway)
+		return
+	}
+	writeError(w, err)
+}
+
+func isTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func (s *Server) auditPlatformBreakGlassLogin(email, result string) error {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2085,6 +2085,206 @@ func TestFleetStreamStatsWindow30dAndOrgScope(t *testing.T) {
 	}
 }
 
+func TestFleetStreamStatsProxyModeUsesVideoCloudAndActiveOrg(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("Authorization"); got != "Bearer access" {
+			t.Fatalf("%s Authorization = %q, want Bearer access", r.URL.Path, got)
+		}
+		switch r.URL.Path {
+		case "/v1/me":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"user": map[string]any{"id": "u1", "email": "customer@example.com", "name": "Customer"},
+				"organizations": []map[string]any{
+					{"id": "org-acme", "name": "Acme", "role": "owner"},
+					{"id": "org-nova", "name": "Nova", "role": "viewer"},
+				},
+			})
+		case "/v1/orgs/org-acme/devices":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"devices": []map[string]any{
+					{"id": "dev-acme", "organization_id": "org-acme", "organization": "Acme", "name": "Acme Cam", "category": "ip_camera", "model": "RTK-CAM-A", "serial_number": "ACME-001", "video_cloud_devid": "vc-acme", "status": "online", "readiness": "online", "last_seen_at": "2026-05-11T00:00:00Z", "updated_at": "2026-05-11T00:00:00Z"},
+				},
+			})
+		case "/v1/orgs/org-nova/devices":
+			t.Fatalf("inactive organization devices endpoint should not be called")
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	var streamStatsCalls int
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if got := r.Header.Get("Authorization"); got != "Bearer vc-secret" {
+			t.Fatalf("%s Authorization = %q, want Bearer vc-secret", r.URL.Path, got)
+		}
+		switch r.URL.Path {
+		case "/api/fleet/stream-stats":
+			streamStatsCalls++
+			q := r.URL.Query()
+			if q.Get("org_id") != "org-acme" || q.Get("window") != "30d" || q.Get("devices") != "vc-acme" {
+				t.Fatalf("stream stats query = %s, want org_id=org-acme window=30d devices=vc-acme", r.URL.RawQuery)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"org_id":               "org-acme",
+				"window":               "30d",
+				"success_rate_pct":     88.5,
+				"avg_duration_seconds": 14.5,
+				"active_sessions":      7,
+				"never_streamed_count": 2,
+				"by_mode": map[string]any{
+					"webrtc": map[string]any{"requests": 16, "success_rate_pct": 88.5},
+				},
+				"trend": []map[string]any{
+					{"date": "2026-05-11", "requests": 16, "success_rate_pct": 88.5},
+				},
+				"trend_by_mode": []map[string]any{
+					{"mode": "webrtc", "points": []map[string]any{{"date": "2026-05-11", "requests": 16, "success_rate_pct": 88.5}}},
+				},
+				"worst_devices": []map[string]any{
+					{"device_id": "dev-acme", "device_name": "Acme Cam", "mode_used": "webrtc", "readiness": "online", "success_rate_pct": 88.5, "requests": 16, "last_stream_at": "2026-05-11T00:00:00Z"},
+				},
+			})
+		default:
+			t.Fatalf("stream stats proxy should not call unrelated Video Cloud path: %s", r.URL.Path)
+		}
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u1", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config: config.Config{
+			AccountManagerBaseURL: accountUpstream.URL,
+			VideoCloudBaseURL:     videoUpstream.URL,
+			VideoCloudAdminToken:  "vc-secret",
+		},
+		AccountClient: accountclient.New(accountUpstream.URL),
+		VideoClient:   videoclient.New(videoUpstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats?window=30d", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.FleetStreamStats
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode stream stats payload: %v", err)
+	}
+	if payload.SuccessRatePct != 88.5 || payload.ActiveSessions != 7 || payload.ByMode["webrtc"].Requests != 16 {
+		t.Fatalf("payload = %#v", payload)
+	}
+	if streamStatsCalls != 1 {
+		t.Fatalf("stream stats calls = %d, want 1", streamStatsCalls)
+	}
+}
+
+func TestFleetStreamStatsProxyFailureDoesNotFallback(t *testing.T) {
+	t.Parallel()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fleet/stream-stats" {
+			http.NotFound(w, r)
+			return
+		}
+		http.Error(w, "stream backend unavailable", http.StatusInternalServerError)
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:      config.Config{VideoCloudBaseURL: videoUpstream.URL, VideoCloudAdminToken: "vc-secret"},
+		VideoClient: videoclient.New(videoUpstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Video Cloud request failed") {
+		t.Fatalf("stream stats body = %s", rec.Body.String())
+	}
+}
+
+func TestFleetStreamStatsProxyTimeoutReturnsGatewayTimeout(t *testing.T) {
+	t.Parallel()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fleet/stream-stats" {
+			http.NotFound(w, r)
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]any{"org_id": "org-acme", "window": "7d"})
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:      config.Config{VideoCloudBaseURL: videoUpstream.URL, VideoCloudAdminToken: "vc-secret"},
+		VideoClient: videoclient.NewWithHTTPClient(videoUpstream.URL, &http.Client{Timeout: 5 * time.Millisecond}),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusGatewayTimeout {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusGatewayTimeout, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Video Cloud request timed out") {
+		t.Fatalf("stream stats body = %s", rec.Body.String())
+	}
+}
+
 func TestFleetStreamStatsWorstDevicesSortedAsc(t *testing.T) {
 	t.Parallel()
 
@@ -2931,6 +3131,153 @@ func TestPlatformAdminReadModelsIncludeDashboardFields(t *testing.T) {
 	}
 	if devices[0].Health == "" || devices[0].SignalQuality == "" || len(devices[0].SourceFacts) == 0 {
 		t.Fatalf("admin device runtime facts are incomplete: %#v", devices[0])
+	}
+}
+
+func TestPlatformAdminReadModelsUseAccountManagerAdminInventory(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-access" {
+			t.Fatalf("%s Authorization = %q, want Bearer admin-access", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/admin/orgs":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"organizations": []map[string]any{
+					{"id": "org-admin", "name": "Admin Org", "role": "owner", "tier": "commercial"},
+				},
+			})
+		case "/v1/admin/devices":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"devices": []map[string]any{
+					{"id": "dev-admin", "organization_id": "org-admin", "organization": "Admin Org", "name": "Admin Camera", "category": "ip_camera", "model": "RTK-CAM-A", "serial_number": "ADMIN-001", "status": "online", "readiness": "online", "last_seen_at": "2026-05-11T00:00:00Z", "updated_at": "2026-05-11T00:00:00Z"},
+				},
+			})
+		case "/v1/admin/operations":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"operations": []map[string]any{
+					{"id": "op-admin", "device_id": "dev-admin", "device_name": "Admin Camera", "organization_id": "org-admin", "organization": "Admin Org", "type": "DeviceProvisionRequested", "state": "published", "message": "queued", "updated_at": "2026-05-11T00:00:00Z"},
+				},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "admin-access", "admin-refresh", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession platform_admin returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: accountUpstream.URL},
+		AccountClient: accountclient.New(accountUpstream.URL),
+	})
+
+	adminGet := func(path string) *httptest.ResponseRecorder {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+		srv.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("%s status = %d, want %d; body=%s", path, rec.Code, http.StatusOK, rec.Body.String())
+		}
+		return rec
+	}
+
+	var summary contracts.Summary
+	if err := json.NewDecoder(adminGet("/api/admin/summary").Body).Decode(&summary); err != nil {
+		t.Fatalf("decode summary: %v", err)
+	}
+	if summary.TotalDevices != 1 || summary.Customers != 1 || summary.OpenOperations != 1 {
+		t.Fatalf("summary = %#v", summary)
+	}
+
+	var customers []contracts.CustomerSummary
+	if err := json.NewDecoder(adminGet("/api/admin/customers").Body).Decode(&customers); err != nil {
+		t.Fatalf("decode customers: %v", err)
+	}
+	if len(customers) != 1 || customers[0].OrganizationID != "org-admin" || customers[0].Organization != "Admin Org" || customers[0].TotalDevices != 1 {
+		t.Fatalf("customers = %#v", customers)
+	}
+
+	var devices []contracts.Device
+	if err := json.NewDecoder(adminGet("/api/admin/devices").Body).Decode(&devices); err != nil {
+		t.Fatalf("decode devices: %v", err)
+	}
+	if len(devices) != 1 || devices[0].ID != "dev-admin" || devices[0].OrganizationID != "org-admin" || devices[0].Name != "Admin Camera" {
+		t.Fatalf("devices = %#v", devices)
+	}
+
+	var ops []contracts.Operation
+	if err := json.NewDecoder(adminGet("/api/admin/operations").Body).Decode(&ops); err != nil {
+		t.Fatalf("decode operations: %v", err)
+	}
+	if len(ops) != 1 || ops[0].ID != "op-admin" || ops[0].DeviceID != "dev-admin" || ops[0].Organization != "Admin Org" {
+		t.Fatalf("operations = %#v", ops)
+	}
+}
+
+func TestPlatformAdminReadModelsSurfaceUpstreamFailure(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-access" {
+			t.Fatalf("%s Authorization = %q, want Bearer admin-access", r.URL.Path, got)
+		}
+		switch r.URL.Path {
+		case "/v1/admin/orgs":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"organizations": []map[string]any{{"id": "org-admin", "name": "Admin Org"}},
+			})
+		case "/v1/admin/devices":
+			http.Error(w, "inventory unavailable", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "admin-access", "admin-refresh", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession platform_admin returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: accountUpstream.URL},
+		AccountClient: accountclient.New(accountUpstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/devices", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("admin devices status = %d, want %d; body=%s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Account Manager request failed") {
+		t.Fatalf("admin devices body = %s", rec.Body.String())
 	}
 }
 

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -119,12 +119,56 @@ type DeviceTelemetryEvent struct {
 	Payload    json.RawMessage `json:"payload,omitempty"`
 }
 
+type FleetStreamStatsMode struct {
+	Requests       int     `json:"requests"`
+	SuccessRatePct float64 `json:"success_rate_pct"`
+}
+
+type FleetStreamTrendPoint struct {
+	Date           string  `json:"date"`
+	Requests       int     `json:"requests"`
+	SuccessRatePct float64 `json:"success_rate_pct"`
+}
+
+type FleetStreamWorstDevice struct {
+	DeviceID       string  `json:"device_id"`
+	DeviceName     string  `json:"device_name"`
+	ModeUsed       string  `json:"mode_used"`
+	Readiness      string  `json:"readiness"`
+	SuccessRatePct float64 `json:"success_rate_pct"`
+	Requests       int     `json:"requests"`
+	LastStreamAt   string  `json:"last_stream_at,omitempty"`
+}
+
+type FleetStreamModeTrend struct {
+	Mode   string                  `json:"mode"`
+	Points []FleetStreamTrendPoint `json:"points"`
+}
+
+type FleetStreamStats struct {
+	OrgID              string                          `json:"org_id"`
+	Window             string                          `json:"window"`
+	SuccessRatePct     float64                         `json:"success_rate_pct"`
+	AvgDurationSeconds float64                         `json:"avg_duration_seconds"`
+	ActiveSessions     int                             `json:"active_sessions"`
+	NeverStreamedCount int                             `json:"never_streamed_count"`
+	ByMode             map[string]FleetStreamStatsMode `json:"by_mode"`
+	Trend              []FleetStreamTrendPoint         `json:"trend"`
+	TrendByMode        []FleetStreamModeTrend          `json:"trend_by_mode"`
+	WorstDevices       []FleetStreamWorstDevice        `json:"worst_devices"`
+}
+
 func New(baseURL string) *Client {
+	return NewWithHTTPClient(baseURL, &http.Client{Timeout: 6 * time.Second})
+}
+
+func NewWithHTTPClient(baseURL string, httpClient *http.Client) *Client {
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 6 * time.Second}
+	}
 	return &Client{
-		baseURL: strings.TrimRight(baseURL, "/"),
-		httpClient: &http.Client{
-			Timeout: 6 * time.Second,
-		},
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
 	}
 }
 
@@ -356,6 +400,37 @@ func (c *Client) DeviceTelemetry(ctx context.Context, adminToken, devid, orgID s
 	var out DeviceTelemetryResponse
 	if err := c.doJSON(ctx, http.MethodGet, path, adminToken, nil, &out); err != nil {
 		return DeviceTelemetryResponse{}, err
+	}
+	return out, nil
+}
+
+func (c *Client) FleetStreamStats(ctx context.Context, adminToken, orgID, window string, devices []string) (FleetStreamStats, error) {
+	if !c.Enabled() {
+		return FleetStreamStats{}, fmt.Errorf("video cloud base URL is not configured")
+	}
+	q := url.Values{}
+	if strings.TrimSpace(orgID) != "" {
+		q.Set("org_id", strings.TrimSpace(orgID))
+	}
+	if strings.TrimSpace(window) != "" {
+		q.Set("window", strings.TrimSpace(window))
+	}
+	cleanDevices := make([]string, 0, len(devices))
+	for _, device := range devices {
+		if trimmed := strings.TrimSpace(device); trimmed != "" {
+			cleanDevices = append(cleanDevices, trimmed)
+		}
+	}
+	if len(cleanDevices) > 0 {
+		q.Set("devices", strings.Join(cleanDevices, ","))
+	}
+	path := "/api/fleet/stream-stats"
+	if encoded := q.Encode(); encoded != "" {
+		path += "?" + encoded
+	}
+	var out FleetStreamStats
+	if err := c.doJSON(ctx, http.MethodGet, path, adminToken, nil, &out); err != nil {
+		return FleetStreamStats{}, err
 	}
 	return out, nil
 }

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -86,6 +86,65 @@ func TestDisabledClient(t *testing.T) {
 	if _, err := client.DeviceTelemetry(t.Context(), "tok", "d1", "org-1"); err == nil {
 		t.Fatal("expected disabled DeviceTelemetry error")
 	}
+	if _, err := client.FleetStreamStats(t.Context(), "tok", "org-1", "7d", []string{"d1"}); err == nil {
+		t.Fatal("expected disabled FleetStreamStats error")
+	}
+}
+
+func TestFleetStreamStats(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/fleet/stream-stats" {
+			t.Fatalf("path = %q, want /api/fleet/stream-stats", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+			t.Fatalf("Authorization = %q, want Bearer secret", got)
+		}
+		q := r.URL.Query()
+		if got := q.Get("org_id"); got != "org-1" {
+			t.Fatalf("org_id query = %q, want org-1", got)
+		}
+		if got := q.Get("window"); got != "30d" {
+			t.Fatalf("window query = %q, want 30d", got)
+		}
+		if got := q.Get("devices"); got != "dev-a,dev-b" {
+			t.Fatalf("devices query = %q, want dev-a,dev-b", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"org_id":               "org-1",
+			"window":               "30d",
+			"success_rate_pct":     91.5,
+			"avg_duration_seconds": 42.25,
+			"active_sessions":      3,
+			"never_streamed_count": 1,
+			"by_mode": map[string]any{
+				"webrtc": map[string]any{"requests": 12, "success_rate_pct": 91.5},
+			},
+			"trend": []map[string]any{
+				{"date": "2026-05-11", "requests": 12, "success_rate_pct": 91.5},
+			},
+			"trend_by_mode": []map[string]any{
+				{"mode": "webrtc", "points": []map[string]any{{"date": "2026-05-11", "requests": 12, "success_rate_pct": 91.5}}},
+			},
+			"worst_devices": []map[string]any{
+				{"device_id": "dev-a", "device_name": "Lobby", "mode_used": "webrtc", "readiness": "online", "success_rate_pct": 80, "requests": 5, "last_stream_at": "2026-05-11T00:00:00Z"},
+			},
+		})
+	}))
+	defer upstream.Close()
+
+	stats, err := New(upstream.URL).FleetStreamStats(t.Context(), "secret", "org-1", "30d", []string{"dev-a", "dev-b"})
+	if err != nil {
+		t.Fatalf("FleetStreamStats returned error: %v", err)
+	}
+	if stats.OrgID != "org-1" || stats.Window != "30d" || stats.SuccessRatePct != 91.5 || stats.ActiveSessions != 3 {
+		t.Fatalf("stats = %#v", stats)
+	}
+	if stats.ByMode["webrtc"].Requests != 12 {
+		t.Fatalf("by_mode = %#v", stats.ByMode)
+	}
 }
 
 func TestQueryActivation(t *testing.T) {


### PR DESCRIPTION
## Summary
- proxy `/api/fleet/stream-stats` to Video Cloud when configured, preserving local/demo fallback when unset
- add Account Manager admin inventory client methods and upstream read-through for platform admin summary/customers/devices/operations
- surface configured upstream failures as gateway errors and keep local break-glass admin fallback without upstream tokens

Closes #88
Closes #89

## Tests
- `go test ./internal/videoclient ./internal/accountclient ./internal/app`
- `go test ./...`