### PR TITLE
Add Linode admin deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,8 @@ docker run --rm -p 18081:8080 \
 Container health uses `/healthz`.
 
 For a production private-cloud deployment, see
-[`docs/private-cloud-deployment.md`](docs/private-cloud-deployment.md).
+[`docs/private-cloud-deployment.md`](docs/private-cloud-deployment.md). For the
+Linode staging scripts, see [`deploy/linode/`](deploy/linode/).
 
 ## CI
 

--- a/deploy/linode/.gitignore
+++ b/deploy/linode/.gitignore
@@ -1,0 +1,4 @@
+*.env
+*.env.local
+*.json
+*.state

--- a/deploy/linode/README.md
+++ b/deploy/linode/README.md
@@ -1,0 +1,149 @@
+# Linode Admin Dashboard Deployment
+
+This directory contains the operator-local deployment scripts for running
+`rtk_cloud_admin` on a dedicated Linode VM.
+
+The Admin VM is intentionally independent from the `rtk_video_cloud` Linode VPC:
+
+- one dedicated public Linode VM
+- no VPC interface
+- no dependency on the Video Cloud edge VM as a gateway
+- public HTTPS to Account Manager and Video Cloud upstreams
+- local SQLite persisted on the Admin VM
+
+## Target Shape
+
+```text
+internet
+  -> admin.video-cloud-staging.realtekconnect.com:443
+  -> nginx on the Admin VM
+  -> rtk_cloud_admin container on 127.0.0.1:8080
+
+rtk_cloud_admin
+  -> ACCOUNT_MANAGER_BASE_URL over public HTTPS
+  -> VIDEO_CLOUD_BASE_URL over public HTTPS
+```
+
+This is the same operator-local deployment model used by the Video Cloud Linode
+tooling: CI builds/test artifacts; a trusted operator machine performs Linode
+mutation and host deployment with local secrets.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `admin-staging.env.example` | Local operator env template. Copy it before editing. |
+| `provision-admin-vm.sh` | Creates the public-only Linode VM and firewall with `linode-cli`. |
+| `deploy-admin.sh` | Builds the Docker image locally, uploads it, installs nginx/systemd, and starts the service. |
+| `verify-admin.sh` | Runs external HTTP checks against the deployed dashboard. |
+| `backup-admin-db.sh` | Pulls a sanitized SQLite backup archive from the Admin VM. |
+
+## Prerequisites
+
+Operator machine:
+
+- `linode-cli`
+- `jq`
+- `docker`
+- `ssh` and `scp`
+- a Linode API token configured for `linode-cli`
+- an SSH key allowed for the Admin VM
+- DNS control for the chosen hostname
+
+Remote Admin VM:
+
+- Ubuntu 24.04 image
+- public IPv4 only
+- inbound `22/tcp` limited to operator CIDRs
+- inbound `80/tcp` and `443/tcp` public for certbot and dashboard HTTPS
+
+## 1. Prepare Local Env
+
+```sh
+cp deploy/linode/admin-staging.env.example deploy/linode/admin-staging.env
+$EDITOR deploy/linode/admin-staging.env
+set -a
+. deploy/linode/admin-staging.env
+set +a
+```
+
+Do not commit the copied env file. It contains deployment secrets.
+
+## 2. Provision VM
+
+```sh
+deploy/linode/provision-admin-vm.sh
+```
+
+The script writes a local ignored state file such as:
+
+```text
+deploy/linode/rtk-cloud-admin-staging.state
+```
+
+Create the DNS A record printed by the script before running the deploy step.
+
+## 3. Deploy App
+
+```sh
+set -a
+. deploy/linode/admin-staging.env
+. deploy/linode/rtk-cloud-admin-staging.state
+set +a
+
+deploy/linode/deploy-admin.sh
+```
+
+The deploy script:
+
+1. builds `rtk-cloud-admin:<release>` locally
+2. uploads a Docker image archive to the VM
+3. installs Docker, nginx, certbot, and systemd units
+4. writes `/etc/rtk_cloud_admin/admin.env`
+5. stores SQLite data under `/var/lib/rtk_cloud_admin`
+6. starts `rtk-cloud-admin.service`
+7. optionally obtains a Let's Encrypt certificate and redirects HTTP to HTTPS
+
+## 4. Verify
+
+```sh
+set -a
+. deploy/linode/admin-staging.env
+. deploy/linode/rtk-cloud-admin-staging.state
+set +a
+
+deploy/linode/verify-admin.sh
+```
+
+The verifier checks:
+
+- `/healthz`
+- `/api/service-health`
+- `/console`
+- platform break-glass login when bootstrap credentials are supplied
+
+Artifacts are written to `.artifacts/linode-admin-verify/` and are not tracked.
+
+## Backup
+
+```sh
+set -a
+. deploy/linode/admin-staging.env
+. deploy/linode/rtk-cloud-admin-staging.state
+set +a
+
+deploy/linode/backup-admin-db.sh
+```
+
+The backup script pulls `rtk-cloud-admin.db` and any SQLite WAL/SHM files into
+`.artifacts/linode-admin-backups/` with a SHA-256 checksum.
+
+## Security Notes
+
+- Remote hosts never push to GitHub.
+- Secrets are provided from the operator shell and copied only to
+  `/etc/rtk_cloud_admin/admin.env` on the VM.
+- The Admin VM does not join the Video Cloud VPC and must not call private
+  `10.42.x.x` service addresses.
+- `ADMIN_BREAK_GLASS_ENABLED=true` is acceptable for staging bootstrap. The
+  production direction remains Account Manager-backed SSO.

