### PR TITLE
[codex] Add Linode release artifact workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release Bundle
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Release version. Defaults to the git ref name or short SHA."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Package release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Select version
+        id: version
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [ -n "${INPUT_VERSION:-}" ]; then
+            version="$INPUT_VERSION"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            version="$GITHUB_REF_NAME"
+          else
+            version="${GITHUB_SHA::12}"
+          fi
+          case "$version" in
+            *[!A-Za-z0-9._-]* | "" | .* | *..*)
+              echo "invalid version: use only letters, digits, dot, underscore, and dash" >&2
+              exit 1
+              ;;
+          esac
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build release bundle
+        run: VERSION="${{ steps.version.outputs.version }}" deploy/package-release.sh
+
+      - name: Verify release bundle
+        run: deploy/check-release.sh "dist/rtk_cloud_admin-${{ steps.version.outputs.version }}.tar.gz"
+
+      - name: Upload release bundle to Linode Object Storage
+        shell: bash
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.LINODE_OBJ_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: us-sea
+          AWS_EC2_METADATA_DISABLED: "true"
+          LINODE_OBJ_BUCKET: ${{ vars.LINODE_OBJ_BUCKET }}
+          LINODE_OBJ_ENDPOINT: ${{ vars.LINODE_OBJ_ENDPOINT }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          if ! command -v aws >/dev/null 2>&1; then
+            python3 -m pip install --user awscli
+            export PATH="$HOME/.local/bin:$PATH"
+          fi
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          test -n "$LINODE_OBJ_BUCKET"
+          test -n "$LINODE_OBJ_ENDPOINT"
+
+          bundle="dist/rtk_cloud_admin-$VERSION.tar.gz"
+          checksum="$bundle.sha256"
+          manifest="dist/rtk_cloud_admin-$VERSION.object-manifest.json"
+          prefix="s3://$LINODE_OBJ_BUCKET/releases/$VERSION"
+
+          aws s3 cp "$bundle" "$prefix/rtk_cloud_admin-$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$checksum" "$prefix/rtk_cloud_admin-$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$manifest" "$prefix/manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: rtk_cloud_admin-${{ steps.version.outputs.version }}
+          path: |
+            dist/rtk_cloud_admin-${{ steps.version.outputs.version }}.tar.gz
+            dist/rtk_cloud_admin-${{ steps.version.outputs.version }}.tar.gz.sha256
+            dist/rtk_cloud_admin-${{ steps.version.outputs.version }}.object-manifest.json
+          if-no-files-found: error
+
+      - name: Publish GitHub release
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          assets=(
+            "dist/rtk_cloud_admin-$version.tar.gz"
+            "dist/rtk_cloud_admin-$version.tar.gz.sha256"
+            "dist/rtk_cloud_admin-$version.object-manifest.json"
+          )
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" "${assets[@]}" --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" "${assets[@]}" --generate-notes --title "$GITHUB_REF_NAME"
+          fi

--- a/README.md
+++ b/README.md
@@ -206,11 +206,29 @@ For a production private-cloud deployment, see
 [`docs/private-cloud-deployment.md`](docs/private-cloud-deployment.md). For the
 Linode staging scripts, see [`deploy/linode/`](deploy/linode/).
 
+## Release Artifacts
+
+Release artifacts are Docker image archives produced by
+`deploy/package-release.sh` and verified by `deploy/check-release.sh`:
+
+```sh
+VERSION=v1.2.3 deploy/package-release.sh
+deploy/check-release.sh dist/rtk_cloud_admin-v1.2.3.tar.gz
+```
+
+The release workflow uploads the bundle, checksum, and manifest to Linode Object
+Storage under `releases/<version>/`. Object Storage credentials belong in
+GitHub repository secrets and variables, not local `.env` files.
+
 ## CI
 
 `.github/workflows/ci.yml` checks out submodules and runs `go test ./...`,
 `go build ./cmd/server`, `npm ci`, `npm run build`, a container smoke test, and
 Docker cache cleanup on the self-hosted `rtk-cloud-admin-ci` runner.
+
+`.github/workflows/release.yml` runs only for `v*` tags or manual dispatch. It
+builds a release bundle and publishes it to Linode Object Storage; normal PR and
+main CI do not upload release artifacts.
 
 Runner health and recovery notes live in [`docs/ci-runner.md`](docs/ci-runner.md).
 

--- a/deploy/check-release.sh
+++ b/deploy/check-release.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <release-bundle-or-stem>" >&2
+  exit 1
+fi
+
+input="$1"
+bundle="$input"
+if [ ! -f "$bundle" ] && [ -f "$input.tar.gz" ]; then
+  bundle="$input.tar.gz"
+fi
+
+case "$(basename "$bundle")" in
+  rtk_cloud_admin-*.tar.gz)
+    version="$(basename "$bundle")"
+    version="${version#rtk_cloud_admin-}"
+    version="${version%.tar.gz}"
+    ;;
+  *)
+    echo "release bundle must be named rtk_cloud_admin-<version>.tar.gz" >&2
+    exit 1
+    ;;
+esac
+
+checksum="$bundle.sha256"
+manifest="${bundle%.tar.gz}.object-manifest.json"
+
+require_file() {
+  if [ ! -s "$1" ]; then
+    echo "missing or empty required file: $1" >&2
+    exit 1
+  fi
+}
+
+require_file "$bundle"
+require_file "$checksum"
+require_file "$manifest"
+
+if command -v shasum >/dev/null 2>&1; then
+  actual="$(shasum -a 256 "$bundle" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+  actual="$(sha256sum "$bundle" | awk '{print $1}')"
+else
+  echo "shasum or sha256sum is required" >&2
+  exit 1
+fi
+expected="$(awk '{print $1}' "$checksum")"
+if [ "$actual" != "$expected" ]; then
+  echo "checksum mismatch for $bundle" >&2
+  exit 1
+fi
+
+python3 - "$manifest" "$version" "$expected" <<'PY'
+import json
+import sys
+
+manifest_path, version, expected_sha = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(manifest_path, "r", encoding="utf-8") as handle:
+    manifest = json.load(handle)
+
+required = ["version", "source_commit", "bundle", "artifact_path", "sha256", "created_at"]
+missing = [field for field in required if not manifest.get(field)]
+if missing:
+    raise SystemExit(f"manifest missing fields: {', '.join(missing)}")
+
+bundle = f"rtk_cloud_admin-{version}.tar.gz"
+if manifest["version"] != version:
+    raise SystemExit("manifest version mismatch")
+if manifest["bundle"] != bundle:
+    raise SystemExit("manifest bundle mismatch")
+if manifest["artifact_path"] != f"releases/{version}/{bundle}":
+    raise SystemExit("manifest artifact_path mismatch")
+if manifest["sha256"] != expected_sha:
+    raise SystemExit("manifest sha256 mismatch")
+if not manifest["created_at"].endswith("Z"):
+    raise SystemExit("manifest created_at must be UTC Z")
+PY
+
+gzip -t "$bundle"
+"$DOCKER_BIN" load -i "$bundle" >/dev/null
+"$DOCKER_BIN" image inspect "rtk-cloud-admin:$version" >/dev/null
+
+echo "release bundle verification passed: $bundle"

