### PR TITLE
Proxy brand cloud admin APIs

### DIFF
--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -63,6 +63,9 @@ authorizes the user as `platform_admin` and Admin Console creates the local
 as controlled break-glass access when explicitly enabled by deployment
 configuration. Break-glass admins are bootstrapped by `ADMIN_BOOTSTRAP_EMAIL` /
 `ADMIN_BOOTSTRAP_PASSWORD`, stored in SQLite, and protected with bcrypt hashes.
+Break-glass admins are not Account Manager root users. Brand-cloud management
+requires an Account Manager-backed `platform_admin` session with an upstream
+Bearer token.
 
 ### Platform Admin
 
@@ -79,6 +82,9 @@ Tier 2 customers.
 
 **Can execute:**
 - Platform-side admin actions: customer session refresh and invalidation (existing in `internal/app/app.go`).
+- Brand-cloud backend actions when authenticated through Account Manager as
+  `platform_admin`: create/list/read/update brand clouds and assign existing
+  Account Manager users to a brand cloud.
 - Tenant lifecycle actions (provisioning, deactivation, firmware campaign control on behalf of a tenant): not supported. Tenant-side write actions remain with Tier 2 Fleet Managers.
 
 **Known gap:** There is no cross-tenant device-detail surface today. Operations
@@ -88,8 +94,8 @@ firmware version). A Platform Admin investigating "what is the current state of
 this customer's devices?" cannot answer it from the console today and must
 either read SQLite directly or contact the tenant.
 
-**Future capabilities (deferred):** Read-only impersonation of any tenant's
-Customer View will close this gap.
+**Future capabilities (deferred):** WebUI screens for brand-cloud management
+and read-only impersonation of any tenant's Customer View will close this gap.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -10,7 +10,7 @@ The first implementation uses a Go backend/BFF, SQLite, and a React JavaScript f
 
 The console follows the contracts in `rtk_cloud_contracts_doc`:
 
-- Account Manager owns customer authentication, organizations, members, registry devices, and provisioning/deactivation APIs.
+- Account Manager owns customer authentication, organizations, members, registry devices, provisioning/deactivation APIs, platform-admin/root identity, and brand-cloud administration.
 - Realtek Video Cloud owns activation, scoped tokens, stream/media routes, firmware routes, and transport ownership.
 - Product readiness is an aggregate projection across account registry, claim/bind, local onboarding, cloud activation, and transport online facts.
 - Frontend color, typography, status labels, and layout tone follow `rtk_cloud_contracts_doc/FRONTEND_STYLE.md`.
@@ -21,6 +21,10 @@ identity, tenant context, authorization, entitlement, device registry, and
 provisioning intent. `rtk_cloud_admin` is the enterprise/admin dashboard and
 BFF; it may proxy or aggregate upstream facts but must not become the canonical
 account, organization, device, quota, or provisioning store.
+The same boundary applies to brand clouds: Account Manager owns
+`organization_kind=brand_cloud` records, membership, status, and audit. Admin
+Console may proxy these APIs and later add WebUI screens, but it must not store
+authoritative brand-cloud records in SQLite.
 
 ## MVP Scope
 
@@ -43,6 +47,7 @@ Included in v0.1:
 - Platform admin pages:
   - service health
   - SSO provider status and settings
+  - backend/BFF brand-cloud management routes for future UI consumption
   - lifecycle operations log
   - audit log
 - Audit events are recorded when demo lifecycle actions are created from the
@@ -132,6 +137,11 @@ Public and shared routes:
 - `GET /api/service-health`: configured upstream service health.
 - `GET /api/audit`: audit log.
 - `GET /api/admin/audit`: platform-admin protected audit log.
