### PR TITLE
[codex] Limit Linode release uploads to tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
         run: deploy/check-release.sh "dist/rtk_cloud_admin-${{ steps.version.outputs.version }}.tar.gz"
 
       - name: Upload release bundle to Linode Object Storage
+        if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.LINODE_OBJ_ACCESS_KEY_ID }}

--- a/README.md
+++ b/README.md
@@ -216,11 +216,12 @@ VERSION=v1.2.3 deploy/package-release.sh
 deploy/check-release.sh dist/rtk_cloud_admin-v1.2.3.tar.gz
 ```
 
-The release workflow uploads the bundle, checksum, and manifest to Linode Object
-Storage under `releases/rtk_cloud_admin-<version>/`. The object filenames use
-the version directly, for example `ci-20260516-111747-abcdef123456.tar.gz` for
-manual CI smoke bundles. Object Storage credentials belong in GitHub repository
-secrets and variables, not local `.env` files.
+Tag-triggered release runs upload the bundle, checksum, and manifest to Linode
+Object Storage under `releases/rtk_cloud_admin-<version>/`. The object filenames
+use the version directly, for example `v1.2.3.tar.gz`. Manual release workflow
+runs build and verify the bundle and publish a GitHub workflow artifact only;
+they do not write to Linode Object Storage. Object Storage credentials belong in
+GitHub repository secrets and variables, not local `.env` files.
 
 ## CI
 
@@ -228,9 +229,11 @@ secrets and variables, not local `.env` files.
 `go build ./cmd/server`, `npm ci`, `npm run build`, a container smoke test, and
 Docker cache cleanup on the self-hosted `rtk-cloud-admin-ci` runner.
 
-`.github/workflows/release.yml` runs only for `v*` tags or manual dispatch. It
-builds a release bundle and publishes it to Linode Object Storage; normal PR and
-main CI do not upload release artifacts.
+`.github/workflows/release.yml` runs only for `v*` tags or manual dispatch.
+Manual dispatch builds and verifies a release bundle as a GitHub workflow
+artifact. Tag-triggered runs also publish the release bundle to Linode Object
+Storage and attach assets to the GitHub Release. Normal PR and main CI do not
+upload release artifacts.
 
 Runner health and recovery notes live in [`docs/ci-runner.md`](docs/ci-runner.md).
 


### PR DESCRIPTION
## Summary
- restrict Linode Object Storage uploads to tag-triggered release workflow runs
- keep manual release workflow dispatch as build/verify/GitHub-artifact only
- document tag-only Object Storage behavior

## Validation
- `bash -n deploy/package-release.sh deploy/check-release.sh deploy/test-release-artifacts.sh deploy/linode/deploy-admin.sh`
- `deploy/test-release-artifacts.sh`
- `git diff --check`
