### PR TITLE
Return source states for customer data outages

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.9% |
+| Go total coverage | 80.6% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,7 +28,7 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 89.5% |
-| `rtk_cloud_admin/internal/app` | 80.8% |
+| `rtk_cloud_admin/internal/app` | 80.4% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -749,7 +749,7 @@ func (s *Server) apiFleetStreamStats(w http.ResponseWriter, r *http.Request) {
 	if s.videoClient.Enabled() && strings.TrimSpace(s.cfg.VideoCloudAdminToken) != "" {
 		stats, err := s.videoClient.FleetStreamStats(r.Context(), s.cfg.VideoCloudAdminToken, orgID, window, videoCloudDeviceIDs(devices))
 		if err != nil {
-			s.writeVideoCloudGatewayError(w, fmt.Errorf("%w: %w", errVideoCloudRequestFailed, err))
+			writeJSON(w, unavailableFleetStreamStats(orgID, window, "unavailable", "Stream source is unavailable."))
 			return
 		}
 		writeJSON(w, mapVideoCloudFleetStreamStats(stats, orgID, window))
@@ -777,7 +777,7 @@ func (s *Server) apiFleetFirmwareDistribution(w http.ResponseWriter, r *http.Req
 		return
 	}
 	if dist, ok, err := s.proxyFirmwareDistribution(r.Context(), devices, orgID); err != nil {
-		http.Error(w, err.Error(), http.StatusBadGateway)
+		writeJSON(w, unavailableFirmwareDistribution(orgID, "unavailable", "Firmware source is unavailable."))
 		return
 	} else if ok {
 		dist.SourceStatus = "available"

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2256,11 +2256,21 @@ func TestFleetStreamStatsProxyFailureDoesNotFallback(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats", nil)
 	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
 	srv.ServeHTTP(rec, req)
-	if rec.Code != http.StatusBadGateway {
-		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "Video Cloud request failed") {
-		t.Fatalf("stream stats body = %s", rec.Body.String())
+	var payload contracts.FleetStreamStats
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode stream stats payload: %v", err)
+	}
+	if payload.SourceStatus != "unavailable" {
+		t.Fatalf("source_status = %q, want unavailable", payload.SourceStatus)
+	}
+	if payload.SourceMessage == "" {
+		t.Fatalf("source_message is empty")
+	}
+	if len(payload.Trend) != 0 || len(payload.WorstDevices) != 0 {
+		t.Fatalf("unavailable stream source should not include partial data: %+v", payload)
 	}
 }
 
@@ -2301,11 +2311,18 @@ func TestFleetStreamStatsProxyTimeoutReturnsGatewayTimeout(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "/api/fleet/stream-stats", nil)
 	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
 	srv.ServeHTTP(rec, req)
-	if rec.Code != http.StatusGatewayTimeout {
-		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusGatewayTimeout, rec.Body.String())
+	if rec.Code != http.StatusOK {
+		t.Fatalf("stream stats status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "Video Cloud request timed out") {
-		t.Fatalf("stream stats body = %s", rec.Body.String())
+	var payload contracts.FleetStreamStats
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode stream stats payload: %v", err)
+	}
+	if payload.SourceStatus != "unavailable" {
+		t.Fatalf("source_status = %q, want unavailable", payload.SourceStatus)
+	}
+	if payload.SourceMessage == "" {
+		t.Fatalf("source_message is empty")
 	}
 }
 
@@ -2699,6 +2716,61 @@ func TestFleetFirmwareDistributionProxyModeUsesAlternateRolloutKeys(t *testing.T
 	}
 	if campaign.Applied != 1 || campaign.Pending != 1 || campaign.Total != 2 {
 		t.Fatalf("campaign summary = %+v, want applied=1 pending=1 total=2", campaign)
+	}
+}
+
+func TestFleetFirmwareDistributionProxyFailureReturnsSourceStatus(t *testing.T) {
+	t.Parallel()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/get_camera_info":
+			http.Error(w, "firmware backend unavailable", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:      config.Config{VideoCloudBaseURL: videoUpstream.URL, VideoCloudAdminToken: "vc-secret"},
+		VideoClient: videoclient.New(videoUpstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/fleet/firmware-distribution", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("firmware distribution status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.FirmwareDistribution
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode firmware distribution payload: %v", err)
+	}
+	if payload.SourceStatus != "unavailable" {
+		t.Fatalf("source_status = %q, want unavailable", payload.SourceStatus)
+	}
+	if payload.SourceMessage == "" {
+		t.Fatalf("source_message is empty")
+	}
+	if len(payload.Versions) != 0 || len(payload.Campaigns) != 0 {
+		t.Fatalf("unavailable firmware source should not include partial data: %+v", payload)
 	}
 }
 

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { customerNavItems, devicesPathWithFilters, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
 import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 import { shouldShowBreakGlass } from './auth-state.mjs';
+import { sourceAvailable, sourceMessage } from './source-state.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -2795,17 +2796,6 @@ function sessionLabel(me) {
   if (me.kind === 'platform_admin') return 'Platform Admin · All tenants';
   const membership = getActiveMembership(me);
   return `${roleLabel(membership?.role)} · ${membership?.organization || me.active_org_id || 'Active organization'}`;
-}
-
-function sourceAvailable(source) {
-  return source?.source_status === 'available';
-}
-
-function sourceMessage(source, fallback) {
-  if (!source) return fallback;
-  if (source.source_status === 'not_configured') return source.source_message || fallback;
-  if (source.source_status === 'no_data') return source.source_message || 'No data in selected window.';
-  return source.source_message || fallback;
 }
 
 function roleLabel(role) {

--- a/web/src/source-state.mjs
+++ b/web/src/source-state.mjs
@@ -1,0 +1,20 @@
+export function sourceAvailable(source) {
+  return source?.source_status === 'available';
+}
+
+export function sourceMessage(source, fallback) {
+  if (!source) return fallback;
+  if (source.source_message) return source.source_message;
+  switch (source.source_status) {
+    case 'not_configured':
+      return fallback;
+    case 'no_data':
+      return 'No data in selected window.';
+    case 'unavailable':
+      return 'Source is unavailable.';
+    case 'unauthorized':
+      return 'Session expired; please sign in again.';
+    default:
+      return fallback;
+  }
+}

--- a/web/src/source-state.test.mjs
+++ b/web/src/source-state.test.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { sourceAvailable, sourceMessage } from './source-state.mjs';
+
+test('sourceAvailable only treats available source status as available', () => {
+  assert.equal(sourceAvailable({ source_status: 'available' }), true);
+  assert.equal(sourceAvailable({ source_status: 'no_data' }), false);
+  assert.equal(sourceAvailable({ source_status: 'not_configured' }), false);
+  assert.equal(sourceAvailable({ source_status: 'unavailable' }), false);
+  assert.equal(sourceAvailable(null), false);
+});
+
+test('sourceMessage returns specific customer-safe copy for unavailable states', () => {
+  assert.equal(sourceMessage({ source_status: 'not_configured' }, 'Fallback'), 'Fallback');
+  assert.equal(sourceMessage({ source_status: 'no_data' }, 'Fallback'), 'No data in selected window.');
+  assert.equal(sourceMessage({ source_status: 'unavailable' }, 'Fallback'), 'Source is unavailable.');
+  assert.equal(sourceMessage({ source_status: 'unauthorized' }, 'Fallback'), 'Session expired; please sign in again.');
+  assert.equal(sourceMessage({ source_status: 'unavailable', source_message: 'Stream source is unavailable.' }, 'Fallback'), 'Stream source is unavailable.');
+});


### PR DESCRIPTION
## Summary
- Return customer-safe `source_status=unavailable` DTOs for fleet stream and firmware source outages instead of HTTP-only gateway errors.
- Add tested frontend source-state helpers for unavailable, no-data, not-configured, and unauthorized copy.
- Update regression coverage report after source-state tests.

Closes #92

## Test Plan
- `go test ./internal/app -run 'TestFleet(StreamStatsProxyFailureDoesNotFallback|FirmwareDistributionProxyFailureReturnsSourceStatus)' -count=1`
- `npm test -- source-state.test.mjs`
- `go test ./...`
- `npm test -- --runInBand`
- `npm run build`
- `scripts/validate_test_report.sh docs/TEST_REPORT.md`
