### PR TITLE
Add Stream Health drilldown rows

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -6,6 +6,7 @@ import { shouldShowBreakGlass } from './auth-state.mjs';
 import { deviceActionState, isReadOnlyRole } from './device-actions.mjs';
 import { firmwareCampaignDetailRows, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
 import { sourceAvailable, sourceMessage } from './source-state.mjs';
+import { streamWorstDeviceRows } from './stream.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -1131,7 +1132,7 @@ function FirmwareRiskQueue({ campaigns, onViewDevices }) {
 function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, onOpenDevice }) {
   const trend = stats?.trend || [];
   const modeTrends = stats?.trend_by_mode || [];
-  const worstDevices = stats?.worst_devices || [];
+  const worstDevices = streamWorstDeviceRows(stats?.worst_devices || []);
   const byMode = stats?.by_mode || {};
   const available = sourceAvailable(stats);
   const unavailableText = sourceMessage(stats, 'WebRTC session event source is not configured.');
@@ -1286,14 +1287,14 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
                   <span>Status</span>
                 </div>
                 {worstDevices.map((device) => (
-                  <div key={device.device_id} className="stream-device-table__row">
+                  <button key={device.device_id} type="button" className="stream-device-table__row" onClick={() => onOpenDevice(device.device_id)}>
                     <strong>{device.device_name || device.device_id}</strong>
                     <span>{streamModeLabel(device.mode_used)}</span>
                     <span>{formatPercent(device.success_rate_pct ?? 0)}</span>
                     <span>{device.requests ?? 0}</span>
                     <time title={device.last_stream_at || ''}>{device.last_stream_at ? formatRelativeTime(device.last_stream_at) : '—'}</time>
                     <StatusBadge value={normalizeStatusKey(device.readiness)} label={formatReadinessLabel(device.readiness)} />
-                  </div>
+                  </button>
                 ))}
               </div>
             ) : (

--- a/web/src/stream.mjs
+++ b/web/src/stream.mjs
@@ -1,0 +1,15 @@
+export function streamWorstDeviceRows(devices = []) {
+  return [...devices].sort((left, right) => {
+    const leftRate = numeric(left.success_rate_pct, 100);
+    const rightRate = numeric(right.success_rate_pct, 100);
+    if (leftRate !== rightRate) return leftRate - rightRate;
+    const leftRequests = numeric(left.requests, 0);
+    const rightRequests = numeric(right.requests, 0);
+    if (leftRequests !== rightRequests) return rightRequests - leftRequests;
+    return String(left.device_name || left.device_id).localeCompare(String(right.device_name || right.device_id));
+  });
+}
+
+function numeric(value, fallback) {
+  return Number.isFinite(Number(value)) ? Number(value) : fallback;
+}

--- a/web/src/stream.test.mjs
+++ b/web/src/stream.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { streamWorstDeviceRows } from './stream.mjs';
+
+test('streamWorstDeviceRows sorts worst devices by failure priority', () => {
+  const rows = streamWorstDeviceRows([
+    { device_id: 'dev-a', device_name: 'A', success_rate_pct: 80, requests: 20 },
+    { device_id: 'dev-b', device_name: 'B', success_rate_pct: 20, requests: 3 },
+    { device_id: 'dev-c', device_name: 'C', success_rate_pct: 20, requests: 12 },
+    { device_id: 'dev-d', device_name: 'D', success_rate_pct: 100, requests: 1 },
+  ]);
+
+  assert.deepEqual(rows.map((row) => row.device_id), ['dev-c', 'dev-b', 'dev-a', 'dev-d']);
+});
+
+test('streamWorstDeviceRows keeps customer-safe drawer target fields', () => {
+  const [row] = streamWorstDeviceRows([{ device_id: 'dev-a', device_name: 'A', success_rate_pct: 0, requests: 1 }]);
+  assert.equal(row.device_id, 'dev-a');
+  assert.equal(row.device_name, 'A');
+});

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -748,7 +748,15 @@ p {
   background: rgba(246, 250, 253, 0.92);
   border: 1px solid rgba(0, 104, 183, 0.08);
   border-radius: 12px;
+  cursor: pointer;
   padding: 10px 12px;
+  text-align: left;
+  width: 100%;
+}
+
+.stream-device-table__row:hover {
+  border-color: rgba(0, 104, 183, 0.32);
+  box-shadow: 0 16px 30px rgba(3, 83, 144, 0.08);
 }
 
 .stream-device-table__row strong {


### PR DESCRIPTION
## Summary
- Sort Stream Health worst-device rows by failure priority before rendering.
- Make worst-device rows clickable so they open the Devices drawer for investigation.
- Add focused frontend tests for stream worst-device ordering and drawer target fields.

Closes #95

## Test Plan
- `npm test -- stream.test.mjs`
- `go test ./...`
- `npm test -- --runInBand`
- `npm run build`
