### PR TITLE
[codex] Fix release workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Select version
         id: version


### PR DESCRIPTION
## Summary
- remove recursive submodule checkout from the release packaging workflow
- avoid GitHub-hosted runner failures on local-only SSH alias submodule URLs

## Validation
- `bash -n deploy/package-release.sh deploy/check-release.sh deploy/test-release-artifacts.sh deploy/linode/deploy-admin.sh`
- `deploy/test-release-artifacts.sh`
- `git diff --check`