--- a/deploy/linode/README.md
+++ b/deploy/linode/README.md
@@ -34,7 +34,7 @@ mutation and host deployment with local secrets.
 | --- | --- |
 | `admin-staging.env.example` | Local operator env template. Copy it before editing. |
 | `provision-admin-vm.sh` | Creates the public-only Linode VM and firewall with `linode-cli`. |
-| `deploy-admin.sh` | Builds the Docker image locally, uploads it, installs nginx/systemd, and starts the service. |
+| `deploy-admin.sh` | Builds the Docker image locally or uses `ADMIN_LINODE_RELEASE_BUNDLE`, uploads it, installs nginx/systemd, and starts the service. |
 | `verify-admin.sh` | Runs external HTTP checks against the deployed dashboard. |
 | `backup-admin-db.sh` | Pulls a sanitized SQLite backup archive from the Admin VM. |
 
@@ -96,13 +96,24 @@ deploy/linode/deploy-admin.sh
 
 The deploy script:
 
-1. builds `rtk-cloud-admin:<release>` locally
+1. builds `rtk-cloud-admin:<release>` locally, unless `ADMIN_LINODE_RELEASE_BUNDLE` points at a prebuilt release archive
 2. uploads a Docker image archive to the VM
 3. installs Docker, nginx, certbot, and systemd units
 4. writes `/etc/rtk_cloud_admin/admin.env`
 5. stores SQLite data under `/var/lib/rtk_cloud_admin`
 6. starts `rtk-cloud-admin.service`
 7. optionally obtains a Let's Encrypt certificate and redirects HTTP to HTTPS