--- a/deploy/linode/admin-staging.env.example
+++ b/deploy/linode/admin-staging.env.example
@@ -1,0 +1,33 @@
+# Copy to a local ignored env file before deploying, for example:
+#   cp deploy/linode/admin-staging.env.example deploy/linode/admin-staging.env
+#   set -a; . deploy/linode/admin-staging.env; set +a
+# Do not commit real secrets.
+
+# Linode host and DNS.
+ADMIN_LINODE_LABEL=rtk-cloud-admin-staging
+ADMIN_LINODE_REGION=us-sea
+ADMIN_LINODE_TYPE=g6-standard-2
+ADMIN_LINODE_IMAGE=linode/ubuntu24.04
+ADMIN_LINODE_DOMAIN=admin.video-cloud-staging.realtekconnect.com
+ADMIN_LINODE_CERTBOT_EMAIL=admin@example.com
+ADMIN_LINODE_SSH_USER=root
+ADMIN_LINODE_SSH_KEY=$HOME/.ssh/id_ed25519_rtkcloud
+ADMIN_LINODE_PUBLIC_KEY_PATH=$HOME/.ssh/id_ed25519_rtkcloud.pub
+ADMIN_LINODE_ALLOWED_SSH_CIDRS=203.0.113.10/32
+
+# Deployment behavior.
+ADMIN_LINODE_RELEASE=staging-local
+ADMIN_LINODE_CERTBOT_ENABLE=1
+ADMIN_LINODE_HTTP_ONLY=0
+ADMIN_LINODE_REMOTE_IMAGE=/tmp/rtk-cloud-admin-image.tar.gz
+ADMIN_LINODE_DATA_DIR=/var/lib/rtk_cloud_admin
+ADMIN_LINODE_ENV_PATH=/etc/rtk_cloud_admin/admin.env
+
+# rtk_cloud_admin runtime configuration.
+ACCOUNT_MANAGER_BASE_URL=https://account-manager.example.invalid
+VIDEO_CLOUD_BASE_URL=https://video-cloud-staging.realtekconnect.com
+VIDEO_CLOUD_ADMIN_TOKEN=replace-me
+ADMIN_BOOTSTRAP_EMAIL=admin@example.com
+ADMIN_BOOTSTRAP_PASSWORD=change-me
+ADMIN_BREAK_GLASS_ENABLED=true
+LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED=false

--- a/deploy/linode/backup-admin-db.sh
+++ b/deploy/linode/backup-admin-db.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+admin_host="${ADMIN_LINODE_HOST:-${ADMIN_LINODE_PUBLIC_IPV4:-}}"
+ssh_user="${ADMIN_LINODE_SSH_USER:-root}"
+ssh_key="${ADMIN_LINODE_SSH_KEY:-$HOME/.ssh/id_ed25519_rtkcloud}"
+data_dir="${ADMIN_LINODE_DATA_DIR:-/var/lib/rtk_cloud_admin}"
+backup_dir="${ADMIN_LINODE_BACKUP_DIR:-.artifacts/linode-admin-backups}"
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+remote_archive="/tmp/rtk-cloud-admin-db-$stamp.tar.gz"
+local_archive="$backup_dir/rtk-cloud-admin-db-$stamp.tar.gz"
+
+[ -n "$admin_host" ] || { echo "ADMIN_LINODE_HOST or ADMIN_LINODE_PUBLIC_IPV4 is required" >&2; exit 1; }
+[ -s "$ssh_key" ] || { echo "SSH key not found: $ssh_key" >&2; exit 1; }
+mkdir -p "$backup_dir"
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+remote="$ssh_user@$admin_host"
+
+ssh "${ssh_opts[@]}" "$remote" "tar -C '$data_dir' -czf '$remote_archive' rtk-cloud-admin.db rtk-cloud-admin.db-wal rtk-cloud-admin.db-shm 2>/dev/null || tar -C '$data_dir' -czf '$remote_archive' rtk-cloud-admin.db"
+scp "${ssh_opts[@]}" "$remote:$remote_archive" "$local_archive"
+ssh "${ssh_opts[@]}" "$remote" "rm -f '$remote_archive'"
+sha256sum "$local_archive" > "$local_archive.sha256"
+printf 'Backup written: %s\n' "$local_archive"

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -110,6 +110,10 @@ systemctl enable --now docker
 
 mkdir -p /etc/rtk_cloud_admin "$data_dir" /etc/nginx/sites-available /etc/nginx/sites-enabled
 chmod 0750 /etc/rtk_cloud_admin
