### PR TITLE
Support workspace deployment secrets directory

### DIFF
--- a/deploy/linode/README.md
+++ b/deploy/linode/README.md
@@ -60,14 +60,18 @@ Remote Admin VM:
 ## 1. Prepare Local Env
 
 ```sh
-cp deploy/linode/admin-staging.env.example deploy/linode/admin-staging.env
-$EDITOR deploy/linode/admin-staging.env
-set -a
-. deploy/linode/admin-staging.env
-set +a
+export WORKSPACE=/path/to/rtk_cloud_workspace
+export DEPLOY_SECRETS_DIR="$WORKSPACE/.secrets/staging/linode/admin"
+mkdir -p "$DEPLOY_SECRETS_DIR"/{env,state}
+cp deploy/linode/admin-staging.env.example "$DEPLOY_SECRETS_DIR/env/admin-staging.env"
+$EDITOR "$DEPLOY_SECRETS_DIR/env/admin-staging.env"
 ```
 
-Do not commit the copied env file. It contains deployment secrets.
+When `DEPLOY_SECRETS_DIR` is set, the Linode scripts source
+`$DEPLOY_SECRETS_DIR/env/admin-staging.env` and write/read state under
+`$DEPLOY_SECRETS_DIR/state/`. The legacy `deploy/linode/*.env` and
+`deploy/linode/*.state` paths remain supported for standalone repo usage. Do
+not commit the copied env file. It contains deployment secrets.
 
 ## 2. Provision VM
 
@@ -78,7 +82,7 @@ deploy/linode/provision-admin-vm.sh
 The script writes a local ignored state file such as:
 
 ```text
-deploy/linode/rtk-cloud-admin-staging.state
+$DEPLOY_SECRETS_DIR/state/rtk-cloud-admin-staging.state
 ```
 
 Create the DNS A record printed by the script before running the deploy step.
@@ -86,10 +90,8 @@ Create the DNS A record printed by the script before running the deploy step.
 ## 3. Deploy App
 
 ```sh
-set -a
-. deploy/linode/admin-staging.env
-. deploy/linode/rtk-cloud-admin-staging.state
-set +a
+export WORKSPACE=/path/to/rtk_cloud_workspace
+export DEPLOY_SECRETS_DIR="$WORKSPACE/.secrets/staging/linode/admin"
 
 deploy/linode/deploy-admin.sh
 ```
@@ -118,10 +120,8 @@ the Docker image tag `rtk-cloud-admin:<version>`.
 ## 4. Verify
 
 ```sh
-set -a
-. deploy/linode/admin-staging.env
-. deploy/linode/rtk-cloud-admin-staging.state
-set +a
+export WORKSPACE=/path/to/rtk_cloud_workspace
+export DEPLOY_SECRETS_DIR="$WORKSPACE/.secrets/staging/linode/admin"
 
 deploy/linode/verify-admin.sh
 ```
@@ -138,10 +138,8 @@ Artifacts are written to `.artifacts/linode-admin-verify/` and are not tracked.
 ## Backup
 
 ```sh
-set -a
-. deploy/linode/admin-staging.env
-. deploy/linode/rtk-cloud-admin-staging.state
-set +a
+export WORKSPACE=/path/to/rtk_cloud_workspace
+export DEPLOY_SECRETS_DIR="$WORKSPACE/.secrets/staging/linode/admin"
 
 deploy/linode/backup-admin-db.sh
 ```

--- a/deploy/linode/admin-staging.env.example
+++ b/deploy/linode/admin-staging.env.example
@@ -1,6 +1,6 @@
-# Copy to a local ignored env file before deploying, for example:
-#   cp deploy/linode/admin-staging.env.example deploy/linode/admin-staging.env
-#   set -a; . deploy/linode/admin-staging.env; set +a
+# Copy to $DEPLOY_SECRETS_DIR/env/admin-staging.env before deploying, for example:
+#   export DEPLOY_SECRETS_DIR="$WORKSPACE/.secrets/staging/linode/admin"
+#   cp deploy/linode/admin-staging.env.example "$DEPLOY_SECRETS_DIR/env/admin-staging.env"
 # Do not commit real secrets.
 
 # Linode host and DNS.

