### PR TITLE
Honor Video Cloud readiness facts

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -243,6 +243,24 @@ Operation states:
 - `retrying`
 - `dead_lettered`
 
+Production-mode readiness precedence:
+
+- Account Manager owns registry, organization membership, account status, and
+  lifecycle operation state.
+- Video Cloud owns cloud activation and current transport online facts whenever
+  `VIDEO_CLOUD_BASE_URL` and `VIDEO_CLOUD_ADMIN_TOKEN` are configured.
+- `online` requires both Video Cloud activation and current Video Cloud
+  transport evidence; `DeviceProvisionSucceeded` or Account Manager
+  `status=online` is not enough.
+- Activated devices with missing or stale Video Cloud transport are shown as
+  `activated`, with `transport_online` exposed as a missing/stale source fact.
+- Missing `video_cloud_devid`, unavailable Video Cloud facts, authorization
+  failures, stale data, or partial device-info/transport responses are surfaced
+  as readiness gaps instead of being treated as activation success.
+- Demo/cache mode remains available when upstream services are not configured,
+  but its source facts are local projections and are not authoritative
+  production readiness.
+
 ## Configuration
 
 Environment variables:

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.6% |
+| Go total coverage | 80.5% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,9 +28,9 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 89.6% |
-| `rtk_cloud_admin/internal/app` | 80.3% |
+| `rtk_cloud_admin/internal/app` | 80.1% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
-| `rtk_cloud_admin/internal/readinessfacts` | 85.4% |
+| `rtk_cloud_admin/internal/readinessfacts` | 86.0% |
 | `rtk_cloud_admin/internal/store` | 80.1% |
 | `rtk_cloud_admin/internal/videoclient` | 86.3% |
 

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -196,6 +196,10 @@ Behavior notes:
 - Customer users must not see out-of-org devices.
 - Platform admin data must not leak through the Customer View device drawer or
   customer API payloads.