+# Dockerfile creates the runtime app user/group as the first system uid/gid.
+# The host bind mount must be writable by that non-root container user.
+chown 100:100 "$data_dir"
+chmod 0750 "$data_dir"
 mv /tmp/rtk-cloud-admin-deploy/admin.env "$env_path"
 chmod 0600 "$env_path"
 

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -35,15 +35,16 @@ need() {
   command -v "$1" >/dev/null 2>&1 || die "$1 is required"
 }
 
-quote_env() {
+write_env() {
   local key="$1"
   local value="${!key:-}"
   if printf '%s' "$value" | grep -q '[[:cntrl:]]'; then
     die "$key contains control characters"
   fi
-  value="${value//\\/\\\\}"
-  value="${value//"/\\"}"
-  printf '%s="%s"\n' "$key" "$value"
+  if printf '%s' "$value" | grep -q '[[:space:]]'; then
+    die "$key contains whitespace, which is not supported in Docker env files"
+  fi
+  printf '%s=%s\n' "$key" "$value"
 }
 
 need docker
@@ -75,11 +76,11 @@ trap cleanup EXIT
 {
   printf 'PORT=8080\n'
   printf 'DATABASE_PATH=/data/rtk-cloud-admin.db\n'
-  quote_env ACCOUNT_MANAGER_BASE_URL
-  quote_env VIDEO_CLOUD_BASE_URL
-  quote_env VIDEO_CLOUD_ADMIN_TOKEN
-  quote_env ADMIN_BOOTSTRAP_EMAIL
-  quote_env ADMIN_BOOTSTRAP_PASSWORD
+  write_env ACCOUNT_MANAGER_BASE_URL
+  write_env VIDEO_CLOUD_BASE_URL
+  write_env VIDEO_CLOUD_ADMIN_TOKEN
+  write_env ADMIN_BOOTSTRAP_EMAIL
+  write_env ADMIN_BOOTSTRAP_PASSWORD
   printf 'ADMIN_BREAK_GLASS_ENABLED=%s\n' "${ADMIN_BREAK_GLASS_ENABLED:-true}"
   printf 'LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED=%s\n' "${LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED:-false}"
 } > "$tmp_env"

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -106,7 +106,25 @@ http_only="$8"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y docker.io nginx certbot python3-certbot-nginx curl systemd ca-certificates
+apt-get install -y docker.io curl systemd ca-certificates gnupg2 lsb-release ubuntu-keyring
+curl -fsS https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg.tmp
+mv /usr/share/keyrings/nginx-archive-keyring.gpg.tmp /usr/share/keyrings/nginx-archive-keyring.gpg
+printf 'deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu %s nginx\n' "$(lsb_release -cs)" > /etc/apt/sources.list.d/nginx-org.list
+cat > /etc/apt/preferences.d/99nginx <<'PREF'
+Package: *
+Pin: origin nginx.org
+Pin-Priority: 900
+PREF
+apt-get update -y
+nginx_candidate="$(apt-cache policy nginx | awk '/Candidate:/ {print $2}')"
+dpkg --compare-versions "$nginx_candidate" ge 1.30.0
+apt-get install -y -o Dpkg::Options::=--force-confold nginx certbot python3-certbot-nginx
+if ! grep -q 'server_names_hash_bucket_size' /etc/nginx/nginx.conf; then
+  sed -i '/http {/a\    server_names_hash_bucket_size 128;' /etc/nginx/nginx.conf
+fi
+if [ -d /etc/nginx/sites-enabled ] && ! grep -q 'sites-enabled' /etc/nginx/nginx.conf && [ ! -f /etc/nginx/conf.d/rtk-sites-enabled.conf ]; then
+  printf 'include /etc/nginx/sites-enabled/*;\n' > /etc/nginx/conf.d/rtk-sites-enabled.conf
+fi
 systemctl enable --now docker
 
 mkdir -p /etc/rtk_cloud_admin "$data_dir" /etc/nginx/sites-available /etc/nginx/sites-enabled

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+label="${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}"
+release="${ADMIN_LINODE_RELEASE:-$(git -C "$root_dir" rev-parse --short HEAD)}"
+domain="${ADMIN_LINODE_DOMAIN:-}"
+certbot_email="${ADMIN_LINODE_CERTBOT_EMAIL:-}"
+ssh_user="${ADMIN_LINODE_SSH_USER:-root}"
+ssh_key="${ADMIN_LINODE_SSH_KEY:-$HOME/.ssh/id_ed25519_rtkcloud}"
+admin_host="${ADMIN_LINODE_HOST:-${ADMIN_LINODE_PUBLIC_IPV4:-}}"
+remote_image="${ADMIN_LINODE_REMOTE_IMAGE:-/tmp/rtk-cloud-admin-image.tar.gz}"
+data_dir="${ADMIN_LINODE_DATA_DIR:-/var/lib/rtk_cloud_admin}"
+env_path="${ADMIN_LINODE_ENV_PATH:-/etc/rtk_cloud_admin/admin.env}"
+certbot_enable="${ADMIN_LINODE_CERTBOT_ENABLE:-1}"
+http_only="${ADMIN_LINODE_HTTP_ONLY:-0}"
+image_tag="rtk-cloud-admin:${release}"
+artifact_dir="${ADMIN_LINODE_ARTIFACT_DIR:-$root_dir/.artifacts/linode-admin-deploy/$release}"
+image_archive="$artifact_dir/rtk-cloud-admin-${release}.tar.gz"
+
+required_runtime=(
+  ACCOUNT_MANAGER_BASE_URL
+  VIDEO_CLOUD_BASE_URL
+  VIDEO_CLOUD_ADMIN_TOKEN
+  ADMIN_BOOTSTRAP_EMAIL
+  ADMIN_BOOTSTRAP_PASSWORD
+)
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+quote_env() {
+  local key="$1"
+  local value="${!key:-}"
+  if printf '%s' "$value" | grep -q '[[:cntrl:]]'; then
+    die "$key contains control characters"
+  fi
+  value="${value//\\/\\\\}"
+  value="${value//"/\\"}"
+  printf '%s="%s"\n' "$key" "$value"
+}
+
+need docker
+need ssh
+need scp
+
+[ -n "$domain" ] || die "ADMIN_LINODE_DOMAIN is required"
+[ -n "$certbot_email" ] || [ "$certbot_enable" = "0" ] || die "ADMIN_LINODE_CERTBOT_EMAIL is required when certbot is enabled"
+[ -n "$admin_host" ] || die "ADMIN_LINODE_HOST or ADMIN_LINODE_PUBLIC_IPV4 is required"
+[ -s "$ssh_key" ] || die "SSH key not found: $ssh_key"
+for key in "${required_runtime[@]}"; do
+  [ -n "${!key:-}" ] || die "$key is required"
+done
+
+mkdir -p "$artifact_dir"
+
+printf '[admin-deploy] building Docker image %s\n' "$image_tag" >&2
+docker build -t "$image_tag" "$root_dir"
+
+printf '[admin-deploy] saving image archive %s\n' "$image_archive" >&2
+docker save "$image_tag" | gzip -c > "$image_archive"
+
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+remote="$ssh_user@$admin_host"
+
+tmp_env="$(mktemp)"
+cleanup() { rm -f "$tmp_env"; }
+trap cleanup EXIT
+{
+  printf 'PORT=8080\n'
+  printf 'DATABASE_PATH=/data/rtk-cloud-admin.db\n'
+  quote_env ACCOUNT_MANAGER_BASE_URL
+  quote_env VIDEO_CLOUD_BASE_URL
+  quote_env VIDEO_CLOUD_ADMIN_TOKEN
+  quote_env ADMIN_BOOTSTRAP_EMAIL
+  quote_env ADMIN_BOOTSTRAP_PASSWORD
+  printf 'ADMIN_BREAK_GLASS_ENABLED=%s\n' "${ADMIN_BREAK_GLASS_ENABLED:-true}"
+  printf 'LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED=%s\n' "${LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED:-false}"
+} > "$tmp_env"
+chmod 0600 "$tmp_env"
+
+printf '[admin-deploy] uploading image and env to %s\n' "$remote" >&2
+ssh "${ssh_opts[@]}" "$remote" "mkdir -p /tmp/rtk-cloud-admin-deploy"
+scp "${ssh_opts[@]}" "$image_archive" "$remote:$remote_image"
+scp "${ssh_opts[@]}" "$tmp_env" "$remote:/tmp/rtk-cloud-admin-deploy/admin.env"
+
+printf '[admin-deploy] installing runtime on %s\n' "$remote" >&2
+ssh "${ssh_opts[@]}" "$remote" bash -s -- "$domain" "$certbot_email" "$image_tag" "$remote_image" "$data_dir" "$env_path" "$certbot_enable" "$http_only" <<'REMOTE'
+set -euo pipefail
+
+domain="$1"
+certbot_email="$2"
+image_tag="$3"
+remote_image="$4"
+data_dir="$5"
+env_path="$6"
+certbot_enable="$7"
+http_only="$8"
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y docker.io nginx certbot python3-certbot-nginx curl systemd ca-certificates
+systemctl enable --now docker
+
+mkdir -p /etc/rtk_cloud_admin "$data_dir" /etc/nginx/sites-available /etc/nginx/sites-enabled
+chmod 0750 /etc/rtk_cloud_admin
+mv /tmp/rtk-cloud-admin-deploy/admin.env "$env_path"
+chmod 0600 "$env_path"
+
+cat > /etc/systemd/system/rtk-cloud-admin.service <<UNIT
+[Unit]
+Description=RTK Cloud Admin dashboard
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+
+[Service]
+Restart=always
+RestartSec=5
+TimeoutStartSec=120
+ExecStartPre=-/usr/bin/docker rm -f rtk-cloud-admin
+ExecStart=/usr/bin/docker run --rm --name rtk-cloud-admin --env-file $env_path -p 127.0.0.1:8080:8080 -v $data_dir:/data $image_tag
+ExecStop=/usr/bin/docker rm -f rtk-cloud-admin
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+cat > /etc/nginx/sites-available/rtk-cloud-admin.conf <<NGINX
+server {
+    listen 80;
+    server_name $domain;
+
+    client_max_body_size 10m;
+
+    location / {
+        proxy_pass http://127.0.0.1:8080;
+        proxy_http_version 1.1;
+        proxy_set_header Host \$host;
+        proxy_set_header X-Real-IP \$remote_addr;
+        proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto \$scheme;
+    }
+}
+NGINX
+ln -sf /etc/nginx/sites-available/rtk-cloud-admin.conf /etc/nginx/sites-enabled/rtk-cloud-admin.conf
+rm -f /etc/nginx/sites-enabled/default
+nginx -t
+systemctl reload nginx
+
+docker load -i "$remote_image"
+systemctl daemon-reload
+systemctl enable --now rtk-cloud-admin
+systemctl restart rtk-cloud-admin
+
+for _ in $(seq 1 30); do
+  if curl -fsS http://127.0.0.1:8080/healthz | grep -qx ok; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "${ready:-0}" != "1" ]; then
+  journalctl -u rtk-cloud-admin -n 120 --no-pager >&2 || true
+  exit 1
+fi
+
+if [ "$certbot_enable" = "1" ] && [ "$http_only" != "1" ]; then
+  certbot --nginx --non-interactive --agree-tos --email "$certbot_email" -d "$domain" --redirect
+fi
+
+systemctl is-active rtk-cloud-admin
+systemctl is-active nginx
+REMOTE
+
+printf '[admin-deploy] deployed %s to %s\n' "$image_tag" "$domain" >&2

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -61,7 +61,7 @@ done
 mkdir -p "$artifact_dir"
 
 printf '[admin-deploy] building Docker image %s\n' "$image_tag" >&2
-docker build -t "$image_tag" "$root_dir"
+docker build --platform linux/amd64 -t "$image_tag" "$root_dir"
 
 printf '[admin-deploy] saving image archive %s\n' "$image_archive" >&2
 docker save "$image_tag" | gzip -c > "$image_archive"

--- a/deploy/linode/provision-admin-vm.sh
+++ b/deploy/linode/provision-admin-vm.sh
@@ -44,7 +44,7 @@ create_json="$(linode-cli linodes create \
   --image "$image" \
   --authorized_keys "$ssh_key" \
   --root_pass "$root_pass" \
-  --tags rtk-cloud-admin-staging,managed-by:rtk-cloud-admin-deploy)"
+  --tags rtk-cloud-admin-staging,admin-deploy)"
 
 linode_id="$(printf '%s' "$create_json" | jq -r '.[0].id')"
 public_ipv4="$(printf '%s' "$create_json" | jq -r '.[0].ipv4[0]')"

