### PR TITLE
[codex] Remove GitHub artifact uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,22 +145,6 @@ jobs:
           scripts/generate_test_report.sh coverage.out .artifacts/logs .artifacts/report-candidates/docs/TEST_REPORT.md
           scripts/validate_test_report.sh .artifacts/report-candidates/docs/TEST_REPORT.md
 
-      - name: Upload test report candidate
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: test-report-candidate
-          path: .artifacts/report-candidates/
-
-      - name: Upload CI diagnostics
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: ci-diagnostics
-          path: |
-            .artifacts/logs/
-            coverage.out
-
       - name: Check tracked test report drift
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,18 +113,6 @@ jobs:
           go run ./cmd/s3put --file "$checksum" --key "$prefix/$VERSION.tar.gz.sha256"
           go run ./cmd/s3put --file "$manifest" --key "$prefix/manifest.json"
 
-      - name: Upload workflow artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ steps.version.outputs.artifact_name }}
-          path: |
-            dist/rtk_cloud_admin-${{ steps.version.outputs.version }}
-            dist/rtk_cloud_admin-${{ steps.version.outputs.version }}.tar.gz
-            dist/${{ steps.version.outputs.version }}.tar.gz
-            dist/${{ steps.version.outputs.version }}.tar.gz.sha256
-            dist/${{ steps.version.outputs.version }}.object-manifest.json
-          if-no-files-found: error
-
       - name: Publish GitHub release
         if: startsWith(github.ref, 'refs/tags/')
         env:


### PR DESCRIPTION
## Summary

- remove every `actions/upload-artifact` step from GitHub Actions workflows
- keep release bundle publication on Linode Object Storage as the authoritative artifact path
- avoid GitHub artifact quota affecting CI/release outcomes

## Validation

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f); puts f }'`
- `git diff --check`
- workspace-wide `rg "actions/upload-artifact|upload-artifact"` returned no matches