--- a/deploy/linode/backup-admin-db.sh
+++ b/deploy/linode/backup-admin-db.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+load_secret_env() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$file"
+    set +a
+  fi
+}
+
+if [ -n "${DEPLOY_SECRETS_DIR:-}" ]; then
+  [ -d "$DEPLOY_SECRETS_DIR" ] || { printf 'error: DEPLOY_SECRETS_DIR not found: %s\n' "$DEPLOY_SECRETS_DIR" >&2; exit 1; }
+  load_secret_env "$DEPLOY_SECRETS_DIR/env/admin-staging.env"
+  load_secret_env "$DEPLOY_SECRETS_DIR/state/${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}.state"
+fi
+
 admin_host="${ADMIN_LINODE_HOST:-${ADMIN_LINODE_PUBLIC_IPV4:-}}"
 ssh_user="${ADMIN_LINODE_SSH_USER:-root}"
 ssh_key="${ADMIN_LINODE_SSH_KEY:-$HOME/.ssh/id_ed25519_rtkcloud}"

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -2,6 +2,23 @@
 set -euo pipefail
 
 root_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+load_secret_env() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$file"
+    set +a
+  fi
+}
+
+if [ -n "${DEPLOY_SECRETS_DIR:-}" ]; then
+  [ -d "$DEPLOY_SECRETS_DIR" ] || { printf 'error: DEPLOY_SECRETS_DIR not found: %s\n' "$DEPLOY_SECRETS_DIR" >&2; exit 1; }
+  load_secret_env "$DEPLOY_SECRETS_DIR/env/admin-staging.env"
+  load_secret_env "$DEPLOY_SECRETS_DIR/state/${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}.state"
+fi
+
 label="${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}"
 release_bundle="${ADMIN_LINODE_RELEASE_BUNDLE:-}"
 bundle_release=""

--- a/deploy/linode/provision-admin-vm.sh
+++ b/deploy/linode/provision-admin-vm.sh
@@ -1,6 +1,21 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+load_secret_env() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$file"
+    set +a
+  fi
+}
+
+if [ -n "${DEPLOY_SECRETS_DIR:-}" ]; then
+  [ -d "$DEPLOY_SECRETS_DIR" ] || { printf 'error: DEPLOY_SECRETS_DIR not found: %s\n' "$DEPLOY_SECRETS_DIR" >&2; exit 1; }
+  load_secret_env "$DEPLOY_SECRETS_DIR/env/admin-staging.env"
+fi
+
 label="${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}"
 region="${ADMIN_LINODE_REGION:-us-sea}"
 type="${ADMIN_LINODE_TYPE:-g6-standard-2}"
@@ -8,7 +23,8 @@ image="${ADMIN_LINODE_IMAGE:-linode/ubuntu24.04}"
 public_key_path="${ADMIN_LINODE_PUBLIC_KEY_PATH:-$HOME/.ssh/id_ed25519_rtkcloud.pub}"
 allowed_ssh_cidrs="${ADMIN_LINODE_ALLOWED_SSH_CIDRS:-}"
 firewall_label="${ADMIN_LINODE_FIREWALL_LABEL:-${label}-firewall}"
-state_path="${ADMIN_LINODE_STATE_PATH:-deploy/linode/${label}.state}"
+default_state_path="${DEPLOY_SECRETS_DIR:+$DEPLOY_SECRETS_DIR/state/${label}.state}"
+state_path="${ADMIN_LINODE_STATE_PATH:-${default_state_path:-deploy/linode/${label}.state}}"
 
 die() {
   printf 'error: %s\n' "$*" >&2

--- a/deploy/linode/verify-admin.sh
+++ b/deploy/linode/verify-admin.sh
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+load_secret_env() {
+  local file="$1"
+  if [ -f "$file" ]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$file"
+    set +a
+  fi
+}
+
+if [ -n "${DEPLOY_SECRETS_DIR:-}" ]; then
+  [ -d "$DEPLOY_SECRETS_DIR" ] || { printf 'error: DEPLOY_SECRETS_DIR not found: %s\n' "$DEPLOY_SECRETS_DIR" >&2; exit 1; }
+  load_secret_env "$DEPLOY_SECRETS_DIR/env/admin-staging.env"
+  load_secret_env "$DEPLOY_SECRETS_DIR/state/${ADMIN_LINODE_LABEL:-rtk-cloud-admin-staging}.state"
+fi
+
 base_url="${ADMIN_LINODE_BASE_URL:-}"
 if [ -z "$base_url" ]; then
   domain="${ADMIN_LINODE_DOMAIN:-}"


### PR DESCRIPTION
## Summary
- load Linode deployment env/state from DEPLOY_SECRETS_DIR when set
- keep deploy/linode/*.env and deploy/linode/*.state as legacy fallback paths
- update Linode runbook/template comments to use workspace .secrets layout

## Validation
- bash -n deploy/linode/*.sh
- go test ./...
- git diff --check

## Notes
- No secret values are added or moved in this PR.
- This follows rtk_cloud_workspace/docs/deployment-secrets-governance.md.