--- a/deploy/linode/provision-admin-vm.sh
+++ b/deploy/linode/provision-admin-vm.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+label="${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}"
+region="${ADMIN_LINODE_REGION:-us-sea}"
+type="${ADMIN_LINODE_TYPE:-g6-standard-2}"
+image="${ADMIN_LINODE_IMAGE:-linode/ubuntu24.04}"
+public_key_path="${ADMIN_LINODE_PUBLIC_KEY_PATH:-$HOME/.ssh/id_ed25519_rtkcloud.pub}"
+allowed_ssh_cidrs="${ADMIN_LINODE_ALLOWED_SSH_CIDRS:-}"
+firewall_label="${ADMIN_LINODE_FIREWALL_LABEL:-${label}-firewall}"
+state_path="${ADMIN_LINODE_STATE_PATH:-deploy/linode/${label}.state}"
+
+die() {
+  printf 'error: %s\n' "$*" >&2
+  exit 1
+}
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+need linode-cli
+need jq
+need openssl
+
+test -s "$public_key_path" || die "public key not found: $public_key_path"
+if [ -z "$allowed_ssh_cidrs" ]; then
+  die "ADMIN_LINODE_ALLOWED_SSH_CIDRS must be set to operator CIDR(s)"
+fi
+
+if linode-cli linodes list --json --label "$label" | jq -e 'length > 0' >/dev/null; then
+  die "Linode label already exists: $label"
+fi
+
+root_pass="$(openssl rand -base64 36)"
+ssh_key="$(cat "$public_key_path")"
+
+printf '[admin-linode] creating public-only Linode %s in %s\n' "$label" "$region" >&2
+create_json="$(linode-cli linodes create \
+  --json \
+  --label "$label" \
+  --region "$region" \
+  --type "$type" \
+  --image "$image" \
+  --authorized_keys "$ssh_key" \
+  --root_pass "$root_pass" \
+  --tags rtk-cloud-admin-staging,managed-by:rtk-cloud-admin-deploy)"
+
+linode_id="$(printf '%s' "$create_json" | jq -r '.[0].id')"
+public_ipv4="$(printf '%s' "$create_json" | jq -r '.[0].ipv4[0]')"
+if [ -z "$linode_id" ] || [ "$linode_id" = "null" ] || [ -z "$public_ipv4" ] || [ "$public_ipv4" = "null" ]; then
+  die "failed to read Linode id/public IPv4 from linode-cli output"
+fi
+
+rules="$(jq -cn --arg cidrs "$allowed_ssh_cidrs" '{
+  inbound_policy: "DROP",
+  outbound_policy: "ACCEPT",
+  inbound: [
+    {label: "ssh", action: "ACCEPT", protocol: "TCP", ports: "22", ipv4: {addresses: ($cidrs | split(","))}},
+    {label: "http", action: "ACCEPT", protocol: "TCP", ports: "80", ipv4: {addresses: ["0.0.0.0/0"]}},
+    {label: "https", action: "ACCEPT", protocol: "TCP", ports: "443", ipv4: {addresses: ["0.0.0.0/0"]}}
+  ],
+  outbound: []
+}')"
+
+printf '[admin-linode] creating firewall %s\n' "$firewall_label" >&2
+firewall_json="$(linode-cli firewalls create --json --label "$firewall_label" --rules "$rules")"
+firewall_id="$(printf '%s' "$firewall_json" | jq -r '.[0].id')"
+if [ -z "$firewall_id" ] || [ "$firewall_id" = "null" ]; then
+  die "failed to read firewall id from linode-cli output"
+fi
+
+linode-cli firewalls device-create "$firewall_id" --id "$linode_id" --type linode >/dev/null
+
+mkdir -p "$(dirname "$state_path")"
+cat > "$state_path" <<STATE
+ADMIN_LINODE_ID=$linode_id
+ADMIN_LINODE_LABEL=$label
+ADMIN_LINODE_PUBLIC_IPV4=$public_ipv4
+ADMIN_LINODE_FIREWALL_ID=$firewall_id
+ADMIN_LINODE_FIREWALL_LABEL=$firewall_label
+STATE
+chmod 0600 "$state_path"
+
+cat <<EOF_OUT
+Linode created.
+
+State file: $state_path
+Public IPv4: $public_ipv4
+
+Create or update DNS before deploying:
+  ${ADMIN_LINODE_DOMAIN:-admin.video-cloud-staging.realtekconnect.com} A $public_ipv4
+EOF_OUT