+- `GET /api/admin/brand-clouds`: Account Manager-backed brand cloud list.
+- `POST /api/admin/brand-clouds`: Account Manager-backed brand cloud create.
+- `GET /api/admin/brand-clouds/{id}`: Account Manager-backed brand cloud read.
+- `PATCH /api/admin/brand-clouds/{id}`: Account Manager-backed brand cloud update.
+- `POST /api/admin/brand-clouds/{id}/members`: Account Manager-backed brand cloud member assignment.
 - `GET /assets/...`: built frontend assets.
 - `GET /*`: React SPA fallback.
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.8% |
+| Go total coverage | 80.6% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -27,8 +27,8 @@
 | Package | Coverage |
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 88.8% |
-| `rtk_cloud_admin/internal/app` | 80.7% |
+| `rtk_cloud_admin/internal/accountclient` | 89.6% |
+| `rtk_cloud_admin/internal/app` | 80.3% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
 | `rtk_cloud_admin/internal/store` | 80.1% |

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -24,11 +24,34 @@ type User struct {
 }
 
 type Organization struct {
-	ID                    string `json:"id"`
-	Name                  string `json:"name"`
-	Role                  string `json:"role"`
-	Tier                  string `json:"tier,omitempty"`
-	EvaluationDeviceQuota int    `json:"evaluation_device_quota,omitempty"`
+	ID                    string         `json:"id"`
+	Name                  string         `json:"name"`
+	Role                  string         `json:"role"`
+	OrganizationKind      string         `json:"organization_kind,omitempty"`
+	Status                string         `json:"status,omitempty"`
+	Tier                  string         `json:"tier,omitempty"`
+	EvaluationDeviceQuota int            `json:"evaluation_device_quota,omitempty"`
+	Metadata              map[string]any `json:"metadata,omitempty"`
+}
+
+type BrandCloud = Organization
+
+type BrandCloudRequest struct {
+	Name     string         `json:"name,omitempty"`
+	Status   string         `json:"status,omitempty"`
+	Metadata map[string]any `json:"metadata,omitempty"`
+}
+
+type BrandCloudMemberRequest struct {
+	UserID string `json:"user_id"`
+	Role   string `json:"role"`
+}
+
+type Member struct {
+	OrganizationID string `json:"organization_id"`
+	UserID         string `json:"user_id"`
+	Email          string `json:"email,omitempty"`
+	Role           string `json:"role"`
 }
 
 type Device struct {
@@ -316,6 +339,51 @@ func (c *Client) AdminOrganizations(ctx context.Context, accessToken string) ([]
 		return nil, err
 	}
 	return body.Organizations, nil
+}
+
+func (c *Client) CreateBrandCloud(ctx context.Context, accessToken string, req BrandCloudRequest) (BrandCloud, error) {
+	var body struct {
+		BrandCloud BrandCloud `json:"brand_cloud"`
+	}
+	err := c.doJSON(ctx, http.MethodPost, "/v1/admin/brand-clouds", accessToken, req, &body)
+	return body.BrandCloud, err
+}
+
+func (c *Client) BrandClouds(ctx context.Context, accessToken string) ([]BrandCloud, error) {
+	var body struct {
+		BrandClouds []BrandCloud `json:"brand_clouds"`
+	}
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/admin/brand-clouds", accessToken, nil, &body); err != nil {
+		return nil, err
+	}
+	return body.BrandClouds, nil
+}
+
+func (c *Client) BrandCloud(ctx context.Context, accessToken, brandCloudID string) (BrandCloud, error) {
+	var body struct {
+		BrandCloud BrandCloud `json:"brand_cloud"`
+	}
+	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID)
+	err := c.doJSON(ctx, http.MethodGet, path, accessToken, nil, &body)
+	return body.BrandCloud, err
+}
+
+func (c *Client) UpdateBrandCloud(ctx context.Context, accessToken, brandCloudID string, req BrandCloudRequest) (BrandCloud, error) {
+	var body struct {
+		BrandCloud BrandCloud `json:"brand_cloud"`
+	}
+	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID)
+	err := c.doJSON(ctx, http.MethodPatch, path, accessToken, req, &body)
+	return body.BrandCloud, err
+}
+
+func (c *Client) AssignBrandCloudMember(ctx context.Context, accessToken, brandCloudID string, req BrandCloudMemberRequest) (Member, error) {
+	var body struct {
+		Member Member `json:"member"`
+	}
+	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/members"
+	err := c.doJSON(ctx, http.MethodPost, path, accessToken, req, &body)
+	return body.Member, err
 }
 
 func (c *Client) Devices(ctx context.Context, accessToken, orgID string) ([]Device, error) {

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -130,6 +130,74 @@ func TestClientAdminInventory(t *testing.T) {
 	}
 }
 
