### PR TITLE
Reconcile WebUI planning docs

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -34,22 +34,22 @@ Included in v0.1:
 - Local Realtek logo asset under `web/public/assets/realtek-logo.png`, sourced
   from the Realtek Connect+ marketing site and served locally by the app.
 - Customer console pages:
-  - dashboard overview
-  - customer overview
-  - device list
-  - device detail
-  - provisioning/deactivation actions
-  - readiness status display
-  - member/support placeholders
+  - Fleet Health Overview
+  - Devices with detail drawer
+  - Firmware & OTA
+  - Stream Health
+  - provisioning/deactivation actions in the device drawer
+  - readiness, health, firmware, telemetry, and stream status displays
 - Platform admin pages:
-  - customer overview
-  - all devices
-  - lifecycle operations
   - service health
+  - SSO provider status and settings
+  - lifecycle operations log
   - audit log
 - Audit events are recorded when demo lifecycle actions are created from the
   console.
-- Local demo mode backed by SQLite seed data so the console is useful before real service endpoints are configured.
+- Local demo mode backed by SQLite seed data so the console is useful before
+  real service endpoints are configured. Demo mode is for local development
+  only and is not acceptable for production or server validation.
 
 Out of scope for v0.1:
 
@@ -57,6 +57,7 @@ Out of scope for v0.1:
 - Full OTA campaign engine.
 - Telemetry ingestion pipeline.
 - WebRTC player, clip library, or media download manager.
+- Device Groups in the first Customer View batch.
 - Smart-home schedules, scenes, Matter, Alexa, or Google Assistant runtime features.
 - Multi-language UI. Console UI is English-first.
 

--- a/docs/backend-api-gap-audit.md
+++ b/docs/backend-api-gap-audit.md
@@ -12,6 +12,10 @@ Scope: backend API contracts needed by customer dashboard, platform dashboard,
 membership, quota, and device detail flows. WebUI-only entry points and visual
 design are called out separately.
 
+This document distinguishes Admin Console work from upstream blockers. Items
+listed as implemented in `rtk_cloud_admin` can still depend on production data
+from Account Manager or Video Cloud before server validation is complete.
+
 ## Status Legend
 
 - `implemented`: API exists and has the fields/guards required for v0.1.
@@ -138,6 +142,26 @@ pages can be treated as complete:
 Local demo, deterministic sample generation, or readiness-derived trends may
 remain useful for development, but they are not acceptable evidence for server
 validation.
+
+### Admin Repo Follow-Up Work
+
+Status: open WebUI issues.
+
+These items can be implemented in `rtk_cloud_admin` without making this repo the
+source of truth for upstream facts:
+
+- Harden source-aware UI states for Customer View pages and device telemetry.
+- Complete Devices filter, drill-down, and drawer action workflows.
+- Add read-only Firmware & OTA campaign drill-downs.
+- Add Stream Health worst-device and attention drill-downs.
+- Polish Platform View guards, Operations Log, and Audit Log states.
+- Complete SSO, signup, and quota UX states around the existing BFF routes.
+- Add repeatable browser QA coverage for desktop and mobile console workflows.
+
+Production telemetry, firmware rollout, and stream-session facts remain
+upstream blockers. Admin Console must show blocked/unavailable states when
+those sources are absent; it must not replace those sources with demo-derived
+production data.
 
 ### Read-only Observer Enforcement
 

--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -7,8 +7,9 @@ against the approved design assets in `docs/assets/webui-design/`.
 
 - Sidebar uses the Realtek Ops Console navy background and primary blue active
   nav state.
-- Customer View navigation contains Overview, Devices, Firmware & OTA, Stream
-  Health, and Groups only.
+- Customer View navigation contains Overview, Devices, Firmware & OTA, and
+  Stream Health only. Groups are deferred and must not appear in the first
+  batch sidebar or as a placeholder page.
 - Platform View switcher is visually separated from Customer View navigation.
 - Header contains page title, active organization, relevant window control,
   last updated text, and refresh action.


### PR DESCRIPTION
## Summary
- Align Customer View docs with the current first-batch nav: Overview, Devices, Firmware & OTA, Stream Health.
- Remove stale member/support placeholder language from the active MVP page list.
- Clarify that Admin repo WebUI follow-ups are separate from upstream production data blockers.

Closes #99

## Test Plan
- `go test ./...`
- `npm test -- --runInBand`
- `npm run build`
- `rg "Customer View navigation|Groups|member/support|placeholder|demo mode|production validation|Admin Repo Follow-Up" docs`
