### PR TITLE
Enable manual CI dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary\n- Add workflow_dispatch to the ci workflow so it can be manually triggered for tag or branch refs.\n\n## Validation\n- git diff --check -- .github/workflows/ci.yml