### PR TITLE
Complete SSO and quota UX states

### DIFF
--- a/web/src/auth-state.mjs
+++ b/web/src/auth-state.mjs
@@ -5,3 +5,11 @@ export function shouldShowBreakGlass(me) {
 export function isPlatformOnlySSOSettingsRoute(route) {
   return route === 'platform-sso';
 }
+
+export function quotaUsageLabel(currentUsage, currentQuota) {
+  const quota = Number.isFinite(Number(currentQuota)) ? Number(currentQuota) : 0;
+  if (!Number.isFinite(Number(currentUsage))) {
+    return `Current usage unavailable. Current evaluation cap: ${quota} devices.`;
+  }
+  return `Current usage: ${Number(currentUsage)} / ${quota} devices.`;
+}

--- a/web/src/auth-state.test.mjs
+++ b/web/src/auth-state.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { isPlatformOnlySSOSettingsRoute, shouldShowBreakGlass } from './auth-state.mjs';
+import { isPlatformOnlySSOSettingsRoute, quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
 import { customerNavItems, platformNavItems } from './routes.mjs';
 
 test('break-glass UI is visible only when backend policy enables it', () => {
@@ -12,4 +12,9 @@ test('break-glass UI is visible only when backend policy enables it', () => {
 test('customer navigation does not expose platform SSO provider controls', () => {
   assert.equal(customerNavItems.some((item) => isPlatformOnlySSOSettingsRoute(item.id)), false);
   assert.equal(platformNavItems.some((item) => isPlatformOnlySSOSettingsRoute(item.id)), true);
+});
+
+test('quota usage copy includes current usage and configured cap', () => {
+  assert.equal(quotaUsageLabel(4, 5), 'Current usage: 4 / 5 devices.');
+  assert.equal(quotaUsageLabel(undefined, 10), 'Current usage unavailable. Current evaluation cap: 10 devices.');
 });

--- a/web/src/http.mjs
+++ b/web/src/http.mjs
@@ -30,12 +30,21 @@ export async function startSSOLogin(email, returnUrl) {
 }
 
 export function userFacingSSOError(error) {
+  if (error?.status === 401) {
+    return 'Session expired. Sign in again to continue.';
+  }
+  if (error?.status === 403) {
+    return 'You do not have access to this console view.';
+  }
   const message = error?.message || 'SSO sign-in could not be started.';
   if (message.includes('ACCOUNT_MANAGER_BASE_URL') || message.includes('not configured')) {
     return 'SSO is not configured for this environment.';
   }
   if (message.includes('invalid JSON')) {
     return 'SSO is temporarily unavailable. Please try again later.';
+  }
+  if (message.includes('SSO start did not return a redirect URL')) {
+    return 'SSO could not start because the identity provider did not return a redirect URL.';
   }
   return message;
 }

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -148,3 +148,24 @@ test('userFacingSSOError hides internal SSO configuration details', () => {
     'SSO provider is disabled for this organization',
   );
 });
+
+test('userFacingSSOError maps auth and malformed redirect failures to operator-safe copy', () => {
+  const expired = new Error('customer authentication required');
+  expired.status = 401;
+  assert.equal(
+    userFacingSSOError(expired),
+    'Session expired. Sign in again to continue.',
+  );
+
+  const forbidden = new Error('forbidden');
+  forbidden.status = 403;
+  assert.equal(
+    userFacingSSOError(forbidden),
+    'You do not have access to this console view.',
+  );
+
+  assert.equal(
+    userFacingSSOError(new Error('SSO start did not return a redirect URL')),
+    'SSO could not start because the identity provider did not return a redirect URL.',
+  );
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { customerNavItems, devicesPathWithFilters, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
 import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
-import { shouldShowBreakGlass } from './auth-state.mjs';
+import { quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
 import { deviceActionState, isReadOnlyRole } from './device-actions.mjs';
 import { firmwareCampaignDetailRows, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
 import { sourceAvailable, sourceMessage } from './source-state.mjs';
@@ -714,7 +714,7 @@ function VerifyForm({ token, onVerify }) {
   );
 }
 
-function QuotaRaiseForm({ organizationId, organizationName, currentQuota, onSubmit }) {
+function QuotaRaiseForm({ organizationId, organizationName, currentUsage, currentQuota, onSubmit }) {
   const [requestedQuota, setRequestedQuota] = useState(currentQuota);
   const [useCase, setUseCase] = useState('');
   const [contactEmail, setContactEmail] = useState('');
@@ -751,7 +751,7 @@ function QuotaRaiseForm({ organizationId, organizationName, currentQuota, onSubm
 
   return (
     <form className="quota-form" onSubmit={submit}>
-      <p className="auth-status">Current evaluation cap: {currentQuota} devices.</p>
+      <p className="auth-status">{quotaUsageLabel(currentUsage, currentQuota)}</p>
       <label>
         Requested quota
         <input type="number" min="1" max="200" value={requestedQuota} onChange={(event) => setRequestedQuota(event.target.value)} />
@@ -852,6 +852,7 @@ function Overview({
           <QuotaRaiseForm
             organizationId={activeMembership?.organization_id}
             organizationName={activeMembership?.organization}
+            currentUsage={activeDevices}
             currentQuota={quotaLimit}
             onSubmit={onRequestQuotaRaise}
           />
@@ -2759,12 +2760,16 @@ function ServiceHealth({ health, compact = false }) {
 function SSOLoginPanel({ title, onSSOStart }) {
   const [email, setEmail] = useState('');
   const [busy, setBusy] = useState(false);
+  const [localError, setLocalError] = useState('');
   async function submit(event) {
     event.preventDefault();
     setBusy(true);
+    setLocalError('');
     try {
       await onSSOStart(email);
-    } catch (_) {
+    } catch (err) {
+      setLocalError(userFacingSSOError(err));
+    } finally {
       setBusy(false);
     }
   }
@@ -2772,12 +2777,13 @@ function SSOLoginPanel({ title, onSSOStart }) {
     <section className="panel login-panel">
       <div>
         <h2>{title}</h2>
-        <p>Use your organization email to continue through Account Manager SSO.</p>
+        <p>Use your organization email to continue through Account Manager SSO. SSO is the primary production sign-in path.</p>
       </div>
       <form onSubmit={submit}>
         <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="name@company.com" required />
         <button type="submit" disabled={busy}>{busy ? 'Redirecting' : 'Continue with SSO'}</button>
       </form>
+      {localError ? <p className="error">{localError}</p> : null}
     </section>
   );
 }


### PR DESCRIPTION
Closes #97\n\n## Summary\n- show SSO start errors locally with operator-safe copy for expired sessions, access denied, unavailable SSO, and malformed redirect responses\n- make the SSO panel explicit that SSO is the production sign-in path\n- show evaluation quota usage and configured cap inside the quota raise form\n\n## Tests\n- go test ./...\n- npm test -- --runInBand\n- npm run build