### PR TITLE
Keep unknown admin routes in Platform View

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -517,7 +517,7 @@ function App() {
           <PlatformSSOProviders providers={ssoProviders} customers={customers} onSave={handleSSOProviderSave} />
         ) : null}
         {!needsPlatformAccess && active === 'platform-operations' ? <Operations operations={operations} /> : null}
-        {!needsPlatformAccess && active === 'platform-audit' ? <AuditLog audit={audit} /> : null}
+        {!needsPlatformAccess && active === 'platform-audit' ? <AuditLog audit={audit} loading={loading} /> : null}
       </main>
     </div>
   );
@@ -2551,7 +2551,7 @@ function PlatformAdmin({ summary, health, devices, customers, operations, audit,
   );
 }
 
-function AuditLog({ audit, compact = false }) {
+function AuditLog({ audit, compact = false, loading = false }) {
   const columns = useMemo(() => [
     { key: 'action', label: 'Action', value: (event) => event.action },
     { key: 'actor', label: 'Actor', value: (event) => event.actor },
@@ -2567,7 +2567,9 @@ function AuditLog({ audit, compact = false }) {
           <p>Local operator actions captured by the Go BFF.</p>
         </div>
       </div>
-      {compact && audit.length ? (
+      {loading && !audit.length ? (
+        <p className="empty-state">Loading audit events.</p>
+      ) : compact && audit.length ? (
         <div className="audit-list">
           {audit.map((event) => (
             <article className="audit-event" key={event.id}>
@@ -2580,8 +2582,10 @@ function AuditLog({ audit, compact = false }) {
             </article>
           ))}
         </div>
+      ) : !audit.length ? (
+        <p className="empty-state">No audit events recorded.</p>
       ) : compact ? (
-        <p>No audit events yet.</p>
+        <p className="empty-state">No audit events recorded.</p>
       ) : (
         <DataTable
           columns={columns}

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -37,6 +37,7 @@ export function routeFromPath(path) {
   if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
   if (path === '/admin/operations' || path.startsWith('/admin/operations/')) return 'platform-operations';
   if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';
+  if (path.startsWith('/admin/')) return 'platform-health';
   if (path === '/console' || path === '/console/' || path === '/console/overview' || path.startsWith('/console/overview/')) return 'overview';
   if (path === '/console/devices' || path.startsWith('/console/devices/')) return 'devices';
   if (path === '/console/firmware-ota' || path.startsWith('/console/firmware-ota/')) return 'firmware-ota';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -52,7 +52,11 @@ test('uses fleet health overview title for the customer landing page', () => {
 test('falls back unknown paths to the customer overview route', () => {
   assert.equal(routeFromPath('/'), 'overview');
   assert.equal(routeFromPath('/console/unknown'), 'overview');
-  assert.equal(routeFromPath('/admin/unknown'), 'overview');
+});
+
+test('falls back unknown platform paths inside Platform View', () => {
+  assert.equal(routeFromPath('/admin/unknown'), 'platform-health');
+  assert.equal(routeFromPath('/admin/unknown/deep'), 'platform-health');
 });
 
 test('provides titles for all public shell routes', () => {


### PR DESCRIPTION
## Summary
- Keep unknown `/admin/...` paths inside Platform View by falling back to Service Health.
- Add route coverage for unknown platform paths so they do not leak into Customer View.
- Add explicit Audit Log loading and empty states.

Closes #96

## Test Plan
- `npm test -- routes.test.mjs`
- `go test ./...`
- `npm test -- --runInBand`
- `npm run build`
