### PR TITLE
Add local Video Cloud staging E2E validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@
 .artifacts/
 bin/
 data/
-keys/
+keys/*
+!keys/README.md
 server
 web/dist/
 web/node_modules/

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -32,7 +32,7 @@
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |
-| `rtk_cloud_admin/internal/videoclient` | 87.4% |
+| `rtk_cloud_admin/internal/videoclient` | 86.3% |
 
 ## Artifact Policy
 

--- a/docs/video-cloud-staging-e2e.md
+++ b/docs/video-cloud-staging-e2e.md
@@ -1,0 +1,77 @@
+# Video Cloud Staging E2E
+
+This local-only validation connects `rtk_cloud_admin` to Video Cloud staging and
+runs deeper API and browser checks than the mocked WebUI smoke test.
+
+The test is intentionally not part of default CI because it depends on local
+operator certificate material and real staging data.
+
+## Required Local Files
+
+Copy the admin client material from the sibling Video Cloud repo:
+
+```sh
+mkdir -p keys
+cp ../rtk_video_cloud/keys/admin-client.ed25519.cert.pem keys/
+cp ../rtk_video_cloud/keys/admin-client.ed25519.key.pem keys/
+cp ../rtk_video_cloud/keys/admin-client-root-ca.ed25519.cert.pem keys/
+chmod 600 keys/admin-client.ed25519.key.pem
+```
+
+Only `keys/README.md` should be tracked by git. The certificate, private key,
+and generated token must remain local.
+
+## Command
+
+```sh
+VIDEO_CLOUD_BASE_URL=https://video-cloud-staging.realtekconnect.com \
+./scripts/local_video_cloud_e2e.sh
+```
+
+Useful overrides:
+
+```sh
+E2E_ORG_ID=org-acme
+E2E_ACCOUNT_DEVICE_1=dev-001
+E2E_VIDEO_DEVICE_1=device-1
+E2E_ACCOUNT_DEVICE_2=dev-002
+E2E_VIDEO_DEVICE_2=device-2
+E2E_PORT=19082
+E2E_KEEP_TMP=1
+```
+
+## What It Checks
+
+- Bootstraps a runtime-only Video Cloud admin bearer token with the local admin
+  client certificate.
+- Builds the WebUI and starts a local Admin BFF with:
+  - `VIDEO_CLOUD_BASE_URL`
+  - runtime `VIDEO_CLOUD_ADMIN_TOKEN`
+  - local platform break-glass credentials
+  - temporary SQLite database
+- Verifies:
+  - `/healthz`
+  - `/api/service-health` reports Video Cloud `ok`
+  - platform break-glass login and `/api/me.kind == platform_admin`
+  - customer-safe `/api/devices`
+  - `/api/devices/{id}/telemetry` has `telemetry_status == available`
+  - `/api/fleet/firmware-distribution` has `source_status == available`
+  - `/api/fleet/stream-stats?window=7d|30d` has `source_status == available`
+  - live browser flows for Overview, Devices drawer, Firmware & OTA, Stream
+    Health, and Platform Operations
+
+Screenshots are written under `.artifacts/live-video-cloud-e2e/`.
+
+## Failure Triage
+
+- Token bootstrap failure: check `keys/` material, Homebrew curl/OpenSSL 3, and
+  Video Cloud edge client certificate forwarding.
+- Service health failure: check `VIDEO_CLOUD_BASE_URL`, TLS, and Video Cloud
+  `/healthz`.
+- Telemetry/firmware/stream unavailable: check staging data for the configured
+  `video_cloud_devid` values and the corresponding Video Cloud BFF endpoints.
+- Browser failure: inspect screenshots in `.artifacts/live-video-cloud-e2e/`
+  and console output from the script.
+
+The script hard-fails unavailable telemetry, firmware, and stream sources so
+staging gaps are visible before Linode deployment.

--- a/docs/video-cloud-staging-e2e.md
+++ b/docs/video-cloud-staging-e2e.md
@@ -36,6 +36,8 @@ E2E_ACCOUNT_DEVICE_1=dev-001
 E2E_VIDEO_DEVICE_1=device-1
 E2E_ACCOUNT_DEVICE_2=dev-002
 E2E_VIDEO_DEVICE_2=device-2
+E2E_DIAGNOSTICS=1
+E2E_FIRMWARE_MODEL=RTK-CAM-A
 E2E_PORT=19082
 E2E_KEEP_TMP=1
 ```
@@ -61,6 +63,50 @@ E2E_KEEP_TMP=1
     Health, and Platform Operations
 
 Screenshots are written under `.artifacts/live-video-cloud-e2e/`.
+The script also writes a redacted summary report to
+`.artifacts/live-video-cloud-e2e/report.json`. The report records the fixture
+ids, pass/fail matrix, source status/source message, upstream diagnostic
+summaries when enabled, and browser screenshot directory. It must not contain
+bearer tokens, private keys, certificate bodies, or raw sensitive upstream
+payloads.
+
+## Upstream Diagnostics
+
+Set `E2E_DIAGNOSTICS=1` to add direct Video Cloud probes before the BFF live
+source assertions. Diagnostics use the runtime admin bearer token but only
+write redacted summaries:
+
+- `GET /api/devices/{devid}/telemetry?org_id=...`
+- `GET /api/fleet/stream-stats?org_id=...&window=7d|30d&devices=...`
+- `POST /enum_firmware`
+- `POST /query_firmware_rollout`
+- `POST /query_firmware_campaign`
+
+Diagnostic status values distinguish `auth_failed`, `not_found`,
+`source_unavailable`, `empty_data`, `unexpected_schema`, and successful `ok`
+responses. Use these entries to decide whether the failure is in Admin BFF
+mapping or Video Cloud staging data/API readiness.
+
+## Current Validation Coverage
+
+Validated before a known-good fixture exists:
+
+- admin client certificate can bootstrap a `scope=admin` bearer token
+- local Admin BFF starts with the runtime token
+- `/healthz` and `/api/service-health` reach Video Cloud
+- platform break-glass login and local customer session work
+- `/api/devices` returns customer-safe fields and omits platform-only ids
+
+Blocked until a known-good provisioned/activated Video Cloud staging device
+exists:
+
+- device telemetry available path
+- RSSI / uptime / recent telemetry event mapping
+- active stream status from source data
+- firmware distribution / rollout / campaign mapping
+- stream stats for `7d` and `30d`
+- live browser Overview, Devices drawer, Firmware & OTA, and Stream Health
+  checks against non-demo source data
 
 ## Failure Triage
 
@@ -75,3 +121,28 @@ Screenshots are written under `.artifacts/live-video-cloud-e2e/`.
 
 The script hard-fails unavailable telemetry, firmware, and stream sources so
 staging gaps are visible before Linode deployment.
+
+## Known-Good Fixture Contract
+
+Admin WebUI E2E needs a fixed, production-like Video Cloud staging fixture. It
+does not need a full production onboarding run or a physical camera unless the
+test scope expands to transport/WebRTC pipeline validation.
+
+Required fixture facts:
+
+- fixed org id, default `org-acme`
+- fixed account-device to Video Cloud device mapping, default
+  `dev-001 -> device-1` and `dev-002 -> device-2`
+- provisioned/activated Video Cloud device records for the mapped device ids
+- telemetry samples sufficient for health, RSSI, uptime, and recent events
+- firmware version, rollout, and campaign facts for the configured model
+- stream stats for both `7d` and `30d`
+
+Fixture creation should live in `rtk_video_cloud` as a staging seed or
+maintenance flow because Video Cloud owns the telemetry, firmware, activation,
+and stream data models. `rtk_cloud_admin` only consumes the resulting fixture
+through the documented admin/customer-safe APIs.
+
+As of the first local run, the default `dev-001 -> device-1` mapping reaches
+the Admin BFF telemetry assertion but returns `telemetry_status=unavailable`;
+that is the current staging fixture blocker.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1421,7 +1421,8 @@ func (s *Server) apiDeviceTelemetry(w http.ResponseWriter, r *http.Request) {
 		for _, device := range devices {
 			if device.ID == r.PathValue("id") {
 				if telemetry, ok, err := s.proxyTelemetryForDevice(r.Context(), device.OrganizationID, device); err != nil {
-					writeJSON(w, unavailableTelemetryForDevice(device, "unavailable", "Video Cloud telemetry is unavailable."))
+					status, reason := telemetryUnavailableFromVideoCloudError(err)
+					writeJSON(w, unavailableTelemetryForDevice(device, status, reason))
 					return
 				} else if ok {
 					writeJSON(w, telemetry)
@@ -1462,7 +1463,8 @@ func (s *Server) apiDeviceTelemetry(w http.ResponseWriter, r *http.Request) {
 		UpdatedAt:       device.UpdatedAt,
 	}
 	if telemetry, ok, err := s.proxyTelemetryForDevice(r.Context(), telemetryDevice.OrganizationID, telemetryDevice); err != nil {
-		writeJSON(w, unavailableTelemetryForDevice(telemetryDevice, "unavailable", "Video Cloud telemetry is unavailable."))
+		status, reason := telemetryUnavailableFromVideoCloudError(err)
+		writeJSON(w, unavailableTelemetryForDevice(telemetryDevice, status, reason))
 		return
 	} else if ok {
 		writeJSON(w, telemetry)
@@ -1477,7 +1479,10 @@ func (s *Server) proxyTelemetryForDevice(ctx context.Context, orgID string, devi
 	}
 	upstream, err := s.videoClient.DeviceTelemetry(ctx, s.cfg.VideoCloudAdminToken, device.VideoCloudDevID, orgID)
 	if err != nil {
-		return contracts.DeviceTelemetry{}, true, fmt.Errorf("%w: %v", errVideoCloudRequestFailed, err)
+		return contracts.DeviceTelemetry{}, true, fmt.Errorf("%w: %w", errVideoCloudRequestFailed, err)
+	}
+	if !videoCloudTelemetryHasSamples(upstream) {
+		return unavailableTelemetryForDevice(device, "unavailable", "No telemetry samples are available for this device."), true, nil
 	}
 	info, err := s.videoClient.GetDeviceInfo(ctx, s.cfg.VideoCloudAdminToken, device.VideoCloudDevID)
 	firmwareVersion := firmwareVersionFromDevice(device)
@@ -1485,6 +1490,33 @@ func (s *Server) proxyTelemetryForDevice(ctx context.Context, orgID string, devi
 		firmwareVersion = strings.TrimSpace(info.FirmwareVersion)
 	}
 	return telemetryFromVideoCloud(device, firmwareVersion, upstream), true, nil
+}
+
+func telemetryUnavailableFromVideoCloudError(err error) (string, string) {
+	var statusErr videoclient.HTTPStatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.StatusCode {
+		case http.StatusUnauthorized, http.StatusForbidden:
+			return "unauthorized", "Video Cloud telemetry is not authorized for this customer."
+		case http.StatusNotFound:
+			return "unavailable", "Video Cloud telemetry source was not found for this device."
+		default:
+			return "unavailable", "Video Cloud telemetry is unavailable."
+		}
+	}
+	var syntaxErr *json.SyntaxError
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &syntaxErr) || errors.As(err, &typeErr) {
+		return "unavailable", "Video Cloud telemetry returned an unexpected schema."
+	}
+	return "unavailable", "Video Cloud telemetry is unavailable."
+}
+
+func videoCloudTelemetryHasSamples(upstream videoclient.DeviceTelemetryResponse) bool {
+	return upstream.LatestHealth != nil ||
+		len(upstream.RSSIHistory) > 0 ||
+		len(upstream.UptimeHistory) > 0 ||
+		len(upstream.RecentEvents) > 0
 }
 
 func telemetryFromVideoCloud(device contracts.Device, firmwareVersion string, upstream videoclient.DeviceTelemetryResponse) contracts.DeviceTelemetry {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3074,6 +3074,116 @@ func TestDeviceTelemetryProxyModeMapsVideoCloudFailure(t *testing.T) {
 	}
 }
 
+func TestDeviceTelemetryProxyModeMapsVideoCloudFailureModes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		status             int
+		body               string
+		wantTelemetryState string
+		wantReasonContains string
+	}{
+		{name: "unauthorized", status: http.StatusUnauthorized, body: `{"error":"expired"}`, wantTelemetryState: "unauthorized", wantReasonContains: "authorized"},
+		{name: "forbidden", status: http.StatusForbidden, body: `{"error":"denied"}`, wantTelemetryState: "unauthorized", wantReasonContains: "authorized"},
+		{name: "not found", status: http.StatusNotFound, body: `{"error":"missing"}`, wantTelemetryState: "unavailable", wantReasonContains: "not found"},
+		{name: "gateway failure", status: http.StatusServiceUnavailable, body: `{"error":"down"}`, wantTelemetryState: "unavailable", wantReasonContains: "unavailable"},
+		{name: "invalid json", status: http.StatusOK, body: `{`, wantTelemetryState: "unavailable", wantReasonContains: "unexpected"},
+		{name: "empty source", status: http.StatusOK, body: `{"status":"ok","device_id":"device-2"}`, wantTelemetryState: "unavailable", wantReasonContains: "No telemetry samples"},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v1/me":
+					_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"customer@example.com","name":"Customer"},"organizations":[{"id":"org-acme","name":"Acme Smart Camera","role":"owner"}]}`))
+				case "/v1/orgs/org-acme/devices":
+					_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"activated","status":"online","video_cloud_devid":"device-2"}]}`))
+				default:
+					t.Fatalf("unexpected account path: %s", r.URL.Path)
+				}
+			}))
+			defer accountUpstream.Close()
+
+			videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/query_camera_activate":
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"status":  "ok",
+						"devices": []string{"1"},
+					})
+				case "/api/devices/device-2/telemetry":
+					w.WriteHeader(tt.status)
+					_, _ = w.Write([]byte(tt.body))
+				case "/get_camera_info":
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"status": "ok",
+						"info": map[string]any{
+							"firmware_version":  "v1.2.3",
+							"current_transport": "websocket",
+						},
+					})
+				default:
+					t.Fatalf("unexpected video path: %s", r.URL.Path)
+				}
+			}))
+			defer videoUpstream.Close()
+
+			st, err := store.Open(t.TempDir() + "/admin.db")
+			if err != nil {
+				t.Fatalf("Open returned error: %v", err)
+			}
+			defer st.Close()
+			if err := st.Migrate(); err != nil {
+				t.Fatalf("Migrate returned error: %v", err)
+			}
+			if err := st.SeedDemoData(); err != nil {
+				t.Fatalf("SeedDemoData returned error: %v", err)
+			}
+
+			srv := NewWithOptions(st, Options{
+				Config: config.Config{
+					AccountManagerBaseURL:              accountUpstream.URL,
+					LegacyCustomerPasswordLoginEnabled: true,
+					VideoCloudBaseURL:                  videoUpstream.URL,
+					VideoCloudAdminToken:               "vc-secret",
+				},
+				AccountClient: accountclient.New(accountUpstream.URL),
+				VideoClient:   videoclient.New(videoUpstream.URL),
+			})
+			session, err := st.CreateSession("customer", "u1", "customer@example.com", "access", "refresh", "", time.Hour)
+			if err != nil {
+				t.Fatalf("CreateSession returned error: %v", err)
+			}
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/devices/dev-002/telemetry", nil)
+			req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+			srv.ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("proxy telemetry status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			if strings.Contains(rec.Body.String(), "video_cloud_devid") || strings.Contains(rec.Body.String(), "vc-secret") || strings.Contains(rec.Body.String(), "operation_id") {
+				t.Fatalf("proxy telemetry response exposed sensitive/platform-only data: %s", rec.Body.String())
+			}
+			var payload contracts.DeviceTelemetry
+			if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode telemetry payload: %v", err)
+			}
+			if payload.TelemetryStatus != tt.wantTelemetryState {
+				t.Fatalf("telemetry_status = %q, want %q; body=%s", payload.TelemetryStatus, tt.wantTelemetryState, rec.Body.String())
+			}
+			if !strings.Contains(payload.UnavailableReason, tt.wantReasonContains) {
+				t.Fatalf("unavailable_reason = %q, want containing %q", payload.UnavailableReason, tt.wantReasonContains)
+			}
+		})
+	}
+}
+
 func TestAdminRoutesRequirePlatformAdmin(t *testing.T) {
 	t.Parallel()
 

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -17,6 +17,18 @@ type Client struct {
 	httpClient *http.Client
 }
 
+type HTTPStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e HTTPStatusError) Error() string {
+	if strings.TrimSpace(e.Body) != "" {
+		return fmt.Sprintf("status %d: %s", e.StatusCode, strings.TrimSpace(e.Body))
+	}
+	return fmt.Sprintf("status %d", e.StatusCode)
+}
+
 type DeviceInfo struct {
 	FirmwareVersion  string
 	CurrentTransport string
@@ -206,10 +218,7 @@ func (c *Client) doJSON(ctx context.Context, method, path, adminToken string, in
 	defer resp.Body.Close()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		data, _ := io.ReadAll(io.LimitReader(resp.Body, 4<<10))
-		if len(data) > 0 {
-			return fmt.Errorf("status %d: %s", resp.StatusCode, strings.TrimSpace(string(data)))
-		}
-		return fmt.Errorf("status %d", resp.StatusCode)
+		return HTTPStatusError{StatusCode: resp.StatusCode, Body: strings.TrimSpace(string(data))}
 	}
 	if out == nil {
 		return nil

--- a/keys/README.md
+++ b/keys/README.md
@@ -1,0 +1,58 @@
+# Local Video Cloud Admin Certificate Material
+
+This directory is for operator-local certificate material used by
+`rtk_cloud_admin` when bootstrapping or validating access to Video Cloud
+staging.
+
+Only this README is intended to be tracked by git. Private keys, generated
+certificates, CSRs, serial files, tokens, and rendered secret material must stay
+local.
+
+## Expected Local Files
+
+Copy these files from `../rtk_video_cloud/keys/`:
+
+```text
+admin-client.ed25519.cert.pem
+admin-client.ed25519.key.pem
+admin-client-root-ca.ed25519.cert.pem
+```
+
+`admin-client.ed25519.key.pem` should be mode `0600`.
+
+## Staging Admin Token Bootstrap
+
+Use Homebrew curl on macOS because the system curl may not support Ed25519
+client certificates:
+
+```sh
+/opt/homebrew/opt/curl/bin/curl \
+  --cert keys/admin-client.ed25519.cert.pem \
+  --key keys/admin-client.ed25519.key.pem \
+  -H 'Content-Type: application/json' \
+  -d '{"scope":"admin","expiry":3600}' \
+  https://video-cloud-staging.realtekconnect.com/request_token
+```
+
+The returned `access_token` is the value to pass to this service as
+`VIDEO_CLOUD_ADMIN_TOKEN`. Do not commit or log the token.
+
+## Runtime Use
+
+```sh
+VIDEO_CLOUD_BASE_URL=https://video-cloud-staging.realtekconnect.com
+VIDEO_CLOUD_ADMIN_TOKEN=<redacted>
+```
+
+The Admin BFF sends the token to Video Cloud as:
+
+```http
+Authorization: Bearer <VIDEO_CLOUD_ADMIN_TOKEN>
+```
+
+## Notes
+
+- The admin client certificate subject is expected to be `CN=Video Cloud Admin`.
+- Video Cloud staging must trust `admin-client-root-ca.ed25519.cert.pem` at the
+  edge and forward verified client certificate identity to the API.
+- Never copy CA private keys into this repository.

--- a/scripts/local_video_cloud_e2e.sh
+++ b/scripts/local_video_cloud_e2e.sh
@@ -15,6 +15,8 @@ ADMIN_EMAIL="${E2E_ADMIN_EMAIL:-admin@example.com}"
 ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-local-e2e-secret}"
 PORT="${E2E_PORT:-}"
 ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-$ROOT_DIR/.artifacts/live-video-cloud-e2e}"
+REPORT_PATH="$ARTIFACTS_DIR/report.json"
+REPORT_LINES="$ARTIFACTS_DIR/report.jsonl"
 
 SERVER_PID=""
 TMP_DIR=""
@@ -28,7 +30,42 @@ cleanup() {
     rm -rf "$TMP_DIR"
   fi
 }
-trap cleanup EXIT
+
+finalize_report() {
+  local exit_code="$1"
+  local status="passed"
+  if [[ "$exit_code" != "0" ]]; then
+    status="failed"
+  fi
+  mkdir -p "$ARTIFACTS_DIR"
+  if [[ ! -f "$REPORT_LINES" ]]; then
+    : >"$REPORT_LINES"
+  fi
+  jq -s \
+    --arg status "$status" \
+    --arg base_url "$VIDEO_CLOUD_BASE_URL" \
+    --arg org_id "$ORG_ID" \
+    --arg account_device_1 "$ACCOUNT_DEVICE_1" \
+    --arg video_device_1 "$VIDEO_DEVICE_1" \
+    --arg account_device_2 "$ACCOUNT_DEVICE_2" \
+    --arg video_device_2 "$VIDEO_DEVICE_2" \
+    --arg artifacts_dir "$ARTIFACTS_DIR" \
+    '{
+      status: $status,
+      video_cloud_base_url: $base_url,
+      fixture: {
+        org_id: $org_id,
+        devices: [
+          {account_device_id: $account_device_1, video_device_id: $video_device_1},
+          {account_device_id: $account_device_2, video_device_id: $video_device_2}
+        ]
+      },
+      artifacts_dir: $artifacts_dir,
+      checks: .
+    }' "$REPORT_LINES" >"$REPORT_PATH"
+  cleanup
+}
+trap 'exit_code=$?; finalize_report "$exit_code"; exit "$exit_code"' EXIT
 
 fail() {
   printf 'FAIL: %s\n' "$*" >&2
@@ -37,6 +74,31 @@ fail() {
 
 log() {
   printf '[local-video-cloud-e2e] %s\n' "$*"
+}
+
+record_check() {
+  local name="$1"
+  local status="$2"
+  local detail="${3:-}"
+  local endpoint="${4:-}"
+  local source_status="${5:-}"
+  local source_message="${6:-}"
+  mkdir -p "$ARTIFACTS_DIR"
+  jq -cn \
+    --arg name "$name" \
+    --arg status "$status" \
+    --arg detail "$detail" \
+    --arg endpoint "$endpoint" \
+    --arg source_status "$source_status" \
+    --arg source_message "$source_message" \
+    '{
+      name: $name,
+      status: $status,
+      detail: $detail,
+      endpoint: $endpoint,
+      source_status: $source_status,
+      source_message: $source_message
+    } | with_entries(select(.value != ""))' >>"$REPORT_LINES"
 }
 
 require_file() {
@@ -87,6 +149,7 @@ SERVER_LOG="$TMP_DIR/server.log"
 COOKIE_JAR="$TMP_DIR/platform.cookies"
 BASE_URL="http://127.0.0.1:$PORT"
 mkdir -p "$ARTIFACTS_DIR"
+: >"$REPORT_LINES"
 
 log "bootstrapping Video Cloud admin token from client certificate"
 token_response="$("$curl_bin" -fsS \
@@ -98,6 +161,7 @@ token_response="$("$curl_bin" -fsS \
 
 admin_token="$(printf '%s' "$token_response" | jq -r 'select(.token_type=="Bearer" and .scope=="admin") | .access_token // empty')"
 [[ -n "$admin_token" ]] || fail "admin token bootstrap did not return a Bearer admin access_token"
+record_check "token bootstrap" "pass" "admin bearer token issued"
 log "admin token bootstrap passed"
 
 log "building WebUI assets"
@@ -130,6 +194,7 @@ for _ in $(seq 1 40); do
   sleep 0.25
 done
 [[ "$ready" == "1" ]] || { sed -n '1,120p' "$SERVER_LOG" >&2 || true; fail "Admin BFF did not become ready"; }
+record_check "local Admin BFF ready" "pass" "$BASE_URL"
 
 log "normalizing local demo fixture device ids"
 "$sqlite_bin" "$DB_PATH" <<SQL
@@ -144,12 +209,17 @@ expires_at="$(node -e 'console.log(new Date(Date.now()+3600*1000).toISOString())
 INSERT INTO sessions (id, kind, subject, email, access_token, refresh_token, active_org_id, expires_at, created_at)
 VALUES ('$customer_session', 'customer', 'local-e2e-customer', 'customer@example.local', 'local-access', 'local-refresh', '$ORG_ID', '$expires_at', '$created_at');
 SQL
+record_check "local customer session" "pass" "$ORG_ID"
 
 assert_json() {
   local label="$1"
   local json="$2"
   shift 2
   printf '%s' "$json" | jq -e "$@" >/dev/null || {
+    local source_status source_message
+    source_status="$(printf '%s' "$json" | jq -r '.source_status // .telemetry_status // empty' 2>/dev/null || true)"
+    source_message="$(printf '%s' "$json" | jq -r '.source_message // .unavailable_reason // empty' 2>/dev/null || true)"
+    record_check "$label" "fail" "JSON assertion failed" "" "$source_status" "$source_message"
     printf 'Assertion failed for %s. Body:\n%s\n' "$label" "$json" >&2
     exit 1
   }
@@ -165,11 +235,158 @@ customer_get_json() {
   "$curl_bin" -fsS -H "Cookie: rtk_admin_session=$customer_session" "$BASE_URL$path"
 }
 
+classify_upstream_response() {
+  local status="$1"
+  local body_file="$2"
+  if [[ "$status" == "401" || "$status" == "403" ]]; then
+    printf 'auth_failed'
+  elif [[ "$status" == "404" ]]; then
+    printf 'not_found'
+  elif [[ "$status" =~ ^5 ]]; then
+    printf 'source_unavailable'
+  elif [[ ! "$status" =~ ^2 ]]; then
+    printf 'http_%s' "$status"
+  elif ! jq -e . "$body_file" >/dev/null 2>&1; then
+    printf 'unexpected_schema'
+  else
+    printf 'ok'
+  fi
+}
+
+summarize_upstream_body() {
+  local kind="$1"
+  local body_file="$2"
+  case "$kind" in
+    telemetry)
+      jq -c '{
+        status: .status,
+        telemetry_status: .telemetry_status,
+        device_id: .device_id,
+        latest_health: (.latest_health != null),
+        rssi_samples: (.rssi_history // [] | length),
+        uptime_samples: (.uptime_history // [] | length),
+        recent_events: (.recent_events // [] | length),
+        unavailable_reason: .unavailable_reason
+      }' "$body_file" 2>/dev/null || printf '{}'
+      ;;
+    stream)
+      jq -c '{
+        status: .status,
+        source_status: .source_status,
+        source_message: .source_message,
+        window: .window,
+        active_sessions: .active_sessions,
+        worst_devices: (.worst_devices // [] | length),
+        trend_points: (.trend // [] | length)
+      }' "$body_file" 2>/dev/null || printf '{}'
+      ;;
+    firmware)
+      jq -c '{
+        status: .status,
+        source_status: .source_status,
+        source_message: .source_message,
+        versions: (.versions // .releases // [] | length),
+        rollouts: (.rollouts // [] | length),
+        campaigns: (.campaigns // (if .campaign then [.campaign] else [] end) // [] | length)
+      }' "$body_file" 2>/dev/null || printf '{}'
+      ;;
+    *)
+      jq -c '{status: .status, source_status: .source_status, source_message: .source_message}' "$body_file" 2>/dev/null || printf '{}'
+      ;;
+  esac
+}
+
+classify_upstream_data() {
+  local kind="$1"
+  local body_file="$2"
+  case "$kind" in
+    telemetry)
+      jq -e '(.latest_health != null) or ((.rssi_history // []) | length > 0) or ((.uptime_history // []) | length > 0) or ((.recent_events // []) | length > 0)' "$body_file" >/dev/null 2>&1 || {
+        printf 'empty_data'
+        return
+      }
+      ;;
+    stream)
+      jq -e '(.source_status? == "available") or ((.trend // []) | length > 0) or ((.worst_devices // []) | length > 0) or ((.active_sessions // 0) > 0)' "$body_file" >/dev/null 2>&1 || {
+        printf 'empty_data'
+        return
+      }
+      ;;
+    firmware)
+      jq -e '((.versions // .releases // []) | length > 0) or ((.rollouts // []) | length > 0) or ((.campaigns // []) | length > 0) or (.campaign != null)' "$body_file" >/dev/null 2>&1 || {
+        printf 'empty_data'
+        return
+      }
+      ;;
+  esac
+  printf 'ok'
+}
+
+diagnose_get() {
+  local name="$1"
+  local path="$2"
+  local kind="$3"
+  local body_file="$TMP_DIR/diag-$(printf '%s' "$name" | tr -cs '[:alnum:]' '-').json"
+  local status
+  status="$("$curl_bin" -sS -o "$body_file" -w '%{http_code}' \
+    -H "Authorization: Bearer $admin_token" \
+    "$VIDEO_CLOUD_BASE_URL$path" || true)"
+  local class summary
+  class="$(classify_upstream_response "$status" "$body_file")"
+  if [[ "$class" == "ok" ]]; then
+    class="$(classify_upstream_data "$kind" "$body_file")"
+  fi
+  summary="$(summarize_upstream_body "$kind" "$body_file")"
+  record_check "$name" "$class" "$summary" "$path"
+}
+
+diagnose_post() {
+  local name="$1"
+  local path="$2"
+  local payload="$3"
+  local kind="$4"
+  local body_file="$TMP_DIR/diag-$(printf '%s' "$name" | tr -cs '[:alnum:]' '-').json"
+  local status
+  status="$("$curl_bin" -sS -o "$body_file" -w '%{http_code}' \
+    -H "Authorization: Bearer $admin_token" \
+    -H 'Content-Type: application/json' \
+    -d "$payload" \
+    "$VIDEO_CLOUD_BASE_URL$path" || true)"
+  local class summary
+  class="$(classify_upstream_response "$status" "$body_file")"
+  if [[ "$class" == "ok" ]]; then
+    class="$(classify_upstream_data "$kind" "$body_file")"
+  fi
+  summary="$(summarize_upstream_body "$kind" "$body_file")"
+  record_check "$name" "$class" "$summary" "$path"
+}
+
+run_upstream_diagnostics() {
+  if [[ "${E2E_DIAGNOSTICS:-}" != "1" ]]; then
+    return
+  fi
+  log "running redacted Video Cloud upstream diagnostics"
+  local devices_csv model
+  devices_csv="$VIDEO_DEVICE_1,$VIDEO_DEVICE_2"
+  model="${E2E_FIRMWARE_MODEL:-RTK-CAM-A}"
+  diagnose_get "upstream telemetry $VIDEO_DEVICE_1" "/api/devices/$VIDEO_DEVICE_1/telemetry?org_id=$ORG_ID" telemetry
+  diagnose_get "upstream telemetry $VIDEO_DEVICE_2" "/api/devices/$VIDEO_DEVICE_2/telemetry?org_id=$ORG_ID" telemetry
+  diagnose_get "upstream stream 7d" "/api/fleet/stream-stats?org_id=$ORG_ID&window=7d&devices=$devices_csv" stream
+  diagnose_get "upstream stream 30d" "/api/fleet/stream-stats?org_id=$ORG_ID&window=30d&devices=$devices_csv" stream
+  diagnose_post "upstream firmware enum $model" "/enum_firmware" "{\"model\":\"$model\"}" firmware
+  diagnose_post "upstream firmware rollout $model" "/query_firmware_rollout" "{\"model\":\"$model\"}" firmware
+  diagnose_post "upstream firmware campaign $model" "/query_firmware_campaign" "{\"model\":\"$model\"}" firmware
+}
+
 log "checking service health"
 healthz="$(get_json /healthz)"
 [[ "$healthz" == "ok" ]] || fail "/healthz returned $healthz"
+record_check "healthz" "pass" "ok" "/healthz"
 service_health="$(get_json /api/service-health)"
 assert_json "service health" "$service_health" '.[] | select(.name=="Video Cloud" and .status=="ok")'
+record_check "service health" "pass" "Video Cloud ok" "/api/service-health"
+
+run_upstream_diagnostics
 
 log "checking platform break-glass login"
 platform_login="$("$curl_bin" -fsS -c "$COOKIE_JAR" \
@@ -181,6 +398,7 @@ platform_session="$(awk '($0 !~ /^#/ || $0 ~ /^#HttpOnly_/) && $6=="rtk_admin_se
 [[ -n "$platform_session" ]] || fail "platform login did not return rtk_admin_session cookie"
 platform_me="$("$curl_bin" -fsS -b "$COOKIE_JAR" "$BASE_URL/api/me")"
 assert_json "platform me" "$platform_me" '.kind=="platform_admin"'
+record_check "platform break-glass login" "pass" "platform_admin session issued" "/api/auth/platform/login"
 
 log "checking customer-safe devices"
 devices_json="$(customer_get_json /api/devices)"
@@ -189,20 +407,25 @@ if printf '%s' "$devices_json" | grep -Eq 'video_cloud_devid|operation_id|upstre
   printf '%s\n' "$devices_json" >&2
   fail "/api/devices exposed platform-only fields"
 fi
+record_check "customer-safe devices" "pass" "platform-only fields absent" "/api/devices"
 
 log "checking device telemetry"
 telemetry_json="$(customer_get_json "/api/devices/$ACCOUNT_DEVICE_1/telemetry")"
 assert_json "device telemetry" "$telemetry_json" '.telemetry_status=="available"'
+record_check "device telemetry" "pass" "telemetry source available" "/api/devices/$ACCOUNT_DEVICE_1/telemetry" "$(printf '%s' "$telemetry_json" | jq -r '.telemetry_status // empty')" "$(printf '%s' "$telemetry_json" | jq -r '.unavailable_reason // empty')"
 
 log "checking firmware distribution"
 firmware_json="$(customer_get_json /api/fleet/firmware-distribution)"
 assert_json "firmware distribution" "$firmware_json" '.source_status=="available" and (.versions | length > 0)'
+record_check "firmware distribution" "pass" "firmware source available" "/api/fleet/firmware-distribution" "$(printf '%s' "$firmware_json" | jq -r '.source_status // empty')" "$(printf '%s' "$firmware_json" | jq -r '.source_message // empty')"
 
 log "checking stream stats"
 stream_7d_json="$(customer_get_json /api/fleet/stream-stats?window=7d)"
 assert_json "stream stats 7d" "$stream_7d_json" '.source_status=="available"'
+record_check "stream stats 7d" "pass" "stream source available" "/api/fleet/stream-stats?window=7d" "$(printf '%s' "$stream_7d_json" | jq -r '.source_status // empty')" "$(printf '%s' "$stream_7d_json" | jq -r '.source_message // empty')"
 stream_30d_json="$(customer_get_json /api/fleet/stream-stats?window=30d)"
 assert_json "stream stats 30d" "$stream_30d_json" '.source_status=="available"'
+record_check "stream stats 30d" "pass" "stream source available" "/api/fleet/stream-stats?window=30d" "$(printf '%s' "$stream_30d_json" | jq -r '.source_status // empty')" "$(printf '%s' "$stream_30d_json" | jq -r '.source_message // empty')"
 
 log "running live browser validation"
 LIVE_BFF_BASE_URL="$BASE_URL" \
@@ -211,5 +434,6 @@ LIVE_BFF_BASE_URL="$BASE_URL" \
   E2E_ACCOUNT_DEVICE_1="$ACCOUNT_DEVICE_1" \
   E2E_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
   node "$ROOT_DIR/web/scripts/live-bff-e2e.mjs"
+record_check "live browser validation" "pass" "browser flows passed" "$ARTIFACTS_DIR"
 
 log "passed. Artifacts: $ARTIFACTS_DIR"

--- a/scripts/local_video_cloud_e2e.sh
+++ b/scripts/local_video_cloud_e2e.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VIDEO_CLOUD_BASE_URL="${VIDEO_CLOUD_BASE_URL:-https://video-cloud-staging.realtekconnect.com}"
+CERT_PATH="${VIDEO_CLOUD_ADMIN_CERT_PATH:-$ROOT_DIR/keys/admin-client.ed25519.cert.pem}"
+KEY_PATH="${VIDEO_CLOUD_ADMIN_KEY_PATH:-$ROOT_DIR/keys/admin-client.ed25519.key.pem}"
+CA_PATH="${VIDEO_CLOUD_ADMIN_CA_PATH:-$ROOT_DIR/keys/admin-client-root-ca.ed25519.cert.pem}"
+ORG_ID="${E2E_ORG_ID:-org-acme}"
+ACCOUNT_DEVICE_1="${E2E_ACCOUNT_DEVICE_1:-dev-001}"
+VIDEO_DEVICE_1="${E2E_VIDEO_DEVICE_1:-device-1}"
+ACCOUNT_DEVICE_2="${E2E_ACCOUNT_DEVICE_2:-dev-002}"
+VIDEO_DEVICE_2="${E2E_VIDEO_DEVICE_2:-device-2}"
+ADMIN_EMAIL="${E2E_ADMIN_EMAIL:-admin@example.com}"
+ADMIN_PASSWORD="${E2E_ADMIN_PASSWORD:-local-e2e-secret}"
+PORT="${E2E_PORT:-}"
+ARTIFACTS_DIR="${E2E_ARTIFACTS_DIR:-$ROOT_DIR/.artifacts/live-video-cloud-e2e}"
+
+SERVER_PID=""
+TMP_DIR=""
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "$TMP_DIR" && "${E2E_KEEP_TMP:-}" != "1" ]]; then
+    rm -rf "$TMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+log() {
+  printf '[local-video-cloud-e2e] %s\n' "$*"
+}
+
+require_file() {
+  [[ -f "$1" ]] || fail "missing required file: $1"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "missing required command: $1"
+}
+
+curl_bin="${CURL_BIN:-/opt/homebrew/opt/curl/bin/curl}"
+if [[ ! -x "$curl_bin" ]]; then
+  fail "Homebrew curl is required at /opt/homebrew/opt/curl/bin/curl, or set CURL_BIN to a curl built with OpenSSL 3"
+fi
+require_cmd jq
+require_cmd go
+require_cmd npm
+require_cmd node
+
+sqlite_bin="${SQLITE3_BIN:-$(command -v sqlite3 || true)}"
+if [[ -z "$sqlite_bin" && -x /Users/kevinhuang/Library/Android/sdk/platform-tools/sqlite3 ]]; then
+  sqlite_bin="/Users/kevinhuang/Library/Android/sdk/platform-tools/sqlite3"
+fi
+[[ -n "$sqlite_bin" ]] || fail "sqlite3 is required"
+
+require_file "$CERT_PATH"
+require_file "$KEY_PATH"
+require_file "$CA_PATH"
+
+key_mode="$(stat -f '%Lp' "$KEY_PATH" 2>/dev/null || stat -c '%a' "$KEY_PATH" 2>/dev/null || true)"
+[[ "$key_mode" == "600" ]] || fail "$KEY_PATH must be mode 0600; current mode is ${key_mode:-unknown}"
+
+if ! "$curl_bin" --version | head -n1 | grep -Eq 'OpenSSL/[3-9]'; then
+  fail "curl must be built with OpenSSL 3+ for the Ed25519 client certificate: $("$curl_bin" --version | head -n1)"
+fi
+
+if [[ -n "$PORT" ]]; then
+  if lsof -nP -iTCP:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+    fail "requested E2E_PORT $PORT is already in use"
+  fi
+else
+  PORT="$(node -e "const net=require('net'); const s=net.createServer(); s.listen(0,'127.0.0.1',()=>{console.log(s.address().port); s.close();});")"
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/rtk-cloud-admin-e2e.XXXXXX")"
+DB_PATH="$TMP_DIR/admin.db"
+SERVER_LOG="$TMP_DIR/server.log"
+COOKIE_JAR="$TMP_DIR/platform.cookies"
+BASE_URL="http://127.0.0.1:$PORT"
+mkdir -p "$ARTIFACTS_DIR"
+
+log "bootstrapping Video Cloud admin token from client certificate"
+token_response="$("$curl_bin" -fsS \
+  --cert "$CERT_PATH" \
+  --key "$KEY_PATH" \
+  -H 'Content-Type: application/json' \
+  -d '{"scope":"admin","expiry":3600}' \
+  "$VIDEO_CLOUD_BASE_URL/request_token")"
+
+admin_token="$(printf '%s' "$token_response" | jq -r 'select(.token_type=="Bearer" and .scope=="admin") | .access_token // empty')"
+[[ -n "$admin_token" ]] || fail "admin token bootstrap did not return a Bearer admin access_token"
+log "admin token bootstrap passed"
+
+log "building WebUI assets"
+(cd "$ROOT_DIR/web" && npm run build >/dev/null)
+
+log "starting Admin BFF on $BASE_URL"
+(
+  cd "$ROOT_DIR"
+  PORT="$PORT" \
+    DATABASE_PATH="$DB_PATH" \
+    VIDEO_CLOUD_BASE_URL="$VIDEO_CLOUD_BASE_URL" \
+    VIDEO_CLOUD_ADMIN_TOKEN="$admin_token" \
+    ADMIN_BOOTSTRAP_EMAIL="$ADMIN_EMAIL" \
+    ADMIN_BOOTSTRAP_PASSWORD="$ADMIN_PASSWORD" \
+    ADMIN_BREAK_GLASS_ENABLED=true \
+    go run ./cmd/server >"$SERVER_LOG" 2>&1
+) &
+SERVER_PID="$!"
+
+ready=0
+for _ in $(seq 1 40); do
+  if "$curl_bin" -fsS "$BASE_URL/healthz" >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    sed -n '1,120p' "$SERVER_LOG" >&2 || true
+    fail "Admin BFF exited before becoming ready"
+  fi
+  sleep 0.25
+done
+[[ "$ready" == "1" ]] || { sed -n '1,120p' "$SERVER_LOG" >&2 || true; fail "Admin BFF did not become ready"; }
+
+log "normalizing local demo fixture device ids"
+"$sqlite_bin" "$DB_PATH" <<SQL
+UPDATE devices SET video_cloud_devid = '$VIDEO_DEVICE_1' WHERE id = '$ACCOUNT_DEVICE_1';
+UPDATE devices SET video_cloud_devid = '$VIDEO_DEVICE_2' WHERE id = '$ACCOUNT_DEVICE_2';
+SQL
+
+customer_session="local-e2e-customer-$(date +%s)-$RANDOM"
+created_at="$(node -e 'console.log(new Date().toISOString())')"
+expires_at="$(node -e 'console.log(new Date(Date.now()+3600*1000).toISOString())')"
+"$sqlite_bin" "$DB_PATH" <<SQL
+INSERT INTO sessions (id, kind, subject, email, access_token, refresh_token, active_org_id, expires_at, created_at)
+VALUES ('$customer_session', 'customer', 'local-e2e-customer', 'customer@example.local', 'local-access', 'local-refresh', '$ORG_ID', '$expires_at', '$created_at');
+SQL
+
+assert_json() {
+  local label="$1"
+  local json="$2"
+  shift 2
+  printf '%s' "$json" | jq -e "$@" >/dev/null || {
+    printf 'Assertion failed for %s. Body:\n%s\n' "$label" "$json" >&2
+    exit 1
+  }
+}
+
+get_json() {
+  local path="$1"
+  "$curl_bin" -fsS "$BASE_URL$path"
+}
+
+customer_get_json() {
+  local path="$1"
+  "$curl_bin" -fsS -H "Cookie: rtk_admin_session=$customer_session" "$BASE_URL$path"
+}
+
+log "checking service health"
+healthz="$(get_json /healthz)"
+[[ "$healthz" == "ok" ]] || fail "/healthz returned $healthz"
+service_health="$(get_json /api/service-health)"
+assert_json "service health" "$service_health" '.[] | select(.name=="Video Cloud" and .status=="ok")'
+
+log "checking platform break-glass login"
+platform_login="$("$curl_bin" -fsS -c "$COOKIE_JAR" \
+  -H 'Content-Type: application/json' \
+  -d "{\"email\":\"$ADMIN_EMAIL\",\"password\":\"$ADMIN_PASSWORD\"}" \
+  "$BASE_URL/api/auth/platform/login")"
+assert_json "platform login" "$platform_login" '.status=="ok"'
+platform_session="$(awk '($0 !~ /^#/ || $0 ~ /^#HttpOnly_/) && $6=="rtk_admin_session"{print $7}' "$COOKIE_JAR" | tail -n1)"
+[[ -n "$platform_session" ]] || fail "platform login did not return rtk_admin_session cookie"
+platform_me="$("$curl_bin" -fsS -b "$COOKIE_JAR" "$BASE_URL/api/me")"
+assert_json "platform me" "$platform_me" '.kind=="platform_admin"'
+
+log "checking customer-safe devices"
+devices_json="$(customer_get_json /api/devices)"
+assert_json "devices" "$devices_json" --arg id "$ACCOUNT_DEVICE_1" 'type=="array" and any(.[]; .id==$id)'
+if printf '%s' "$devices_json" | grep -Eq 'video_cloud_devid|operation_id|upstream_operation_id|raw_payload|dead_lettered'; then
+  printf '%s\n' "$devices_json" >&2
+  fail "/api/devices exposed platform-only fields"
+fi
+
+log "checking device telemetry"
+telemetry_json="$(customer_get_json "/api/devices/$ACCOUNT_DEVICE_1/telemetry")"
+assert_json "device telemetry" "$telemetry_json" '.telemetry_status=="available"'
+
+log "checking firmware distribution"
+firmware_json="$(customer_get_json /api/fleet/firmware-distribution)"
+assert_json "firmware distribution" "$firmware_json" '.source_status=="available" and (.versions | length > 0)'
+
+log "checking stream stats"
+stream_7d_json="$(customer_get_json /api/fleet/stream-stats?window=7d)"
+assert_json "stream stats 7d" "$stream_7d_json" '.source_status=="available"'
+stream_30d_json="$(customer_get_json /api/fleet/stream-stats?window=30d)"
+assert_json "stream stats 30d" "$stream_30d_json" '.source_status=="available"'
+
+log "running live browser validation"
+LIVE_BFF_BASE_URL="$BASE_URL" \
+  E2E_CUSTOMER_SESSION_ID="$customer_session" \
+  E2E_PLATFORM_SESSION_ID="$platform_session" \
+  E2E_ACCOUNT_DEVICE_1="$ACCOUNT_DEVICE_1" \
+  E2E_ARTIFACTS_DIR="$ARTIFACTS_DIR" \
+  node "$ROOT_DIR/web/scripts/live-bff-e2e.mjs"
+
+log "passed. Artifacts: $ARTIFACTS_DIR"

--- a/web/scripts/live-bff-e2e.mjs
+++ b/web/scripts/live-bff-e2e.mjs
@@ -1,0 +1,110 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const baseURL = requiredEnv('LIVE_BFF_BASE_URL').replace(/\/$/, '');
+const customerSessionID = requiredEnv('E2E_CUSTOMER_SESSION_ID');
+const platformSessionID = requiredEnv('E2E_PLATFORM_SESSION_ID');
+const accountDeviceID = process.env.E2E_ACCOUNT_DEVICE_1 || 'dev-001';
+const artifactsDir = process.env.E2E_ARTIFACTS_DIR || path.join(repoRoot, '.artifacts', 'live-video-cloud-e2e');
+
+await mkdir(artifactsDir, { recursive: true });
+
+const browser = await chromium.launch();
+const consoleIssues = [];
+
+try {
+  const customerContext = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  await addSessionCookie(customerContext, customerSessionID);
+  const customerPage = await customerContext.newPage();
+  collectConsoleIssues(customerPage, consoleIssues, 'customer');
+
+  await gotoAndAssert(customerPage, '/console/overview', 'Fleet Health Overview');
+  await expectText(customerPage, 'Online Rate');
+  await expectText(customerPage, 'Needs Attention');
+  await screenshot(customerPage, 'customer-overview.png');
+
+  await gotoAndAssert(customerPage, `/console/devices?device=${encodeURIComponent(accountDeviceID)}`, 'Devices');
+  await expectText(customerPage, 'Device detail');
+  await expectText(customerPage, 'Provision device');
+  await screenshot(customerPage, 'customer-devices-drawer.png');
+
+  await gotoAndAssert(customerPage, '/console/firmware-ota', 'Firmware & OTA');
+  await expectText(customerPage, 'Firmware distribution');
+  await expectText(customerPage, 'Rollout Campaigns');
+  await screenshot(customerPage, 'customer-firmware.png');
+
+  await gotoAndAssert(customerPage, '/console/stream-health', 'Stream Health');
+  await expectText(customerPage, 'Worst devices');
+  await screenshot(customerPage, 'customer-stream-health.png');
+  await customerContext.close();
+
+  const platformContext = await browser.newContext({ viewport: { width: 1440, height: 1000 } });
+  await addSessionCookie(platformContext, platformSessionID);
+  const platformPage = await platformContext.newPage();
+  collectConsoleIssues(platformPage, consoleIssues, 'platform');
+  await gotoAndAssert(platformPage, '/admin/ops', 'Operations');
+  await expectText(platformPage, 'Lifecycle operations');
+  await expectText(platformPage, 'Friendly Summary');
+  await screenshot(platformPage, 'platform-operations.png');
+  await platformContext.close();
+
+  if (consoleIssues.length) {
+    throw new Error(`Console issues detected:\n${consoleIssues.join('\n')}`);
+  }
+
+  console.log(`Live BFF browser E2E passed. Screenshots: ${artifactsDir}`);
+} finally {
+  await browser.close();
+}
+
+function requiredEnv(name) {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`${name} is required`);
+  }
+  return value;
+}
+
+async function addSessionCookie(context, value) {
+  await context.addCookies([{
+    name: 'rtk_admin_session',
+    value,
+    url: baseURL,
+    httpOnly: true,
+    sameSite: 'Lax',
+  }]);
+}
+
+function collectConsoleIssues(page, issues, label) {
+  page.on('console', (message) => {
+    if (!['error', 'warning'].includes(message.type())) return;
+    issues.push(`${label} ${message.type()}: ${message.text()}`);
+  });
+  page.on('pageerror', (error) => {
+    issues.push(`${label} pageerror: ${error.message}`);
+  });
+}
+
+async function gotoAndAssert(page, routePath, expectedText) {
+  await page.goto(`${baseURL}${routePath}`, { waitUntil: 'networkidle' });
+  await expectText(page, expectedText);
+  const rootText = await page.locator('#root').innerText({ timeout: 5000 });
+  if (!rootText.trim()) {
+    throw new Error(`Blank app shell at ${routePath}`);
+  }
+  if (/Internal server error|vite|webpack|ReferenceError|TypeError/.test(rootText)) {
+    throw new Error(`Framework/runtime overlay detected at ${routePath}`);
+  }
+}
+
+async function expectText(page, text) {
+  await page.getByText(text, { exact: false }).first().waitFor({ state: 'visible', timeout: 10000 });
+}
+
+async function screenshot(page, name) {
+  await page.screenshot({ path: path.join(artifactsDir, name), fullPage: false });
+}


### PR DESCRIPTION
Closes #108
Closes #110
Closes #111
Closes #112
Closes #113
Closes #114

## Summary
- Add `scripts/local_video_cloud_e2e.sh` for manual local-only Video Cloud staging validation.
- Add `web/scripts/live-bff-e2e.mjs` for live BFF browser validation without mocked APIs.
- Add redacted upstream diagnostics with `E2E_DIAGNOSTICS=1` and a redacted `.artifacts/live-video-cloud-e2e/report.json` summary.
- Harden customer-safe Admin BFF telemetry error mapping for Video Cloud auth/not-found/unavailable/unexpected-schema/empty-source cases.
- Document current blocked live validation coverage and the known-good Video Cloud staging fixture contract.
- Add `keys/README.md`, `.gitignore` rules, and staging E2E docs for local cert/key setup, redaction policy, and failure triage.

## What the local E2E checks
- Bootstraps a `scope=admin` bearer token from Video Cloud staging using the admin client certificate.
- Starts the local Admin BFF with temp SQLite and runtime-only `VIDEO_CLOUD_ADMIN_TOKEN`.
- Validates `/healthz`, Video Cloud service health, platform break-glass login, customer-safe devices, telemetry, firmware, and 7d/30d stream stats.
- Runs browser validation against the live local BFF for Overview, Devices drawer, Firmware & OTA, Stream Health, and Platform Operations.
- Optional diagnostics directly probe upstream Video Cloud telemetry, stream, and firmware endpoints without logging token material.

## Validation
- `bash -n scripts/local_video_cloud_e2e.sh`
- `node --check web/scripts/live-bff-e2e.mjs`
- `git diff --check`
- `go test ./internal/app -run 'TestDeviceTelemetryProxyMode|TestFleetStreamStatsProxyFailure|TestFleetFirmwareDistributionProxyFailure' -count=1`
- `go test ./...`
- `cd web && npm test -- --runInBand`
- `cd web && npm run build`
- `cd web && npm run browser:smoke`

## Live staging result
`E2E_DIAGNOSTICS=1 VIDEO_CLOUD_BASE_URL=https://video-cloud-staging.realtekconnect.com ./scripts/local_video_cloud_e2e.sh` now reaches the BFF customer API assertions and writes a redacted report. It hard-fails as designed because the default staging fixture is not known-good yet:

- `device-1` telemetry upstream: `not_found`
- `device-2` telemetry upstream: `not_found`
- firmware enum/rollout/campaign for `RTK-CAM-A`: `empty_data`
- stream stats `7d` and `30d`: upstream endpoint responds with trend data
- BFF customer telemetry assertion fails with `telemetry_status=unavailable` and `unavailable_reason="Video Cloud telemetry source was not found for this device."`

This is the intended signal for developer triage: create or point the script at a known-good provisioned/activated Video Cloud staging fixture with telemetry, firmware, and stream data. The script does not print or persist the staging token.

## CI policy
This live staging E2E is manual/protected-runner only and is not wired into default CI because it depends on local cert/key material and real staging state.