+
+To deploy a CI-built release artifact instead of building locally:
+
+```sh
+ADMIN_LINODE_RELEASE=v1.2.3 \
+ADMIN_LINODE_RELEASE_BUNDLE="$PWD/dist/rtk_cloud_admin-v1.2.3.tar.gz" \
+deploy/linode/deploy-admin.sh
+```
+
+The release bundle must be named `rtk_cloud_admin-<version>.tar.gz` and contain
+the Docker image tag `rtk-cloud-admin:<version>`.
 
 ## 4. Verify
 

--- a/deploy/linode/admin-staging.env.example
+++ b/deploy/linode/admin-staging.env.example
@@ -17,6 +17,8 @@ ADMIN_LINODE_ALLOWED_SSH_CIDRS=203.0.113.10/32
 
 # Deployment behavior.
 ADMIN_LINODE_RELEASE=staging-local
+# Optional: deploy a prebuilt release archive instead of building locally.
+# ADMIN_LINODE_RELEASE_BUNDLE=/path/to/dist/rtk_cloud_admin-staging-local.tar.gz
 ADMIN_LINODE_CERTBOT_ENABLE=1
 ADMIN_LINODE_HTTP_ONLY=0
 ADMIN_LINODE_REMOTE_IMAGE=/tmp/rtk-cloud-admin-image.tar.gz

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -3,7 +3,33 @@ set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 label="${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}"
-release="${ADMIN_LINODE_RELEASE:-$(git -C "$root_dir" rev-parse --short HEAD)}"
+release_bundle="${ADMIN_LINODE_RELEASE_BUNDLE:-}"
+bundle_release=""
+if [ -n "$release_bundle" ]; then
+  release_name="$(basename "$release_bundle")"
+  case "$release_name" in
+    rtk_cloud_admin-*.tar.gz)
+      bundle_release="${release_name#rtk_cloud_admin-}"
+      bundle_release="${bundle_release%.tar.gz}"
+      ;;
+    *)
+      printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz\n' >&2
+      exit 1
+      ;;
+  esac
+fi
+
+if [ -n "${ADMIN_LINODE_RELEASE:-}" ]; then
+  release="$ADMIN_LINODE_RELEASE"
+elif [ -n "$release_bundle" ]; then
+  release="$bundle_release"
+else
+  release="$(git -C "$root_dir" rev-parse --short HEAD)"
+fi
+if [ -n "$bundle_release" ] && [ "$release" != "$bundle_release" ]; then
+  printf 'error: ADMIN_LINODE_RELEASE (%s) must match bundle version (%s)\n' "$release" "$bundle_release" >&2
+  exit 1
+fi
 domain="${ADMIN_LINODE_DOMAIN:-}"
 certbot_email="${ADMIN_LINODE_CERTBOT_EMAIL:-}"
 ssh_user="${ADMIN_LINODE_SSH_USER:-root}"
@@ -47,7 +73,9 @@ write_env() {
   printf '%s=%s\n' "$key" "$value"
 }
 
-need docker
+if [ -z "$release_bundle" ]; then
+  need docker
+fi
 need ssh
 need scp
 
@@ -61,11 +89,17 @@ done
 
 mkdir -p "$artifact_dir"
 
-printf '[admin-deploy] building Docker image %s\n' "$image_tag" >&2
-docker build --platform linux/amd64 -t "$image_tag" "$root_dir"
+if [ -n "$release_bundle" ]; then
+  [ -s "$release_bundle" ] || die "ADMIN_LINODE_RELEASE_BUNDLE not found or empty: $release_bundle"
+  image_archive="$release_bundle"
+  printf '[admin-deploy] using release bundle %s\n' "$image_archive" >&2
+else
+  printf '[admin-deploy] building Docker image %s\n' "$image_tag" >&2
+  docker build --platform linux/amd64 -t "$image_tag" "$root_dir"
 
-printf '[admin-deploy] saving image archive %s\n' "$image_archive" >&2
-docker save "$image_tag" | gzip -c > "$image_archive"
+  printf '[admin-deploy] saving image archive %s\n' "$image_archive" >&2
+  docker save "$image_tag" | gzip -c > "$image_archive"
+fi
 
 ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
 remote="$ssh_user@$admin_host"

