### PR TITLE
[codex] Clarify release smoke artifact version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version. Defaults to the git ref name or short SHA."
+        description: "Release version. Defaults to tag name or release-smoke-<timestamp>-<shortsha>."
         required: false
         type: string
 
@@ -34,7 +34,7 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             version="$GITHUB_REF_NAME"
           else
-            version="${GITHUB_SHA::12}"
+            version="release-smoke-$(date -u +%Y%m%d-%H%M%S)-${GITHUB_SHA::12}"
           fi
           case "$version" in
             *[!A-Za-z0-9._-]* | "" | .* | *..*)


### PR DESCRIPTION
## Summary
- make manual release workflow smoke versions self-describing
- default workflow_dispatch versions now include UTC timestamp and source commit prefix

## Example
- `release-smoke-20260516-083000-d0f9dca12345`

## Validation
- `bash -n deploy/package-release.sh deploy/check-release.sh deploy/test-release-artifacts.sh deploy/linode/deploy-admin.sh`
- `deploy/test-release-artifacts.sh`
- `git diff --check`
