### PR TITLE
[codex] Use project-prefixed release object paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version. Defaults to tag name or release-smoke-<timestamp>-<shortsha>."
+        description: "Release version. Defaults to tag name or ci-<timestamp>-<shortsha>."
         required: false
         type: string
 
@@ -34,7 +34,7 @@ jobs:
           elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
             version="$GITHUB_REF_NAME"
           else
-            version="release-smoke-$(date -u +%Y%m%d-%H%M%S)-${GITHUB_SHA::12}"
+            version="ci-$(date -u +%Y%m%d-%H%M%S)-${GITHUB_SHA::12}"
           fi
           case "$version" in
             *[!A-Za-z0-9._-]* | "" | .* | *..*)
@@ -74,10 +74,10 @@ jobs:
           bundle="dist/rtk_cloud_admin-$VERSION.tar.gz"
           checksum="$bundle.sha256"
           manifest="dist/rtk_cloud_admin-$VERSION.object-manifest.json"
-          prefix="s3://$LINODE_OBJ_BUCKET/releases/$VERSION"
+          prefix="s3://$LINODE_OBJ_BUCKET/releases/rtk_cloud_admin-$VERSION"
 
-          aws s3 cp "$bundle" "$prefix/rtk_cloud_admin-$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
-          aws s3 cp "$checksum" "$prefix/rtk_cloud_admin-$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$bundle" "$prefix/$VERSION.tar.gz" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
+          aws s3 cp "$checksum" "$prefix/$VERSION.tar.gz.sha256" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
           aws s3 cp "$manifest" "$prefix/manifest.json" --endpoint-url "$LINODE_OBJ_ENDPOINT" --only-show-errors
 
       - name: Upload workflow artifact

--- a/README.md
+++ b/README.md
@@ -217,8 +217,10 @@ deploy/check-release.sh dist/rtk_cloud_admin-v1.2.3.tar.gz
 ```
 
 The release workflow uploads the bundle, checksum, and manifest to Linode Object
-Storage under `releases/<version>/`. Object Storage credentials belong in
-GitHub repository secrets and variables, not local `.env` files.
+Storage under `releases/rtk_cloud_admin-<version>/`. The object filenames use
+the version directly, for example `ci-20260516-111747-abcdef123456.tar.gz` for
+manual CI smoke bundles. Object Storage credentials belong in GitHub repository
+secrets and variables, not local `.env` files.
 
 ## CI
 

--- a/deploy/check-release.sh
+++ b/deploy/check-release.sh
@@ -67,12 +67,12 @@ missing = [field for field in required if not manifest.get(field)]
 if missing:
     raise SystemExit(f"manifest missing fields: {', '.join(missing)}")
 
-bundle = f"rtk_cloud_admin-{version}.tar.gz"
+bundle = f"{version}.tar.gz"
 if manifest["version"] != version:
     raise SystemExit("manifest version mismatch")
 if manifest["bundle"] != bundle:
     raise SystemExit("manifest bundle mismatch")
-if manifest["artifact_path"] != f"releases/{version}/{bundle}":
+if manifest["artifact_path"] != f"releases/rtk_cloud_admin-{version}/{bundle}":
     raise SystemExit("manifest artifact_path mismatch")
 if manifest["sha256"] != expected_sha:
     raise SystemExit("manifest sha256 mismatch")

--- a/deploy/package-release.sh
+++ b/deploy/package-release.sh
@@ -56,16 +56,17 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 version = os.environ["VERSION"]
-bundle = f"rtk_cloud_admin-{version}.tar.gz"
-checksum = Path(f"{os.environ.get('OUTPUT_DIR', 'dist')}/{bundle}.sha256")
+local_bundle = f"rtk_cloud_admin-{version}.tar.gz"
+object_bundle = f"{version}.tar.gz"
+checksum = Path(f"{os.environ.get('OUTPUT_DIR', 'dist')}/{local_bundle}.sha256")
 if not checksum.exists():
     checksum = Path(os.environ["BUNDLE_SHA256_PATH"])
 sha256 = checksum.read_text(encoding="utf-8").strip()
 print(json.dumps({
     "version": version,
     "source_commit": os.environ["SOURCE_COMMIT"],
-    "bundle": bundle,
-    "artifact_path": f"releases/{version}/{bundle}",
+    "bundle": object_bundle,
+    "artifact_path": f"releases/rtk_cloud_admin-{version}/{object_bundle}",
     "sha256": sha256,
     "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
 }, indent=2, sort_keys=True))

--- a/deploy/test-release-artifacts.sh
+++ b/deploy/test-release-artifacts.sh
@@ -89,8 +89,8 @@ manifest_path, version = sys.argv[1], sys.argv[2]
 with open(manifest_path, "r", encoding="utf-8") as handle:
     manifest = json.load(handle)
 assert manifest["version"] == version
-assert manifest["bundle"] == f"rtk_cloud_admin-{version}.tar.gz"
-assert manifest["artifact_path"] == f"releases/{version}/rtk_cloud_admin-{version}.tar.gz"
+assert manifest["bundle"] == f"{version}.tar.gz"
+assert manifest["artifact_path"] == f"releases/rtk_cloud_admin-{version}/{version}.tar.gz"
 assert manifest["sha256"]
 assert manifest["created_at"].endswith("Z")
 PY


### PR DESCRIPTION
## Summary
- make manual CI release versions use `ci-<timestamp>-<shortsha>`
- publish Object Storage bundles under project-prefixed directories
- use version-only object filenames inside the project directory
- update release manifest validation and docs for the new layout

## Object Storage layout
- `releases/rtk_cloud_admin-ci-<timestamp>-<shortsha>/ci-<timestamp>-<shortsha>.tar.gz`
- `releases/rtk_cloud_admin-ci-<timestamp>-<shortsha>/ci-<timestamp>-<shortsha>.tar.gz.sha256`
- `releases/rtk_cloud_admin-ci-<timestamp>-<shortsha>/manifest.json`

## Validation
- `bash -n deploy/package-release.sh deploy/check-release.sh deploy/test-release-artifacts.sh deploy/linode/deploy-admin.sh`
- `deploy/test-release-artifacts.sh`
- `git diff --check`