--- a/deploy/package-release.sh
+++ b/deploy/package-release.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT_DIR="${OUTPUT_DIR:-$ROOT_DIR/dist}"
+VERSION="${VERSION:-}"
+DOCKER_BIN="${DOCKER_BIN:-docker}"
+
+if [ -z "$VERSION" ]; then
+  if command -v git >/dev/null 2>&1 && git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    VERSION="$(git -C "$ROOT_DIR" rev-parse --short HEAD)"
+  else
+    VERSION="$(date +%Y%m%d%H%M%S)"
+  fi
+fi
+
+case "$VERSION" in
+  *[!A-Za-z0-9._-]* | "" | .* | *..*)
+    echo "invalid VERSION: use only letters, digits, dot, underscore, and dash" >&2
+    exit 1
+    ;;
+esac
+
+SOURCE_COMMIT="${GITHUB_SHA:-unknown}"
+if [ "$SOURCE_COMMIT" = "unknown" ] && command -v git >/dev/null 2>&1 && git -C "$ROOT_DIR" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  SOURCE_COMMIT="$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || printf unknown)"
+fi
+
+mkdir -p "$OUTPUT_DIR"
+
+image_tag="rtk-cloud-admin:$VERSION"
+bundle="$OUTPUT_DIR/rtk_cloud_admin-$VERSION.tar.gz"
+checksum="$bundle.sha256"
+manifest="$OUTPUT_DIR/rtk_cloud_admin-$VERSION.object-manifest.json"
+
+printf '[release] building Docker image %s\n' "$image_tag" >&2
+"$DOCKER_BIN" build --platform linux/amd64 -t "$image_tag" "$ROOT_DIR"
+
+printf '[release] saving image archive %s\n' "$bundle" >&2
+rm -f "$bundle" "$checksum" "$manifest"
+"$DOCKER_BIN" save "$image_tag" | gzip -c > "$bundle"
+
+if command -v shasum >/dev/null 2>&1; then
+  shasum -a 256 "$bundle" | awk '{print $1}' > "$checksum"
+elif command -v sha256sum >/dev/null 2>&1; then
+  sha256sum "$bundle" | awk '{print $1}' > "$checksum"
+else
+  echo "shasum or sha256sum is required" >&2
+  exit 1
+fi
+
+VERSION="$VERSION" OUTPUT_DIR="$OUTPUT_DIR" SOURCE_COMMIT="$SOURCE_COMMIT" BUNDLE_SHA256_PATH="$checksum" python3 - <<'PY' > "$manifest"
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+version = os.environ["VERSION"]
+bundle = f"rtk_cloud_admin-{version}.tar.gz"
+checksum = Path(f"{os.environ.get('OUTPUT_DIR', 'dist')}/{bundle}.sha256")
+if not checksum.exists():
+    checksum = Path(os.environ["BUNDLE_SHA256_PATH"])
+sha256 = checksum.read_text(encoding="utf-8").strip()
+print(json.dumps({
+    "version": version,
+    "source_commit": os.environ["SOURCE_COMMIT"],
+    "bundle": bundle,
+    "artifact_path": f"releases/{version}/{bundle}",
+    "sha256": sha256,
+    "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+}, indent=2, sort_keys=True))
+PY
+
+printf '[release] created %s\n' "$bundle" >&2

--- a/deploy/test-release-artifacts.sh
+++ b/deploy/test-release-artifacts.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+FAKE_BIN="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN"
+
+cat > "$FAKE_BIN/docker" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_DOCKER_LOG:?}"
+case "$1" in
+  build)
+    exit 0
+    ;;
+  save)
+    printf 'fake docker image archive for %s\n' "$2"
+    ;;
+  load)
+    shift
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        -i)
+          test -s "$2"
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    ;;
+  image)
+    test "$2" = "inspect"
+    test "$3" = "rtk-cloud-admin:${EXPECTED_VERSION:?}"
+    ;;
+  *)
+    echo "unexpected docker command: $*" >&2
+    exit 1
+    ;;
+esac
+SH
+chmod +x "$FAKE_BIN/docker"
+
+cat > "$FAKE_BIN/ssh" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_SSH_LOG:?}"
+exit 0
+SH
+chmod +x "$FAKE_BIN/ssh"
+
+cat > "$FAKE_BIN/scp" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_SCP_LOG:?}"
+exit 0
+SH
+chmod +x "$FAKE_BIN/scp"
+
+export PATH="$FAKE_BIN:$PATH"
+export FAKE_DOCKER_LOG="$TMP_DIR/docker.log"
+export FAKE_SSH_LOG="$TMP_DIR/ssh.log"
+export FAKE_SCP_LOG="$TMP_DIR/scp.log"
+export EXPECTED_VERSION="test-local"
+: > "$FAKE_DOCKER_LOG"
+: > "$FAKE_SSH_LOG"
+: > "$FAKE_SCP_LOG"
+
+OUTPUT_DIR="$TMP_DIR/dist"
+OUTPUT_DIR="$OUTPUT_DIR" VERSION="$EXPECTED_VERSION" "$ROOT_DIR/deploy/package-release.sh"
+
+BUNDLE="$OUTPUT_DIR/rtk_cloud_admin-$EXPECTED_VERSION.tar.gz"
+CHECKSUM="$BUNDLE.sha256"
+MANIFEST="$OUTPUT_DIR/rtk_cloud_admin-$EXPECTED_VERSION.object-manifest.json"
+
+test -s "$BUNDLE"
+test -s "$CHECKSUM"
+test -s "$MANIFEST"
+
+python3 - "$MANIFEST" "$EXPECTED_VERSION" <<'PY'
+import json
+import sys
+
+manifest_path, version = sys.argv[1], sys.argv[2]
+with open(manifest_path, "r", encoding="utf-8") as handle:
+    manifest = json.load(handle)
+assert manifest["version"] == version
+assert manifest["bundle"] == f"rtk_cloud_admin-{version}.tar.gz"
+assert manifest["artifact_path"] == f"releases/{version}/rtk_cloud_admin-{version}.tar.gz"
+assert manifest["sha256"]
+assert manifest["created_at"].endswith("Z")
+PY
+
+"$ROOT_DIR/deploy/check-release.sh" "$BUNDLE"
+
+SSH_KEY="$TMP_DIR/id_ed25519"
+printf 'fake-key\n' > "$SSH_KEY"
+chmod 0600 "$SSH_KEY"
+: > "$FAKE_DOCKER_LOG"
+
+ADMIN_LINODE_RELEASE="$EXPECTED_VERSION" \
+ADMIN_LINODE_RELEASE_BUNDLE="$BUNDLE" \
+ADMIN_LINODE_DOMAIN="admin.example.test" \
+ADMIN_LINODE_CERTBOT_EMAIL="admin@example.test" \
+ADMIN_LINODE_HOST="203.0.113.10" \
+ADMIN_LINODE_SSH_KEY="$SSH_KEY" \
+ACCOUNT_MANAGER_BASE_URL="https://account.example.test" \
+VIDEO_CLOUD_BASE_URL="https://video.example.test" \
+VIDEO_CLOUD_ADMIN_TOKEN="token" \
+ADMIN_BOOTSTRAP_EMAIL="admin@example.test" \
+ADMIN_BOOTSTRAP_PASSWORD="password" \
+"$ROOT_DIR/deploy/linode/deploy-admin.sh"
+
+if grep -q '^build ' "$FAKE_DOCKER_LOG"; then
+  echo "deploy-admin.sh built a local Docker image despite ADMIN_LINODE_RELEASE_BUNDLE" >&2
+  cat "$FAKE_DOCKER_LOG" >&2
+  exit 1
+fi
+grep -q "$BUNDLE" "$FAKE_SCP_LOG"
+
+echo "release artifact tests passed"


### PR DESCRIPTION
## Summary
- add release packaging and verification scripts for Docker archive bundles
- add a tag/manual GitHub release workflow that uploads bundle, checksum, and manifest to Linode Object Storage
- allow Linode admin deploys to use a prebuilt `ADMIN_LINODE_RELEASE_BUNDLE` while preserving local-build default
- document release artifact and deployment usage

## Validation
- `bash -n deploy/package-release.sh deploy/check-release.sh deploy/test-release-artifacts.sh deploy/linode/deploy-admin.sh deploy/linode/provision-admin-vm.sh deploy/linode/verify-admin.sh deploy/linode/backup-admin-db`
- `deploy/test-release-artifacts.sh`
- `VERSION=test-local-real OUTPUT_DIR=.artifacts/release-test deploy/package-release.sh && deploy/check-release.sh .artifacts/release-test/rtk_cloud_admin-test-local-real.tar.gz`
- container `/healthz` smoke against `rtk-cloud-admin:test-local-real`
- `go test ./...`
- `cd web && npm test`