+func TestClientBrandCloudLifecycle(t *testing.T) {
+	t.Parallel()
+
+	var createBody map[string]any
+	var patchBody map[string]any
+	var memberBody map[string]any
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-access" {
+			t.Fatalf("%s Authorization = %q, want Bearer admin-access", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds":
+			if err := json.NewDecoder(r.Body).Decode(&createBody); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds":
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_clouds": []map[string]any{{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}}})
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1/admin/brand-clouds/brand-1":
+			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
+				t.Fatal(err)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect Plus", "organization_kind": "brand_cloud", "status": "disabled"}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/members":
+			if err := json.NewDecoder(r.Body).Decode(&memberBody); err != nil {
+				t.Fatal(err)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"organization_id": "brand-1", "user_id": "user-1", "role": "owner"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer upstream.Close()
+
+	client := New(upstream.URL)
+	created, err := client.CreateBrandCloud(t.Context(), "admin-access", BrandCloudRequest{Name: "Realtek Connect+"})
+	if err != nil {
+		t.Fatalf("CreateBrandCloud returned error: %v", err)
+	}
+	if created.ID != "brand-1" || created.OrganizationKind != "brand_cloud" || createBody["name"] != "Realtek Connect+" {
+		t.Fatalf("created brand cloud = %#v body=%#v", created, createBody)
+	}
+	list, err := client.BrandClouds(t.Context(), "admin-access")
+	if err != nil {
+		t.Fatalf("BrandClouds returned error: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "brand-1" {
+		t.Fatalf("list = %#v", list)
+	}
+	updated, err := client.UpdateBrandCloud(t.Context(), "admin-access", "brand-1", BrandCloudRequest{Name: "Realtek Connect Plus", Status: "disabled"})
+	if err != nil {
+		t.Fatalf("UpdateBrandCloud returned error: %v", err)
+	}
+	if updated.Status != "disabled" || patchBody["status"] != "disabled" {
+		t.Fatalf("updated brand cloud = %#v body=%#v", updated, patchBody)
+	}
+	member, err := client.AssignBrandCloudMember(t.Context(), "admin-access", "brand-1", BrandCloudMemberRequest{UserID: "user-1", Role: "owner"})
+	if err != nil {
+		t.Fatalf("AssignBrandCloudMember returned error: %v", err)
+	}
+	if member.UserID != "user-1" || memberBody["user_id"] != "user-1" {
+		t.Fatalf("member = %#v body=%#v", member, memberBody)
+	}
+}
+
 func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -156,6 +156,8 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds":
 			_ = json.NewEncoder(w).Encode(map[string]any{"brand_clouds": []map[string]any{{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds/brand-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active", "metadata": map[string]any{"region": "tw"}}})
 		case r.Method == http.MethodPatch && r.URL.Path == "/v1/admin/brand-clouds/brand-1":
 			if err := json.NewDecoder(r.Body).Decode(&patchBody); err != nil {
 				t.Fatal(err)
@@ -187,6 +189,13 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 	}
 	if len(list) != 1 || list[0].ID != "brand-1" {
 		t.Fatalf("list = %#v", list)
+	}
+	got, err := client.BrandCloud(t.Context(), "admin-access", "brand-1")
+	if err != nil {
+		t.Fatalf("BrandCloud returned error: %v", err)
+	}
+	if got.ID != "brand-1" || got.Metadata["region"] != "tw" {
+		t.Fatalf("brand cloud = %#v", got)
 	}
 	updated, err := client.UpdateBrandCloud(t.Context(), "admin-access", "brand-1", BrandCloudRequest{Name: "Realtek Connect Plus", Status: "disabled"})
 	if err != nil {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -97,6 +97,11 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/admin/customers", s.apiAdminCustomers)
 	s.mux.HandleFunc("GET /api/devices", s.apiDevices)
 	s.mux.HandleFunc("GET /api/admin/devices", s.apiAdminDevices)
+	s.mux.HandleFunc("GET /api/admin/brand-clouds", s.apiAdminBrandClouds)
+	s.mux.HandleFunc("POST /api/admin/brand-clouds", s.apiAdminBrandClouds)
+	s.mux.HandleFunc("GET /api/admin/brand-clouds/{brandCloudId}", s.apiAdminBrandCloud)
+	s.mux.HandleFunc("PATCH /api/admin/brand-clouds/{brandCloudId}", s.apiAdminBrandCloud)
+	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/members", s.apiAdminBrandCloudMember)
 	s.mux.HandleFunc("GET /api/admin/sso/providers", s.apiAdminSSOProviders)
 	s.mux.HandleFunc("GET /api/admin/orgs/{orgId}/sso-provider", s.apiAdminSSOProvider)
 	s.mux.HandleFunc("PUT /api/admin/orgs/{orgId}/sso-provider", s.apiAdminSSOProvider)
@@ -2072,6 +2077,95 @@ func (s *Server) apiAdminSSOProviders(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string][]accountclient.SSOProviderStatus{"providers": providers})
 }
 
+func (s *Server) apiAdminBrandClouds(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requireUpstreamPlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	if r.Method == http.MethodGet {
+		brandClouds, err := s.accountClient.BrandClouds(r.Context(), session.AccessToken)
+		if err != nil {
+			s.writeUpstreamReadError(w, err)
+			return
+		}
+		writeJSON(w, map[string][]accountclient.BrandCloud{"brand_clouds": brandClouds})
+		return
+	}
+
+	var body accountclient.BrandCloudRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid brand cloud request", http.StatusBadRequest)
+		return
+	}
+	body.Name = strings.TrimSpace(body.Name)
+	brandCloud, err := s.accountClient.CreateBrandCloud(r.Context(), session.AccessToken, body)
+	if err != nil {
+		s.writeUpstreamReadError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusCreated, map[string]accountclient.BrandCloud{"brand_cloud": brandCloud})
+}
+
+func (s *Server) apiAdminBrandCloud(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requireUpstreamPlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	brandCloudID := strings.TrimSpace(r.PathValue("brandCloudId"))
+	if brandCloudID == "" {
+		http.Error(w, "brand cloud id is required", http.StatusBadRequest)
+		return
+	}
+	if r.Method == http.MethodGet {
+		brandCloud, err := s.accountClient.BrandCloud(r.Context(), session.AccessToken, brandCloudID)
+		if err != nil {
+			s.writeUpstreamReadError(w, err)
+			return
+		}
+		writeJSON(w, map[string]accountclient.BrandCloud{"brand_cloud": brandCloud})
+		return
+	}
+
+	var body accountclient.BrandCloudRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid brand cloud request", http.StatusBadRequest)
+		return
+	}
+	body.Name = strings.TrimSpace(body.Name)
+	body.Status = strings.TrimSpace(body.Status)
+	brandCloud, err := s.accountClient.UpdateBrandCloud(r.Context(), session.AccessToken, brandCloudID, body)
+	if err != nil {
+		s.writeUpstreamReadError(w, err)
+		return
+	}
+	writeJSON(w, map[string]accountclient.BrandCloud{"brand_cloud": brandCloud})
+}
+
+func (s *Server) apiAdminBrandCloudMember(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requireUpstreamPlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	brandCloudID := strings.TrimSpace(r.PathValue("brandCloudId"))
+	if brandCloudID == "" {
+		http.Error(w, "brand cloud id is required", http.StatusBadRequest)
+		return
+	}
+	var body accountclient.BrandCloudMemberRequest
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid brand cloud member request", http.StatusBadRequest)
+		return
+	}
+	body.UserID = strings.TrimSpace(body.UserID)
+	body.Role = strings.TrimSpace(body.Role)
+	member, err := s.accountClient.AssignBrandCloudMember(r.Context(), session.AccessToken, brandCloudID, body)
+	if err != nil {
+		s.writeUpstreamReadError(w, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusCreated, map[string]accountclient.Member{"member": member})
+}
+
 func (s *Server) apiAdminSSOProvider(w http.ResponseWriter, r *http.Request) {
 	session, ok := s.requirePlatformAdmin(w, r)
 	if !ok {
@@ -2202,6 +2296,22 @@ func (s *Server) requirePlatformAdmin(w http.ResponseWriter, r *http.Request) (s
 	}
 	if session.Kind != "platform_admin" {
 		http.Error(w, "platform admin authentication required", http.StatusForbidden)
+		return store.Session{}, false
+	}
+	return session, true
+}
+
+func (s *Server) requireUpstreamPlatformAdmin(w http.ResponseWriter, r *http.Request) (store.Session, bool) {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return store.Session{}, false
+	}
+	if !s.accountClient.Enabled() {
+		http.Error(w, "Account Manager is not configured for platform administration", http.StatusServiceUnavailable)
+		return store.Session{}, false
+	}
+	if strings.TrimSpace(session.AccessToken) == "" {
+		http.Error(w, "Account Manager-backed platform admin session required", http.StatusForbidden)
 		return store.Session{}, false
 	}
 	return session, true

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3467,6 +3467,27 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds":
 			_ = json.NewEncoder(w).Encode(map[string]any{"brand_clouds": []map[string]any{{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds/brand-1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}})
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1/admin/brand-clouds/brand-1":
+			var body accountclient.BrandCloudRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.Status != "disabled" {
+				t.Fatalf("patch status = %q, want disabled", body.Status)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": body.Name, "organization_kind": "brand_cloud", "status": body.Status}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/members":
+			var body accountclient.BrandCloudMemberRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.UserID != "user-1" || body.Role != "owner" {
+				t.Fatalf("member request = %#v", body)
+			}
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"organization_id": "brand-1", "user_id": "user-1", "role": "owner"}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -3510,12 +3531,57 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 		t.Fatalf("brand cloud list status = %d, want 200; body=%s", list.Code, list.Body.String())
 	}
 
+	getOne := httptest.NewRecorder()
+	getOneReq := httptest.NewRequest(http.MethodGet, "/api/admin/brand-clouds/brand-1", nil)
+	getOneReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
+	srv.ServeHTTP(getOne, getOneReq)
+	if getOne.Code != http.StatusOK {
+		t.Fatalf("brand cloud get status = %d, want 200; body=%s", getOne.Code, getOne.Body.String())
+	}
+
+	update := httptest.NewRecorder()
+	updateReq := httptest.NewRequest(http.MethodPatch, "/api/admin/brand-clouds/brand-1", strings.NewReader(`{"name":"Realtek Connect+","status":" disabled "}`))
+	updateReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
+	srv.ServeHTTP(update, updateReq)
+	if update.Code != http.StatusOK {
+		t.Fatalf("brand cloud update status = %d, want 200; body=%s", update.Code, update.Body.String())
+	}
+
+	member := httptest.NewRecorder()
+	memberReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds/brand-1/members", strings.NewReader(`{"user_id":" user-1 ","role":" owner "}`))
+	memberReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
+	srv.ServeHTTP(member, memberReq)
+	if member.Code != http.StatusCreated {
+		t.Fatalf("brand cloud member status = %d, want 201; body=%s", member.Code, member.Body.String())
+	}
+
 	blocked := httptest.NewRecorder()
 	blockedReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds", strings.NewReader(`{"name":"Blocked"}`))
 	blockedReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: breakGlassSession.ID})
 	srv.ServeHTTP(blocked, blockedReq)
 	if blocked.Code != http.StatusForbidden {
 		t.Fatalf("break-glass brand cloud create status = %d, want 403; body=%s", blocked.Code, blocked.Body.String())
+	}
+
+	notConfiguredStore, err := store.Open(t.TempDir() + "/not-configured.db")
+	if err != nil {
+		t.Fatalf("Open not configured returned error: %v", err)
+	}
+	defer notConfiguredStore.Close()
+	if err := notConfiguredStore.Migrate(); err != nil {
+		t.Fatalf("Migrate not configured returned error: %v", err)
+	}
+	localSession, err := notConfiguredStore.CreateSession("platform_admin", "admin", "admin@example.com", "admin-access", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession not configured returned error: %v", err)
+	}
+	notConfigured := New(notConfiguredStore)
+	missingAccountManager := httptest.NewRecorder()
+	missingReq := httptest.NewRequest(http.MethodGet, "/api/admin/brand-clouds", nil)
+	missingReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: localSession.ID})
+	notConfigured.ServeHTTP(missingAccountManager, missingReq)
+	if missingAccountManager.Code != http.StatusServiceUnavailable {
+		t.Fatalf("not configured status = %d, want 503; body=%s", missingAccountManager.Code, missingAccountManager.Body.String())
 	}
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3453,6 +3453,72 @@ func TestPlatformAdminReadModelsUseAccountManagerAdminInventory(t *testing.T) {
 	}
 }
 