--- a/deploy/linode/verify-admin.sh
+++ b/deploy/linode/verify-admin.sh
@@ -30,9 +30,9 @@ grep -q 'id="root"' "$artifacts_dir/console.html"
 record "PASS console shell"
 
 if [ -n "${ADMIN_BOOTSTRAP_EMAIL:-}" ] && [ -n "${ADMIN_BOOTSTRAP_PASSWORD:-}" ]; then
-  cookie_jar="$artifacts_dir/cookies.txt"
+  cookie_jar="$(mktemp)"
   login_body="$(mktemp)"
-  trap 'rm -f "$login_body"' EXIT
+  trap 'rm -f "$login_body" "$cookie_jar"' EXIT
   printf '{"email":"%s","password":"%s"}' "$ADMIN_BOOTSTRAP_EMAIL" "$ADMIN_BOOTSTRAP_PASSWORD" > "$login_body"
   curl -fsS -c "$cookie_jar" -H 'content-type: application/json' --data-binary "@$login_body" "$base_url/api/auth/platform/login" > "$artifacts_dir/login-response.json"
   rm -f "$login_body"

--- a/deploy/linode/verify-admin.sh
+++ b/deploy/linode/verify-admin.sh
@@ -31,7 +31,8 @@ record "PASS console shell"
 
 if [ -n "${ADMIN_BOOTSTRAP_EMAIL:-}" ] && [ -n "${ADMIN_BOOTSTRAP_PASSWORD:-}" ]; then
   cookie_jar="$artifacts_dir/cookies.txt"
