### PR TITLE
Add authorization capabilities

### DIFF
--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -1,6 +1,6 @@
 # RTK Cloud Admin — Role Definitions
 
-Status: draft.
+Status: implementation-aligned draft.
 
 Author: Kevin Huang
 
@@ -28,7 +28,10 @@ Tier 1 — Realtek (platform owner / landlord)
 ```
 
 Each tier has distinct roles with different visibility and permission scopes
-within the admin console.
+within the admin console. Product authorization decisions are made from Account
+Manager-projected capabilities. Human-readable role names explain the operator
+persona, but route guards and enabled UI actions must use explicit
+capabilities.
 
 ### Tier Relationships
 
@@ -58,11 +61,12 @@ The remainder of this document covers only Tier 1 and Tier 2 roles.
 
 These roles belong to Realtek employees operating the platform. The long-term
 daily authentication path is Account Manager-backed SSO, where Account Manager
-authorizes the user as `platform_admin` and Admin Console creates the local
+authorizes platform capabilities and Admin Console creates the local
 `rtk_admin_session` cookie. The legacy `/admin` password login is retained only
 as controlled break-glass access when explicitly enabled by deployment
 configuration. Break-glass admins are bootstrapped by `ADMIN_BOOTSTRAP_EMAIL` /
-`ADMIN_BOOTSTRAP_PASSWORD`, stored in SQLite, and protected with bcrypt hashes.
+`ADMIN_BOOTSTRAP_PASSWORD`, stored in SQLite, protected with bcrypt hashes, and
+projected only to local emergency compatibility capabilities.
 
 ### Platform Admin
 
@@ -80,6 +84,13 @@ Tier 2 customers.
 **Can execute:**
 - Platform-side admin actions: customer session refresh and invalidation (existing in `internal/app/app.go`).
 - Tenant lifecycle actions (provisioning, deactivation, firmware campaign control on behalf of a tenant): not supported. Tenant-side write actions remain with Tier 2 Fleet Managers.
+
+**Current Admin Console capabilities:**
+- `platform.customers.read`
+- `platform.devices.read`
+- `platform.operations.read`
+- `platform.audit.read`
+- `platform.sso.manage`
 
 **Known gap:** There is no cross-tenant device-detail surface today. Operations
 Log shows lifecycle operation history and Audit Log shows actor/action/target
@@ -122,6 +133,13 @@ deactivation, health monitoring, OTA tracking, stream health.
 
 **Can execute:** Provision, Deactivate.
 
+**Current Admin Console capabilities:**
+- `customer.devices.read`
+- `customer.devices.provision`
+- `customer.devices.deactivate`
+- `customer.firmware.read`
+- `customer.stream.read`
+
 ---
 
 ### Read-only Observer
@@ -138,9 +156,15 @@ staff within a tenant org.
 
 **Cannot execute:** No provision, deactivate, or any write actions.
 
-**Current implementation:** Backend write handlers reject read-only customer
-roles for provision and deactivate. Any future tenant write action must use the
-same backend guard; frontend button hiding is only a usability affordance.
+**Current Admin Console capabilities:**
+- `customer.devices.read`
+- `customer.firmware.read`
+- `customer.stream.read`
+
+**Current implementation:** Backend write handlers require the relevant Account
+Manager-projected capability for provision and deactivate. Any future tenant
+write action must use the same backend guard; frontend button hiding is only a
+usability affordance.
 
 ---
 
@@ -151,6 +175,26 @@ same backend guard; frontend button hiding is only a usability affordance.
 | Platform Admin (T1) | — (impersonation deferred) | Full | Platform-side only (session control); no tenant lifecycle actions |
 | Fleet Manager (T2) | Full (own org) | — | Yes (provision, deactivate) |
 | Read-only Observer (T2) | Full read-only (own org) | — | No |
+
+---
+
+## Capability Projection Contract
+
+Admin Console accepts Account Manager organization projections with either
+`capabilities` or `permissions` arrays and normalizes both into the `/api/me`
+`capabilities` response. Each membership also carries its org-scoped
+`capabilities`. The top-level `/api/me.capabilities` list represents the active
+organization for customer sessions and platform compatibility capabilities for
+platform sessions.
+
+Capability checks are enforced in both layers:
+
+- BFF route guards reject missing write capabilities before calling upstream
+  lifecycle APIs.
+- UI actions use `/api/me.capabilities` or active membership capabilities to
+  enable or disable controls.
+- Local break-glass `platform_admin` remains an emergency deployment path; it
+  is not the product ACL source of truth.
 
 ---
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.7% |
+| Go total coverage | 80.8% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,7 +28,7 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 88.8% |
-| `rtk_cloud_admin/internal/app` | 80.6% |
+| `rtk_cloud_admin/internal/app` | 80.7% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -24,11 +24,13 @@ type User struct {
 }
 
 type Organization struct {
-	ID                    string `json:"id"`
-	Name                  string `json:"name"`
-	Role                  string `json:"role"`
-	Tier                  string `json:"tier,omitempty"`
-	EvaluationDeviceQuota int    `json:"evaluation_device_quota,omitempty"`
+	ID                    string   `json:"id"`
+	Name                  string   `json:"name"`
+	Role                  string   `json:"role"`
+	Tier                  string   `json:"tier,omitempty"`
+	EvaluationDeviceQuota int      `json:"evaluation_device_quota,omitempty"`
+	Capabilities          []string `json:"capabilities,omitempty"`
+	Permissions           []string `json:"permissions,omitempty"`
 }
 
 type Device struct {

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -21,7 +21,7 @@ func TestClientLoginAndMe(t *testing.T) {
 				t.Fatalf("Authorization = %q", got)
 			}
 			w.WriteHeader(http.StatusOK)
-			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-1","name":"Acme","role":"owner","tier":"evaluation","evaluation_device_quota":5}]}`))
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"user@example.com","name":"User"},"organizations":[{"id":"org-1","name":"Acme","role":"fleet_manager","tier":"evaluation","evaluation_device_quota":5,"capabilities":["customer.devices.read","customer.devices.provision"],"permissions":["customer.devices.deactivate"]}]}`))
 		default:
 			http.NotFound(w, r)
 		}
@@ -45,6 +45,12 @@ func TestClientLoginAndMe(t *testing.T) {
 	}
 	if me.Organizations[0].Tier != "evaluation" || me.Organizations[0].EvaluationDeviceQuota != 5 {
 		t.Fatalf("organization metadata = %#v", me.Organizations[0])
+	}
+	if got := strings.Join(me.Organizations[0].Capabilities, ","); got != "customer.devices.read,customer.devices.provision" {
+		t.Fatalf("organization capabilities = %q", got)
+	}
+	if got := strings.Join(me.Organizations[0].Permissions, ","); got != "customer.devices.deactivate" {
+		t.Fatalf("organization permissions = %q", got)
 	}
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -142,6 +142,16 @@ const (
 	streamModeWebRTC = "webrtc"
 )
 
+const (
+	capabilityCustomerDevicesRead       = "customer.devices.read"
+	capabilityCustomerDevicesProvision  = "customer.devices.provision"
+	capabilityCustomerDevicesDeactivate = "customer.devices.deactivate"
+	capabilityCustomerFirmwareRead      = "customer.firmware.read"
+	capabilityCustomerStreamRead        = "customer.stream.read"
+	capabilityPlatformAuditRead         = "platform.audit.read"
+	capabilityPlatformSSOManage         = "platform.sso.manage"
+)
+
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	_, _ = w.Write([]byte("ok\n"))
@@ -256,10 +266,11 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 			DemoMode:      !s.accountClient.Enabled(),
 			Authenticated: false,
 			Memberships: []contracts.Membership{
-				{OrganizationID: "org-acme", Organization: "Acme Smart Camera", Role: "owner", Tier: "evaluation", EvaluationDeviceQuota: 5},
-				{OrganizationID: "org-nova", Organization: "Nova Home Labs", Role: "operator", Tier: "commercial"},
+				{OrganizationID: "org-acme", Organization: "Acme Smart Camera", Role: "owner", Tier: "evaluation", EvaluationDeviceQuota: 5, Capabilities: fleetManagerCapabilities()},
+				{OrganizationID: "org-nova", Organization: "Nova Home Labs", Role: "operator", Tier: "commercial", Capabilities: fleetManagerCapabilities()},
 			},
 		})
+		me.Capabilities = aggregateMembershipCapabilities(me.Memberships, me.ActiveOrgID)
 		writeJSON(w, me)
 		return
 	}
@@ -271,6 +282,7 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 			Kind:          session.Kind,
 			Memberships:   []contracts.Membership{},
 			Authenticated: true,
+			Capabilities:  platformAdminCompatibilityCapabilities(),
 		}))
 		return
 	}
@@ -305,6 +317,7 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		for _, org := range upstream.Organizations {
 			me.Memberships = append(me.Memberships, membershipFromOrganization(org))
 		}
+		me.Capabilities = aggregateMembershipCapabilities(me.Memberships, me.ActiveOrgID)
 	} else {
 		memberships, err := s.demoMemberships()
 		if err != nil {
@@ -315,6 +328,7 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		if me.ActiveOrgID == "" && len(memberships) > 0 {
 			me.ActiveOrgID = memberships[0].OrganizationID
 		}
+		me.Capabilities = aggregateMembershipCapabilities(me.Memberships, me.ActiveOrgID)
 	}
 	writeJSON(w, me)
 }
@@ -2937,6 +2951,15 @@ func organizationRole(orgs []accountclient.Organization, orgID string) (string, 
 	return "", false
 }
 
+func organizationByID(orgs []accountclient.Organization, orgID string) (accountclient.Organization, bool) {
+	for _, org := range orgs {
+		if org.ID == orgID {
+			return org, true
+		}
+	}
+	return accountclient.Organization{}, false
+}
+
 func isReadOnlyCustomerRole(role string) bool {
 	normalized := strings.NewReplacer("-", "_", " ", "_").Replace(strings.ToLower(strings.TrimSpace(role)))
 	switch normalized {
@@ -2945,6 +2968,81 @@ func isReadOnlyCustomerRole(role string) bool {
 	default:
 		return false
 	}
+}
+
+func fleetManagerCapabilities() []string {
+	return []string{
+		capabilityCustomerDevicesRead,
+		capabilityCustomerDevicesProvision,
+		capabilityCustomerDevicesDeactivate,
+		capabilityCustomerFirmwareRead,
+		capabilityCustomerStreamRead,
+	}
+}
+
+func platformAdminCompatibilityCapabilities() []string {
+	return []string{
+		"platform.customers.read",
+		"platform.devices.read",
+		"platform.operations.read",
+		capabilityPlatformAuditRead,
+		capabilityPlatformSSOManage,
+	}
+}
+
+func capabilitiesForOrganization(org accountclient.Organization) []string {
+	caps := normalizeCapabilities(append(append([]string{}, org.Capabilities...), org.Permissions...))
+	if len(caps) > 0 {
+		return caps
+	}
+	if isReadOnlyCustomerRole(org.Role) {
+		return []string{
+			capabilityCustomerDevicesRead,
+			capabilityCustomerFirmwareRead,
+			capabilityCustomerStreamRead,
+		}
+	}
+	return fleetManagerCapabilities()
+}
+
+func normalizeCapabilities(values []string) []string {
+	seen := make(map[string]bool)
+	var out []string
+	for _, value := range values {
+		capability := strings.TrimSpace(value)
+		if capability == "" || seen[capability] {
+			continue
+		}
+		seen[capability] = true
+		out = append(out, capability)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func aggregateMembershipCapabilities(memberships []contracts.Membership, activeOrgID string) []string {
+	var values []string
+	for _, membership := range memberships {
+		if activeOrgID != "" && membership.OrganizationID != activeOrgID {
+			continue
+		}
+		values = append(values, membership.Capabilities...)
+	}
+	if len(values) == 0 && activeOrgID == "" {
+		for _, membership := range memberships {
+			values = append(values, membership.Capabilities...)
+		}
+	}
+	return normalizeCapabilities(values)
+}
+
+func hasCapability(capabilities []string, required string) bool {
+	for _, capability := range capabilities {
+		if capability == required {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) demoMemberships() ([]contracts.Membership, error) {
@@ -2959,6 +3057,7 @@ func (s *Server) demoMemberships() ([]contracts.Membership, error) {
 			Organization:   customer.Organization,
 			Role:           "operator",
 			Tier:           "commercial",
+			Capabilities:   fleetManagerCapabilities(),
 		}
 		if customer.OrganizationID == "org-acme" {
 			membership.Role = "owner"
@@ -3153,12 +3252,17 @@ func (s *Server) tryUpstreamLifecycle(w http.ResponseWriter, r *http.Request, ac
 	if tokens.AccessToken != session.AccessToken || tokens.RefreshToken != session.RefreshToken {
 		_ = s.store.UpdateSessionTokens(session.ID, tokens.AccessToken, tokens.RefreshToken, tokenTTL(tokens))
 	}
-	if role, ok := organizationRole(orgs, session.ActiveOrgID); ok && isReadOnlyCustomerRole(role) {
-		http.Error(w, "read-only customer role cannot perform lifecycle actions", http.StatusForbidden)
+	org, ok := organizationByID(orgs, session.ActiveOrgID)
+	if !ok {
+		http.Error(w, "active organization is not part of the current customer memberships", http.StatusForbidden)
 		return true
 	}
-	if !organizationAllowed(orgs, session.ActiveOrgID) {
-		http.Error(w, "active organization is not part of the current customer memberships", http.StatusForbidden)
+	requiredCapability := capabilityCustomerDevicesProvision
+	if action == "deactivate" {
+		requiredCapability = capabilityCustomerDevicesDeactivate
+	}
+	if !hasCapability(capabilitiesForOrganization(org), requiredCapability) {
+		http.Error(w, "missing required capability: "+requiredCapability, http.StatusForbidden)
 		return true
 	}
 	deviceID := r.PathValue("id")
@@ -3328,6 +3432,7 @@ func membershipFromOrganization(org accountclient.Organization) contracts.Member
 		Role:                  org.Role,
 		Tier:                  org.Tier,
 		EvaluationDeviceQuota: org.EvaluationDeviceQuota,
+		Capabilities:          capabilitiesForOrganization(org),
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3579,6 +3579,106 @@ func TestMeContractStabilizesMembershipShape(t *testing.T) {
 	}
 }
 
+func TestCustomerMeProjectsAccountManagerCapabilities(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/me" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer access" {
+			t.Fatalf("Authorization = %q, want Bearer access", got)
+		}
+		_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"manager@example.com","name":"Manager"},"organizations":[{"id":"org-up","name":"Upstream Org","role":"fleet_manager","tier":"commercial","capabilities":["customer.devices.read","customer.devices.provision"],"permissions":["customer.devices.deactivate"]}]}`))
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	session, err := st.CreateSession("customer", "u1", "manager@example.com", "access", "refresh", "org-up", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/api/me status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Capabilities []string `json:"capabilities"`
+		Memberships  []struct {
+			OrganizationID string   `json:"organization_id"`
+			Capabilities   []string `json:"capabilities"`
+		} `json:"memberships"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /api/me: %v", err)
+	}
+	if strings.Join(body.Capabilities, ",") != "customer.devices.deactivate,customer.devices.provision,customer.devices.read" {
+		t.Fatalf("top-level capabilities = %#v", body.Capabilities)
+	}
+	if len(body.Memberships) != 1 || body.Memberships[0].OrganizationID != "org-up" {
+		t.Fatalf("memberships = %#v", body.Memberships)
+	}
+	if strings.Join(body.Memberships[0].Capabilities, ",") != "customer.devices.deactivate,customer.devices.provision,customer.devices.read" {
+		t.Fatalf("membership capabilities = %#v", body.Memberships[0].Capabilities)
+	}
+}
+
+func TestPlatformAdminMeProjectsBreakGlassCompatibilityCapabilities(t *testing.T) {
+	t.Parallel()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{Config: config.Config{AdminBreakGlassEnabled: true}})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/me", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("/api/me status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var body struct {
+		Kind              string   `json:"kind"`
+		Capabilities      []string `json:"capabilities"`
+		BreakGlassEnabled bool     `json:"break_glass_enabled"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&body); err != nil {
+		t.Fatalf("decode /api/me: %v", err)
+	}
+	if body.Kind != "platform_admin" || !body.BreakGlassEnabled {
+		t.Fatalf("platform me = %#v", body)
+	}
+	if !containsString(body.Capabilities, "platform.audit.read") || !containsString(body.Capabilities, "platform.sso.manage") {
+		t.Fatalf("platform capabilities = %#v", body.Capabilities)
+	}
+}
+
 func TestActiveOrgAndQuotaContractsRejectInvalidOrganizations(t *testing.T) {
 	t.Parallel()
 
@@ -3835,6 +3935,58 @@ func TestCustomerReadOnlyObserverLifecycleReturns403(t *testing.T) {
 	}
 	if upstreamProvisionCalls != 0 {
 		t.Fatalf("read-only lifecycle should not call upstream, got %d calls", upstreamProvisionCalls)
+	}
+}
+
+func TestCustomerLifecycleRequiresAccountManagerCapability(t *testing.T) {
+	t.Parallel()
+
+	upstreamProvisionCalls := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/orgs":
+			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-up","name":"Upstream Org","role":"fleet_manager","capabilities":["customer.devices.read"]}]}`))
+		case "/v1/orgs/org-up/devices/dev-002/provision":
+			upstreamProvisionCalls++
+			_, _ = w.Write([]byte(`{"operation":{"id":"op-up","state":"published","message":"accepted"}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+	session, err := st.CreateSession("customer", "u1", "manager@example.com", "access", "refresh", "org-up", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/devices/dev-002/provision", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("provision status = %d, want %d; body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "customer.devices.provision") {
+		t.Fatalf("forbidden body should name missing capability: %s", rec.Body.String())
+	}
+	if upstreamProvisionCalls != 0 {
+		t.Fatalf("blocked lifecycle should not call upstream, got %d calls", upstreamProvisionCalls)
 	}
 }
 

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -124,11 +124,12 @@ type ServiceHealth struct {
 }
 
 type Membership struct {
-	OrganizationID        string `json:"organization_id"`
-	Organization          string `json:"organization"`
-	Role                  string `json:"role"`
-	Tier                  string `json:"tier,omitempty"`
-	EvaluationDeviceQuota int    `json:"evaluation_device_quota,omitempty"`
+	OrganizationID        string   `json:"organization_id"`
+	Organization          string   `json:"organization"`
+	Role                  string   `json:"role"`
+	Tier                  string   `json:"tier,omitempty"`
+	EvaluationDeviceQuota int      `json:"evaluation_device_quota,omitempty"`
+	Capabilities          []string `json:"capabilities,omitempty"`
 }
 
 type Me struct {
@@ -140,6 +141,7 @@ type Me struct {
 	ActiveOrgID                        string       `json:"active_org_id"`
 	DemoMode                           bool         `json:"demo_mode"`
 	Authenticated                      bool         `json:"authenticated"`
+	Capabilities                       []string     `json:"capabilities,omitempty"`
 	BreakGlassEnabled                  bool         `json:"break_glass_enabled"`
 	LegacyCustomerPasswordLoginEnabled bool         `json:"legacy_customer_password_login_enabled"`
 }

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -15,12 +15,14 @@ const customerMe = {
   kind: 'customer',
   email: 'fleet.manager@example.com',
   active_org_id: 'org-acme',
+  capabilities: ['customer.devices.read', 'customer.devices.provision', 'customer.devices.deactivate', 'customer.firmware.read', 'customer.stream.read'],
   memberships: [{
     organization_id: 'org-acme',
     organization: 'Acme Smart Camera',
     role: 'fleet_manager',
     tier: 'evaluation',
     evaluation_device_quota: 5,
+    capabilities: ['customer.devices.read', 'customer.devices.provision', 'customer.devices.deactivate', 'customer.firmware.read', 'customer.stream.read'],
   }],
 };
 
@@ -28,6 +30,7 @@ const platformMe = {
   authenticated: true,
   kind: 'platform_admin',
   email: 'platform.admin@example.com',
+  capabilities: ['platform.audit.read', 'platform.sso.manage'],
   break_glass_enabled: true,
 };
 

--- a/web/src/device-actions.mjs
+++ b/web/src/device-actions.mjs
@@ -3,8 +3,24 @@ export function isReadOnlyRole(role) {
   return ['viewer', 'observer', 'read_only', 'readonly', 'read_only_observer'].includes(normalized);
 }
 
-export function deviceActionState(device, action, { readOnly = false, telemetryStatus = '' } = {}) {
+export function canUseCapability(subject, capability) {
+  const values = [
+    ...(Array.isArray(subject?.capabilities) ? subject.capabilities : []),
+    ...(Array.isArray(subject?.permissions) ? subject.permissions : []),
+    ...(Array.isArray(subject?.memberships) ? subject.memberships.flatMap((membership) => membership?.capabilities || []) : []),
+  ];
+  return values.includes(capability);
+}
+
+function requiredLifecycleCapability(action) {
+  return action === 'deactivate' ? 'customer.devices.deactivate' : 'customer.devices.provision';
+}
+
+export function deviceActionState(device, action, { readOnly = false, telemetryStatus = '', capabilities } = {}) {
   if (!device) return { enabled: false, reason: 'No device selected.' };
+  if (Array.isArray(capabilities) && !capabilities.includes(requiredLifecycleCapability(action))) {
+    return { enabled: false, reason: 'Your session does not have permission for this lifecycle action.' };
+  }
   if (readOnly) {
     return { enabled: false, reason: 'Read-only Observer cannot change device lifecycle.' };
   }

--- a/web/src/device-actions.test.mjs
+++ b/web/src/device-actions.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { deviceActionState, isReadOnlyRole } from './device-actions.mjs';
+import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
 
 test('isReadOnlyRole recognizes observer-style customer roles', () => {
   assert.equal(isReadOnlyRole('viewer'), true);
@@ -13,6 +13,18 @@ test('deviceActionState disables writes for read-only observers', () => {
   const state = deviceActionState({ readiness: 'registered' }, 'provision', { readOnly: true });
   assert.equal(state.enabled, false);
   assert.match(state.reason, /Read-only Observer/);
+});
+
+test('deviceActionState uses explicit capabilities for lifecycle writes', () => {
+  assert.equal(canUseCapability({ capabilities: ['customer.devices.provision'] }, 'customer.devices.provision'), true);
+  assert.equal(canUseCapability({ memberships: [{ capabilities: ['customer.devices.deactivate'] }] }, 'customer.devices.deactivate'), true);
+
+  const blocked = deviceActionState({ readiness: 'registered' }, 'provision', { capabilities: ['customer.devices.read'] });
+  assert.equal(blocked.enabled, false);
+  assert.match(blocked.reason, /permission/);
+
+  const allowed = deviceActionState({ readiness: 'registered' }, 'provision', { capabilities: ['customer.devices.provision'] });
+  assert.equal(allowed.enabled, true);
 });
 
 test('deviceActionState disables actions when telemetry source is unavailable', () => {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { customerNavItems, devicesPathWithFilters, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
 import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 import { quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
-import { deviceActionState, isReadOnlyRole } from './device-actions.mjs';
+import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
 import { firmwareCampaignDetailRows, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
 import { sourceAvailable, sourceMessage } from './source-state.mjs';
 import { streamWorstDeviceRows } from './stream.mjs';
@@ -1969,7 +1969,9 @@ function Devices({ active, devices, selectedDevice, deviceDrawerOpen, me, setSel
 
   const selectedTelemetry = selectedDevice ? telemetryById[selectedDevice.id] || null : null;
   const telemetryBusy = deviceDrawerOpen && selectedDevice?.id && telemetryLoadingId === selectedDevice.id && !selectedTelemetry;
-  const readOnly = isReadOnlyRole(getActiveMembership(me)?.role);
+  const activeMembership = getActiveMembership(me);
+  const capabilitySubject = { capabilities: me?.capabilities || activeMembership?.capabilities || [] };
+  const readOnly = !canUseCapability(capabilitySubject, 'customer.devices.provision') && !canUseCapability(capabilitySubject, 'customer.devices.deactivate') && isReadOnlyRole(activeMembership?.role);
 
   function updateFilter(next = {}) {
     const nextReadiness = next.readiness ?? readinessFilter;
@@ -2078,6 +2080,7 @@ function Devices({ active, devices, selectedDevice, deviceDrawerOpen, me, setSel
           loading={telemetryBusy}
           error={telemetryError}
           readOnly={readOnly}
+          capabilities={capabilitySubject.capabilities}
           onClose={closeDeviceDrawer}
           onAction={onAction}
         />
@@ -2133,7 +2136,7 @@ function Customers({ customers }) {
   );
 }
 
-function DeviceDrawer({ device, telemetry, loading, error, readOnly, onClose, onAction }) {
+function DeviceDrawer({ device, telemetry, loading, error, readOnly, capabilities, onClose, onAction }) {
   const drawerName = telemetry?.device_name || device?.name || 'Device selected';
   const drawerOrganization = telemetry?.organization || device?.organization || '—';
   const drawerModel = telemetry?.model || device?.model || '—';
@@ -2143,7 +2146,7 @@ function DeviceDrawer({ device, telemetry, loading, error, readOnly, onClose, on
   const telemetryAvailable = telemetry?.telemetry_status === 'available';
   const telemetryUnavailableText = telemetry?.unavailable_reason || error || 'Telemetry source is unavailable for this device.';
   const streamStatus = deriveStreamStatus(telemetry);
-  const actionContext = { readOnly, telemetryStatus: telemetry?.telemetry_status };
+  const actionContext = { readOnly, capabilities, telemetryStatus: telemetry?.telemetry_status };
   const provisionState = deviceActionState(device, 'provision', actionContext);
   const deactivateState = deviceActionState(device, 'deactivate', actionContext);
   function runDrawerAction(action) {


### PR DESCRIPTION
## Summary
- consume Account Manager `capabilities` / `permissions` projections in Admin BFF membership and `/api/me` responses
- enforce customer lifecycle writes with explicit device capabilities before calling upstream Account Manager APIs
- update device action UI guards, browser smoke fixtures, and role documentation for capability-based authorization

## Validation
- `go test ./internal/accountclient ./internal/app`
- `npm test` in `web/`
- `git diff --check`
- `go test ./...`
- `npm run build` in `web/`
- `node web/scripts/browser-smoke.mjs`

Closes #117
Closes #118