+func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer admin-access" {
+			t.Fatalf("%s Authorization = %q, want Bearer admin-access", r.URL.Path, got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds":
+			w.WriteHeader(http.StatusCreated)
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds":
+			_ = json.NewEncoder(w).Encode(map[string]any{"brand_clouds": []map[string]any{{"id": "brand-1", "name": "Realtek Connect+", "organization_kind": "brand_cloud", "status": "active"}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	upstreamSession, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "admin-access", "admin-refresh", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession platform_admin returned error: %v", err)
+	}
+	breakGlassSession, err := st.CreateSession("platform_admin", "break-glass", "break@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession break-glass returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config:        config.Config{AccountManagerBaseURL: accountUpstream.URL},
+		AccountClient: accountclient.New(accountUpstream.URL),
+	})
+
+	create := httptest.NewRecorder()
+	createReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds", strings.NewReader(`{"name":"Realtek Connect+"}`))
+	createReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
+	srv.ServeHTTP(create, createReq)
+	if create.Code != http.StatusCreated {
+		t.Fatalf("brand cloud create status = %d, want 201; body=%s", create.Code, create.Body.String())
+	}
+
+	list := httptest.NewRecorder()
+	listReq := httptest.NewRequest(http.MethodGet, "/api/admin/brand-clouds", nil)
+	listReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
+	srv.ServeHTTP(list, listReq)
+	if list.Code != http.StatusOK {
+		t.Fatalf("brand cloud list status = %d, want 200; body=%s", list.Code, list.Body.String())
+	}
+
+	blocked := httptest.NewRecorder()
+	blockedReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds", strings.NewReader(`{"name":"Blocked"}`))
+	blockedReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: breakGlassSession.ID})
+	srv.ServeHTTP(blocked, blockedReq)
+	if blocked.Code != http.StatusForbidden {
+		t.Fatalf("break-glass brand cloud create status = %d, want 403; body=%s", blocked.Code, blocked.Body.String())
+	}
+}
+
 func TestPlatformAdminReadModelsSurfaceUpstreamFailure(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Adds Account Manager client helpers for brand-cloud management.
- Adds backend/BFF routes under /api/admin/brand-clouds.
- Requires Account Manager-backed platform-admin sessions; local break-glass-only sessions are rejected.
- Syncs nested contracts pointer to the brand-cloud contract PR commit.

## Validation
- go test ./...
- git diff --check

## Dependency
- Depends on hkt999rtk/rtk_cloud_contracts_doc PR and hkt999rtk/rtk_account_manager brand-cloud API PR.