-  login_body="$artifacts_dir/login.json"
+  login_body="$(mktemp)"
+  trap 'rm -f "$login_body"' EXIT
   printf '{"email":"%s","password":"%s"}' "$ADMIN_BOOTSTRAP_EMAIL" "$ADMIN_BOOTSTRAP_PASSWORD" > "$login_body"
   curl -fsS -c "$cookie_jar" -H 'content-type: application/json' --data-binary "@$login_body" "$base_url/api/auth/platform/login" > "$artifacts_dir/login-response.json"
   rm -f "$login_body"

--- a/deploy/linode/verify-admin.sh
+++ b/deploy/linode/verify-admin.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+base_url="${ADMIN_LINODE_BASE_URL:-}"
+if [ -z "$base_url" ]; then
+  domain="${ADMIN_LINODE_DOMAIN:-}"
+  [ -n "$domain" ] || { echo "ADMIN_LINODE_BASE_URL or ADMIN_LINODE_DOMAIN is required" >&2; exit 1; }
+  if [ "${ADMIN_LINODE_HTTP_ONLY:-0}" = "1" ]; then
+    base_url="http://$domain"
+  else
+    base_url="https://$domain"
+  fi
+fi
+
+artifacts_dir="${ADMIN_LINODE_VERIFY_ARTIFACTS:-.artifacts/linode-admin-verify}"
+mkdir -p "$artifacts_dir"
+
+record() {
+  printf '%s\n' "$1" | tee -a "$artifacts_dir/checks.txt" >/dev/null
+}
+
+curl -fsS "$base_url/healthz" | tee "$artifacts_dir/healthz.txt" | grep -qx ok
+record "PASS healthz"
+
+curl -fsS "$base_url/api/service-health" > "$artifacts_dir/service-health.json"
+record "PASS service-health"
+
+curl -fsS "$base_url/console" > "$artifacts_dir/console.html"
+grep -q 'id="root"' "$artifacts_dir/console.html"
+record "PASS console shell"
+
+if [ -n "${ADMIN_BOOTSTRAP_EMAIL:-}" ] && [ -n "${ADMIN_BOOTSTRAP_PASSWORD:-}" ]; then
+  cookie_jar="$artifacts_dir/cookies.txt"
+  login_body="$artifacts_dir/login.json"
+  printf '{"email":"%s","password":"%s"}' "$ADMIN_BOOTSTRAP_EMAIL" "$ADMIN_BOOTSTRAP_PASSWORD" > "$login_body"
+  curl -fsS -c "$cookie_jar" -H 'content-type: application/json' --data-binary "@$login_body" "$base_url/api/auth/platform/login" > "$artifacts_dir/login-response.json"
+  rm -f "$login_body"
+  grep -q '"status":"ok"' "$artifacts_dir/login-response.json"
+  curl -fsS -b "$cookie_jar" "$base_url/api/me" > "$artifacts_dir/me.json"
+  grep -q '"kind":"platform_admin"' "$artifacts_dir/me.json"
+  record "PASS platform login"
+else
+  record "SKIP platform login credentials not provided"
+fi
+
+printf 'Admin verify passed: %s\nArtifacts: %s\n' "$base_url" "$artifacts_dir"

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.6% |
+| Go total coverage | 80.7% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -27,8 +27,8 @@
 | Package | Coverage |
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 89.5% |
-| `rtk_cloud_admin/internal/app` | 80.4% |
+| `rtk_cloud_admin/internal/accountclient` | 88.8% |
+| `rtk_cloud_admin/internal/app` | 80.6% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -21,6 +21,37 @@ The app is not a stateless frontend. Local SQLite holds sessions, platform
 admins, audit metadata, settings, and upstream cache projections. Treat the
 database file as production state and back it up accordingly.
 