+- In production mode, readiness badges and fleet counts must use the API's
+  source-attributed readiness projection: Account Manager owns registry and
+  lifecycle operations, while Video Cloud owns activation and current transport.
+  Demo/cache facts must remain visibly local projections.
 - Filters must preserve table scan speed and avoid card-wall layouts.
 - Read-only Observer sessions must be enforced by the backend before any
   provision or deactivate action is accepted.

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3476,6 +3476,8 @@ func mapUpstreamDevice(org accountclient.Organization, device accountclient.Devi
 	status := fallback(device.Status, metadataString(device.Metadata, "status", "unknown"))
 	videoID := fallback(device.VideoCloudDevID, metadataString(device.Metadata, "video_cloud_devid", ""))
 	updatedAt := fallback(device.UpdatedAt, now)
+	latestOp := upstreamOperationFromMetadata(device, updatedAt)
+	readiness = authoritativeReadiness(readiness, videoID, latestOp, vcFacts)
 	mapped := contracts.Device{
 		ID:              device.ID,
 		OrganizationID:  fallback(device.OrganizationID, org.ID),
@@ -3494,8 +3496,41 @@ func mapUpstreamDevice(org accountclient.Organization, device accountclient.Devi
 		LastSeenAt: fallback(device.LastSeenAt, metadataString(device.Metadata, "last_seen_at", "")),
 		UpdatedAt:  updatedAt,
 	}
-	mapped.SourceFacts = readinessfacts.Build(mapped, upstreamOperationFromMetadata(device, updatedAt), vcFacts)
+	mapped.SourceFacts = readinessfacts.Build(mapped, latestOp, vcFacts)
 	return mapped
+}
+
+func authoritativeReadiness(readiness contracts.ReadinessState, videoID string, latestOp *contracts.Operation, vcFacts *readinessfacts.VideoCloudFacts) contracts.ReadinessState {
+	switch readiness {
+	case contracts.ReadinessFailed, contracts.ReadinessDeactivationPending, contracts.ReadinessDeactivated:
+		return readiness
+	case contracts.ReadinessClaimPending, contracts.ReadinessLocalOnboardingPending:
+		return readiness
+	}
+	if latestOp != nil {
+		switch latestOp.State {
+		case contracts.OperationPending, contracts.OperationPublished, contracts.OperationRetrying:
+			return contracts.ReadinessCloudActivationPending
+		case contracts.OperationFailed, contracts.OperationDeadLettered:
+			return contracts.ReadinessFailed
+		}
+	}
+	if vcFacts == nil {
+		return readiness
+	}
+	if videoID == "" {
+		if readiness == contracts.ReadinessActivated || readiness == contracts.ReadinessOnline {
+			return contracts.ReadinessRegistered
+		}
+		return readiness
+	}
+	if !vcFacts.Activated {
+		return contracts.ReadinessCloudActivationPending
+	}
+	if vcFacts.Transport == "" {
+		return contracts.ReadinessActivated
+	}
+	return contracts.ReadinessOnline
 }
 
 func upstreamOperationFromMetadata(device accountclient.Device, fallbackUpdatedAt string) *contracts.Operation {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1098,6 +1098,112 @@ func TestCustomerDevicesReportVideoCloudActivationFailures(t *testing.T) {
 	}
 }
 
+func TestCustomerDevicesUseVideoCloudTransportForOnlineReadiness(t *testing.T) {
+	t.Parallel()
+
+	accountUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/auth/login":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"customer@example.com","name":"Customer"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+		case "/v1/me":
+			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"customer@example.com","name":"Customer"},"organizations":[{"id":"org-acme","name":"Acme Smart Camera","role":"owner"}]}`))
+		case "/v1/orgs":
+			_, _ = w.Write([]byte(`{"organizations":[{"id":"org-acme","name":"Acme Smart Camera","role":"owner"}]}`))
+		case "/v1/orgs/org-acme/devices":
+			_, _ = w.Write([]byte(`{"devices":[{"id":"dev-002","name":"cam-a-002","model":"RTK-CAM-A","serial_number":"ACME-A-002","readiness":"online","status":"online","video_cloud_devid":"device-2","last_seen_at":"2026-05-01T10:00:00Z"}]}`))
+		default:
+			t.Fatalf("unexpected account path: %s", r.URL.Path)
+		}
+	}))
+	defer accountUpstream.Close()
+
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/query_camera_activate":
+			if got := r.Header.Get("Authorization"); got != "Bearer vc-secret" {
+				t.Fatalf("query activation Authorization = %q, want Bearer vc-secret", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status":  "ok",
+				"devices": []string{"1"},
+			})
+		case "/get_camera_info":
+			if got := r.Header.Get("Authorization"); got != "Bearer vc-secret" {
+				t.Fatalf("camera info Authorization = %q, want Bearer vc-secret", got)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"status": "ok",
+				"info":   map[string]any{"current_transport": ""},
+			})
+		default:
+			t.Fatalf("unexpected video path: %s", r.URL.Path)
+		}
+	}))
+	defer videoUpstream.Close()
+
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatalf("Open returned error: %v", err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatalf("Migrate returned error: %v", err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatalf("SeedDemoData returned error: %v", err)
+	}
+
+	srv := NewWithOptions(st, Options{
+		Config: config.Config{
+			AccountManagerBaseURL:              accountUpstream.URL,
+			LegacyCustomerPasswordLoginEnabled: true,
+			VideoCloudBaseURL:                  videoUpstream.URL,
+			VideoCloudAdminToken:               "vc-secret",
+		},
+		AccountClient: accountclient.New(accountUpstream.URL),
+		VideoClient:   videoclient.New(videoUpstream.URL),
+	})
+
+	login := httptest.NewRecorder()
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"customer@example.com","password":"secret"}`)))
+	if login.Code != http.StatusOK {
+		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
+	}
+	cookie := login.Result().Cookies()[0]
+
+	devices := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/devices", nil)
+	req.AddCookie(cookie)
+	srv.ServeHTTP(devices, req)
+	if devices.Code != http.StatusOK {
+		t.Fatalf("devices status = %d, body=%s", devices.Code, devices.Body.String())
+	}
+	if strings.Contains(devices.Body.String(), "vc-secret") {
+		t.Fatalf("devices response leaked Video Cloud token: %s", devices.Body.String())
+	}
+
+	var payload []contracts.CustomerDevice
+	if err := json.NewDecoder(devices.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode devices response: %v", err)
+	}
+	if len(payload) != 1 {
+		t.Fatalf("devices length = %d, want 1", len(payload))
+	}
+	if payload[0].Readiness != contracts.ReadinessActivated {
+		t.Fatalf("readiness = %q, want %q", payload[0].Readiness, contracts.ReadinessActivated)
+	}
+	var transport contracts.CustomerSourceFact
+	for _, fact := range payload[0].SourceFacts {
+		if fact.Layer == "Transport Online" {
+			transport = fact
+			break
+		}
+	}
+	if transport.State != "missing" {
+		t.Fatalf("transport fact = %#v, want missing", transport)
+	}
+}
+
 func TestCustomerLoginSurvivesProfileRetryFailure(t *testing.T) {
 	t.Parallel()
 

--- a/internal/readinessfacts/facts.go
+++ b/internal/readinessfacts/facts.go
@@ -124,14 +124,19 @@ func transportOnlineFact(device contracts.Device, fallbackUpdatedAt string, vcFa
 	}
 
 	// Video Cloud transport is authoritative; use it regardless of LastSeenAt.
-	if vcFacts != nil && vcFacts.Transport != "" {
+	if vcFacts != nil {
 		ts := fallbackUpdatedAt
 		if vcFacts.UpdatedAt != "" {
 			ts = vcFacts.UpdatedAt
 		}
-		fact.State = "present"
-		fact.Detail = "Video Cloud transport: " + vcFacts.Transport + "."
 		fact.UpdatedAt = ts
+		if vcFacts.Transport != "" {
+			fact.State = "present"
+			fact.Detail = "Video Cloud transport: " + vcFacts.Transport + "."
+			return fact
+		}
+		fact.State = "missing"
+		fact.Detail = "Video Cloud has no current transport evidence."
 		return fact
 	}
 

--- a/internal/readinessfacts/facts_test.go
+++ b/internal/readinessfacts/facts_test.go
@@ -132,7 +132,7 @@ func TestBuildSourceFacts(t *testing.T) {
 				Activated: false,
 				UpdatedAt: "2026-05-01T10:05:00Z",
 			},
-			wantStates:    []string{"present", "stale", "present"},
+			wantStates:    []string{"present", "stale", "missing"},
 			wantRetryable: true,
 		},
 		{
@@ -150,8 +150,7 @@ func TestBuildSourceFacts(t *testing.T) {
 				Transport: "",
 				UpdatedAt: "2026-05-01T10:05:00Z",
 			},
-			// transport falls back to inferred "stale" (status=offline, no VC transport)
-			wantStates: []string{"present", "present", "stale"},
+			wantStates: []string{"present", "present", "missing"},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Apply production-mode readiness precedence so Video Cloud activation and transport facts determine whether a device is `activated` or `online`.
- Treat missing Video Cloud transport as a readiness gap instead of falling back to Account Manager last-seen/status evidence.
- Document production readiness source ownership and demo/cache-mode caveats.

Closes #129

## Tests
- `go test ./internal/readinessfacts`
- `go test ./internal/app -run 'TestCustomerDevicesUseVideoCloudTransportForOnlineReadiness|TestCustomerDevicesReportVideoCloudActivationFailures' -count=1`
- `go test ./...`
- `npm test -- --run` (from `web`)
- `npm run build` (from `web`)
- `git diff --check`
- `go build ./cmd/server`
