### PR TITLE
Finish WebUI foundation route guards

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,6 +1,15 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { customerNavItems, devicesPathWithFilters, platformNavItems, routeFromLocation, titleFor } from './routes.mjs';
+import {
+  customerNavItems,
+  devicesPathWithFilters,
+  isPlatformRouteId,
+  isPublicRouteId,
+  navItemsForRoute,
+  platformNavItems,
+  routeFromLocation,
+  titleFor,
+} from './routes.mjs';
 import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 import { quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
 import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
@@ -32,9 +41,9 @@ function App() {
   const [error, setError] = useState('');
   const [refreshTick, setRefreshTick] = useState(0);
   const [loading, setLoading] = useState(true);
-  const isPublicRoute = active === 'signup' || active === 'signup-check-email' || active === 'verify';
-  const isPlatformView = active.startsWith('platform');
-  const visibleNavItems = isPlatformView ? platformNavItems : customerNavItems;
+  const isPublicRoute = isPublicRouteId(active);
+  const isPlatformView = isPlatformRouteId(active);
+  const visibleNavItems = navItemsForRoute(active);
   const needsPlatformAccess = isPlatformView && me?.kind !== 'platform_admin';
   const customerViewPending = !isPlatformView && !isPublicRoute && me === null;
   const customerViewBlocked = !isPlatformView && !isPublicRoute && me !== null && (me.authenticated === false || me.kind === 'platform_admin');
@@ -1307,20 +1316,6 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
       ) : (
         <p className="empty-state">{unavailableText}</p>
       )}
-    </section>
-  );
-}
-
-function GroupsPage() {
-  return (
-    <section className="panel">
-      <div className="panel-head">
-        <div>
-          <h2>Groups</h2>
-          <p>Customer group management and membership assignment will be added here.</p>
-        </div>
-      </div>
-      <p className="placeholder-subtitle">Placeholder area for customer group workspace.</p>
     </section>
   );
 }

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -12,6 +12,21 @@ export const platformNavItems = [
   { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
 ];
 
+const publicRouteIds = new Set(['signup', 'signup-check-email', 'verify']);
+
+export function isPublicRouteId(route) {
+  return publicRouteIds.has(route);
+}
+
+export function isPlatformRouteId(route) {
+  return String(route || '').startsWith('platform');
+}
+
+export function navItemsForRoute(route) {
+  if (isPublicRouteId(route)) return [];
+  return isPlatformRouteId(route) ? platformNavItems : customerNavItems;
+}
+
 export function titleFor(active) {
   return {
     signup: 'Sign up',

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -1,6 +1,15 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { customerNavItems, devicesPathWithFilters, routeFromPath, titleFor } from './routes.mjs';
+import {
+  customerNavItems,
+  devicesPathWithFilters,
+  isPlatformRouteId,
+  isPublicRouteId,
+  navItemsForRoute,
+  platformNavItems,
+  routeFromPath,
+  titleFor,
+} from './routes.mjs';
 
 test('maps platform shell paths to platform routes', () => {
   assert.equal(routeFromPath('/admin'), 'platform-health');
@@ -24,9 +33,11 @@ test('maps customer shell paths to customer routes', () => {
   assert.equal(routeFromPath('/console/devices'), 'devices');
   assert.equal(routeFromPath('/console/customers'), 'overview');
   assert.equal(routeFromPath('/console/operations'), 'overview');
+  assert.equal(routeFromPath('/console/operations/history'), 'overview');
   assert.equal(routeFromPath('/console/firmware-ota'), 'firmware-ota');
   assert.equal(routeFromPath('/console/stream-health'), 'stream-health');
   assert.equal(routeFromPath('/console/groups'), 'overview');
+  assert.equal(routeFromPath('/console/groups/legacy'), 'overview');
 });
 
 test('customer nav follows the approved Customer View design order', () => {
@@ -34,6 +45,35 @@ test('customer nav follows the approved Customer View design order', () => {
     customerNavItems.map((item) => item.label),
     ['Overview', 'Devices', 'Firmware & OTA', 'Stream Health'],
   );
+});
+
+test('retired customer pages are not exposed in section navigation', () => {
+  const customerLabels = customerNavItems.map((item) => item.label);
+  const platformLabels = platformNavItems.map((item) => item.label);
+
+  assert.equal(customerLabels.includes('Groups'), false);
+  assert.equal(customerLabels.includes('Customers'), false);
+  assert.equal(customerLabels.includes('Operations'), false);
+  assert.equal(platformLabels.includes('Groups'), false);
+  assert.equal(platformLabels.includes('Customers'), false);
+});
+
+test('public auth routes stay outside Customer and Platform section navigation', () => {
+  for (const route of ['signup', 'signup-check-email', 'verify']) {
+    assert.equal(isPublicRouteId(route), true, route);
+    assert.equal(isPlatformRouteId(route), false, route);
+    assert.deepEqual(navItemsForRoute(route), []);
+  }
+});
+
+test('route classification selects the separated view navigation', () => {
+  assert.equal(isPublicRouteId('overview'), false);
+  assert.equal(isPlatformRouteId('overview'), false);
+  assert.deepEqual(navItemsForRoute('overview'), customerNavItems);
+
+  assert.equal(isPublicRouteId('platform-sso'), false);
+  assert.equal(isPlatformRouteId('platform-sso'), true);
+  assert.deepEqual(navItemsForRoute('platform-sso'), platformNavItems);
 });
 
 test('builds devices URLs with supported filters only', () => {


### PR DESCRIPTION
## Summary
- centralize public/platform/customer route classification for the WebUI shell
- keep public auth routes outside Customer/Platform navigation and retired customer paths routed to overview
- remove the unused Groups placeholder component so it cannot be exposed accidentally

Closes #143

## Tests
- cd web && npm test
- cd web && npm run build
- git diff --check