### PR TITLE
[codex] Accept Object Storage admin release bundles

### DIFF
--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -24,13 +24,21 @@ release_bundle="${ADMIN_LINODE_RELEASE_BUNDLE:-}"
 bundle_release=""
 if [ -n "$release_bundle" ]; then
   release_name="$(basename "$release_bundle")"
+  release_parent="$(basename "$(dirname "$release_bundle")")"
   case "$release_name" in
     rtk_cloud_admin-*.tar.gz)
       bundle_release="${release_name#rtk_cloud_admin-}"
       bundle_release="${bundle_release%.tar.gz}"
       ;;
+    *.tar.gz)
+      bundle_release="${release_name%.tar.gz}"
+      if [ "$release_parent" != "rtk_cloud_admin-$bundle_release" ]; then
+        printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz or stored as rtk_cloud_admin-<version>/<version>.tar.gz\n' >&2
+        exit 1
+      fi
+      ;;
     *)
-      printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz\n' >&2
+      printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz or stored as rtk_cloud_admin-<version>/<version>.tar.gz\n' >&2
       exit 1
       ;;
   esac


### PR DESCRIPTION
## Summary

- accept the Linode Object Storage admin release layout `rtk_cloud_admin-<version>/<version>.tar.gz`
- keep support for locally packaged `rtk_cloud_admin-<version>.tar.gz` bundles
- preserve the release/version mismatch guard before deployment

## Root Cause

The release workflow uploads the bundle under a prefixed release directory and stores the object filename as `<version>.tar.gz`, while `deploy-admin.sh` only accepted local package filenames named `rtk_cloud_admin-<version>.tar.gz`. Staging deploy downloaded the valid Object Storage artifact, then failed before SSH deploy.

## Validation

- `bash -n deploy/linode/deploy-admin.sh`
- fake `ssh`/`scp` deploy preflight with `rtk_cloud_admin-admin-staging-20260527T134313Z-0ed21a6/admin-staging-20260527T134313Z-0ed21a6.tar.gz`
- live staging rerun passed Cloud Admin deploy, verify, and e2e smoke checks
