### PR TITLE
[codex] Update release workflow actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Select version
         id: version
@@ -81,7 +81,7 @@ jobs:
           aws s3 cp "$manifest" "$prefix/manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
 
       - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rtk_cloud_admin-${{ steps.version.outputs.version }}
           path: |


### PR DESCRIPTION
## Summary
- update release workflow actions to Node 24-compatible major versions
- keep release packaging behavior unchanged

## Validation
- `bash -n deploy/package-release.sh deploy/check-release.sh deploy/test-release-artifacts.sh deploy/linode/deploy-admin.sh`
- `deploy/test-release-artifacts.sh`
- `git diff --check`