+## Linode Staging Profile
+
+The supported Linode staging shape is a dedicated public-only Admin VM, not a
+node inside the Video Cloud VPC. This keeps the dashboard deployment boundary
+separate from `rtk_video_cloud` and avoids relying on the Video Cloud edge VM as
+a shared gateway.
+
+Recommended staging traffic:
+
+```text
+internet
+  -> admin.video-cloud-staging.realtekconnect.com:443
+  -> nginx on the Admin VM
+  -> rtk_cloud_admin container on 127.0.0.1:8080
+
+rtk_cloud_admin
+  -> ACCOUNT_MANAGER_BASE_URL over public HTTPS
+  -> VIDEO_CLOUD_BASE_URL over public HTTPS
+```
+
+The operator-local scripts live under [`deploy/linode/`](../deploy/linode/):
+
+- `provision-admin-vm.sh` creates the public-only Linode VM and firewall.
+- `deploy-admin.sh` builds and uploads the Docker image, installs nginx, writes
+  the systemd unit, and starts the service.
+- `verify-admin.sh` checks the deployed HTTP surface.
+- `backup-admin-db.sh` pulls a timestamped SQLite backup.
+
+The copied `deploy/linode/*.env` and generated state files are local operator
+artifacts and must not be committed.
+
 ## Runtime Configuration
 
 Required or recommended environment variables:

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -382,7 +382,10 @@ func (c *Client) lifecycle(ctx context.Context, accessToken, orgID, deviceID, ac
 }
 
 func (c *Client) Health(ctx context.Context) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/healthz", nil)
+	if !c.Enabled() {
+		return fmt.Errorf("account manager base URL is not configured")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/health", nil)
 	if err != nil {
 		return err
 	}

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -507,7 +507,7 @@ func TestClientHealthAndHTTPErrorBody(t *testing.T) {
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
-		case "/healthz":
+		case "/v1/health":
 			_, _ = w.Write([]byte("ok"))
 		case "/v1/orgs/org-1/devices":
 			http.Error(w, "forbidden org", http.StatusForbidden)
@@ -553,7 +553,7 @@ func TestClientDisabledHealthAndDecodeErrors(t *testing.T) {
 		switch r.URL.Path {
 		case "/v1/auth/login":
 			_, _ = w.Write([]byte(`{`))
-		case "/healthz":
+		case "/v1/health":
 			http.Error(w, "down", http.StatusBadGateway)
 		case "/v1/me":
 			w.WriteHeader(http.StatusNoContent)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -826,6 +826,32 @@ func TestServiceHealthReportsVideoCloudOK(t *testing.T) {
 	}
 }
 
+func TestServiceHealthReportsAccountManagerOK(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/health" {
+			t.Fatalf("path = %q, want /v1/health", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Fatalf("Authorization = %q, want empty", got)
+		}
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer accountUpstream.Close()
+
+	srv := newSeededTestServer(t, config.Config{AccountManagerBaseURL: accountUpstream.URL})
+	health := requestJSON[[]contracts.ServiceHealth](t, srv, http.MethodGet, "/api/service-health", nil)
+
+	account := findServiceHealth(t, health, "Account Manager")
+	if account.Status != "ok" {
+		t.Fatalf("Account Manager status = %q, want ok; detail=%s", account.Status, account.Detail)
+	}
+	if account.LastCheckedAt == "" {
+		t.Fatal("Account Manager last_checked_at is empty")
+	}
+}
+
 func TestServiceHealthReportsVideoCloudDown(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add operator-local Linode deployment scripts for a dedicated public-only rtk_cloud_admin VM.
- Keep the Admin VM independent from the rtk_video_cloud VPC and edge gateway.
- Document the staging traffic shape, runtime env, verify checks, and SQLite backup flow.

## Added
- `deploy/linode/provision-admin-vm.sh`: creates the public-only Linode VM and firewall using `linode-cli`.
- `deploy/linode/deploy-admin.sh`: builds the Docker image, uploads it, installs Docker/nginx/certbot/systemd, writes the env file, and starts `rtk-cloud-admin.service`.
- `deploy/linode/verify-admin.sh`: checks health, service health, console shell, and optional platform login.
- `deploy/linode/backup-admin-db.sh`: pulls a timestamped SQLite backup.
- `deploy/linode/admin-staging.env.example` and deployment README.

## Validation
- `bash -n deploy/linode/*.sh`
- `git diff --check`
- `go test ./...`

## Notes
- This PR does not deploy live infrastructure.
- Local copied env/state files are ignored and must not be committed.
- Secrets remain operator-local and are only copied to `/etc/rtk_cloud_admin/admin.env` on the target VM.