### PR TITLE
Add Customer View source-aware states

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -14,7 +14,13 @@ import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs
 import { quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
 import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
 import { firmwareCampaignDetailRows, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
-import { sourceAvailable, sourceMessage } from './source-state.mjs';
+import {
+  sourceAvailable,
+  sourceMessage,
+  sourceStateForPanel,
+  sourceUnavailableFromError,
+  telemetrySourceState,
+} from './source-state.mjs';
 import { streamWorstDeviceRows } from './stream.mjs';
 import './styles.css';
 
@@ -129,7 +135,11 @@ function App() {
           setSSOProviders([]);
         }
         if (active === 'firmware-ota' && nextMe.kind !== 'platform_admin') {
-          const nextFirmwareDistribution = await fetchJSON('/api/fleet/firmware-distribution');
+          const nextFirmwareDistribution = await fetchJSON('/api/fleet/firmware-distribution')
+            .catch((err) => {
+              if (err.isAuthError) throw err;
+              return sourceUnavailableFromError('firmware', err);
+            });
           if (!alive) return;
           setFirmwareDistribution(nextFirmwareDistribution);
         } else {
@@ -139,13 +149,21 @@ function App() {
         if (nextMe.authenticated && nextMe.kind === 'customer' && !useAdminApi) {
           const streamWindowToUse = active === 'stream-health' ? streamWindow : overviewWindow;
           const [nextFleetHealth, nextStreamStats] = await Promise.all([
-            fetchJSON(`/api/fleet/health-summary?window=${overviewWindow}`),
-            fetchJSON(`/api/fleet/stream-stats?window=${streamWindowToUse}`),
+            fetchJSON(`/api/fleet/health-summary?window=${overviewWindow}`)
+              .catch((err) => {
+                if (err.isAuthError) throw err;
+                return sourceUnavailableFromError('telemetry', err);
+              }),
+            fetchJSON(`/api/fleet/stream-stats?window=${streamWindowToUse}`)
+              .catch((err) => {
+                if (err.isAuthError) throw err;
+                return sourceUnavailableFromError('stream', err);
+              }),
           ]);
           if (!alive) return;
           setFleetHealth(nextFleetHealth);
           setStreamStats(nextStreamStats);
-          if (active === 'overview') {
+          if (active === 'overview' && sourceAvailable(nextFleetHealth)) {
             const nextAlerts = await fetchRecentAlerts(nextDevices);
             if (!alive) return;
             setRecentAlerts(nextAlerts);
@@ -809,13 +827,27 @@ function Overview({
   const onlineCount = summary?.online_devices ?? '-';
   const telemetryAvailable = sourceAvailable(fleetHealth);
   const streamAvailable = sourceAvailable(streamStats);
+  const telemetryState = sourceStateForPanel({
+    loading,
+    source: fleetHealth,
+    hasData: Boolean(fleetHealth?.current || fleetHealth?.trend?.length),
+    category: 'telemetry',
+    fallbackMessage: 'No telemetry source configured.',
+  });
+  const streamState = sourceStateForPanel({
+    loading,
+    source: streamStats,
+    hasData: Boolean(streamStats?.trend?.length || streamStats?.active_sessions || streamStats?.worst_devices?.length),
+    category: 'stream',
+    fallbackMessage: 'No stream source configured.',
+  });
   const onlineRate = telemetryAvailable ? fleetHealth?.online_rate_7d_pct : null;
   const needsAttention = telemetryAvailable && (current.warning !== undefined || current.critical !== undefined)
     ? (current.warning || 0) + (current.critical || 0)
     : 'Unavailable';
   const activeStreams = streamAvailable ? (streamStats?.active_sessions ?? 0) : 'Unavailable';
-  const telemetryReason = sourceMessage(fleetHealth, 'No telemetry source configured.');
-  const streamReason = sourceMessage(streamStats, 'No stream source configured.');
+  const telemetryReason = telemetryState.message || sourceMessage(fleetHealth, 'No telemetry source configured.');
+  const streamReason = streamState.message || sourceMessage(streamStats, 'No stream source configured.');
   const attentionDevices = buildAttentionQueue(devices, recentAlerts);
 
   return (
@@ -829,7 +861,7 @@ function Overview({
         <MetricCard icon="ST" label="Active Streams" value={activeStreams} hint={streamAvailable ? `of ${summary?.total_devices ?? 0} devices` : streamReason} tone="info" />
       </section>
 
-      {!telemetryAvailable ? <SourceBlockedState title="Telemetry source unavailable" message={telemetryReason} /> : null}
+      {!telemetryAvailable ? <SourceBlockedState title={telemetryState.title} message={telemetryReason} /> : null}
 
       <section className="overview-grid">
         <FleetHealthTrendPanel
@@ -876,7 +908,15 @@ function FirmwareOTAPage({ loading, distribution, onViewDevices }) {
   const campaigns = distribution?.campaigns || [];
   const [selectedCampaignId, setSelectedCampaignId] = useState('');
   const available = sourceAvailable(distribution);
-  const unavailableText = sourceMessage(distribution, 'Firmware observation source is not configured.');
+  const pageState = sourceStateForPanel({
+    loading,
+    source: distribution,
+    hasData: Boolean(versions.length || campaigns.length),
+    category: 'firmware',
+    fallbackMessage: 'Firmware observation source is not configured.',
+    emptyMessage: 'No firmware distribution data available.',
+  });
+  const unavailableText = pageState.message || sourceMessage(distribution, 'Firmware observation source is not configured.');
   const totalDevices = versions.reduce((sum, version) => sum + (version.count || 0), 0);
   const activeCampaigns = campaigns.filter((campaign) => ['active', 'scheduled'].includes(String(campaign.state || '').toLowerCase())).length;
   const latestVersionRow = versions.find((version) => version.is_latest) || versions[0] || null;
@@ -904,7 +944,7 @@ function FirmwareOTAPage({ loading, distribution, onViewDevices }) {
       </section>
 
       {loading && !distribution ? <p className="empty-state">Loading firmware distribution.</p> : null}
-      {distribution && !available ? <SourceBlockedState title="Firmware source unavailable" message={unavailableText} /> : null}
+      {distribution && !available ? <SourceBlockedState title={pageState.title} message={unavailableText} /> : null}
 
       {distribution && available ? (
         <>
@@ -1145,7 +1185,15 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
   const worstDevices = streamWorstDeviceRows(stats?.worst_devices || []);
   const byMode = stats?.by_mode || {};
   const available = sourceAvailable(stats);
-  const unavailableText = sourceMessage(stats, 'WebRTC session event source is not configured.');
+  const pageState = sourceStateForPanel({
+    loading,
+    source: stats,
+    hasData: Boolean(trend.length || worstDevices.length || stats?.active_sessions),
+    category: 'stream',
+    fallbackMessage: 'WebRTC session event source is not configured.',
+    emptyMessage: 'No stream requests in selected window.',
+  });
+  const unavailableText = pageState.message || sourceMessage(stats, 'WebRTC session event source is not configured.');
   const windowLabel = String(streamWindow || '7d').toUpperCase();
   const chart = useMemo(() => buildStreamHealthChart(trend, modeTrends), [trend, modeTrends]);
   const kpis = [
@@ -1196,7 +1244,7 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
         ))}
       </section>
 
-      {!available && stats ? <SourceBlockedState title="Stream source unavailable" message={unavailableText} /> : null}
+      {!available && stats ? <SourceBlockedState title={pageState.title} message={unavailableText} /> : null}
 
       {loading && !stats ? (
         <p className="empty-state">Loading stream health data.</p>
@@ -2139,7 +2187,8 @@ function DeviceDrawer({ device, telemetry, loading, error, readOnly, capabilitie
   const drawerLastSeen = telemetry?.last_seen_at || device?.last_seen_at || '';
   const drawerFirmware = telemetry?.firmware_version || device?.firmware_version || '—';
   const telemetryAvailable = telemetry?.telemetry_status === 'available';
-  const telemetryUnavailableText = telemetry?.unavailable_reason || error || 'Telemetry source is unavailable for this device.';
+  const telemetryState = telemetrySourceState({ telemetry, loading, error });
+  const telemetryUnavailableText = telemetryState.message || 'Telemetry source is unavailable for this device.';
   const streamStatus = deriveStreamStatus(telemetry);
   const actionContext = { readOnly, capabilities, telemetryStatus: telemetry?.telemetry_status };
   const provisionState = deviceActionState(device, 'provision', actionContext);
@@ -2189,7 +2238,7 @@ function DeviceDrawer({ device, telemetry, loading, error, readOnly, capabilitie
             {loading ? <p className="empty-state">Loading telemetry for this device.</p> : null}
             {!loading && (error || (telemetry && !telemetryAvailable)) ? (
               <section className="drawer-unavailable">
-                <strong>Telemetry unavailable</strong>
+                <strong>{telemetryState.title}</strong>
                 <p>{telemetryUnavailableText}</p>
               </section>
             ) : null}

--- a/web/src/source-state.mjs
+++ b/web/src/source-state.mjs
@@ -1,10 +1,26 @@
+const sourceLabels = {
+  telemetry: 'Telemetry',
+  firmware: 'Firmware',
+  stream: 'Stream',
+  source: 'Source',
+};
+
+const sensitiveSourcePatterns = [
+  /video_cloud_devid/i,
+  /operation_id/i,
+  /upstream_operation_id/i,
+  /raw_payload/i,
+  /dead_lettered/i,
+  /\{.*\}/,
+];
+
 export function sourceAvailable(source) {
   return source?.source_status === 'available';
 }
 
 export function sourceMessage(source, fallback) {
   if (!source) return fallback;
-  if (source.source_message) return source.source_message;
+  if (source.source_message) return sanitizeSourceMessage(source.source_message, fallback);
   switch (source.source_status) {
     case 'not_configured':
       return fallback;
@@ -17,4 +33,96 @@ export function sourceMessage(source, fallback) {
     default:
       return fallback;
   }
+}
+
+export function sourceUnavailableFromError(category = 'source', error) {
+  const label = sourceLabel(category);
+  return {
+    source_status: 'unavailable',
+    source_kind: category,
+    source_error: 'gateway',
+    source_message: `${label} source could not be reached.`,
+  };
+}
+
+export function sourceStateForPanel({
+  loading = false,
+  source = null,
+  hasData = false,
+  filtered = false,
+  error = '',
+  category = 'source',
+  emptyMessage,
+  filteredEmptyMessage,
+  fallbackMessage,
+} = {}) {
+  const label = sourceLabel(category);
+  const fallback = fallbackMessage || `${label} source is unavailable.`;
+  if (loading && !source && !error) {
+    return {
+      kind: 'loading',
+      title: `Loading ${label.toLowerCase()} data`,
+      message: `Loading ${label.toLowerCase()} data.`,
+    };
+  }
+  if (error) {
+    return {
+      kind: 'gateway-error',
+      title: `${label} gateway error`,
+      message: sanitizeSourceMessage(error, `${label} source could not be reached.`),
+    };
+  }
+  if (source?.source_error === 'gateway') {
+    return {
+      kind: 'gateway-error',
+      title: `${label} gateway error`,
+      message: sourceMessage(source, `${label} source could not be reached.`),
+    };
+  }
+  if (sourceAvailable(source)) {
+    if (hasData) {
+      return { kind: 'ready', title: `${label} source available`, message: sourceMessage(source, `${label} source available.`) };
+    }
+    if (filtered) {
+      return { kind: 'filtered-empty', title: 'No matching data', message: filteredEmptyMessage || 'No records match the current filters.' };
+    }
+    return { kind: 'empty', title: 'No data available', message: emptyMessage || 'No data is available for the selected window.' };
+  }
+  if (source?.source_status === 'no_data') {
+    return { kind: 'empty', title: 'No data available', message: sourceMessage(source, emptyMessage || 'No data is available for the selected window.') };
+  }
+  return {
+    kind: 'source-unavailable',
+    title: `${label} source unavailable`,
+    message: sourceMessage(source, fallback),
+  };
+}
+
+export function telemetrySourceState({ telemetry = null, loading = false, error = '' } = {}) {
+  const source = telemetry
+    ? {
+        source_status: telemetry.telemetry_status,
+        source_message: telemetry.unavailable_reason,
+      }
+    : null;
+  return sourceStateForPanel({
+    loading,
+    source,
+    hasData: telemetry?.telemetry_status === 'available',
+    error,
+    category: 'telemetry',
+    fallbackMessage: 'Telemetry source is unavailable for this device.',
+    emptyMessage: 'No telemetry samples are available for this device.',
+  });
+}
+
+function sourceLabel(category) {
+  return sourceLabels[category] || sourceLabels.source;
+}
+
+function sanitizeSourceMessage(message, fallback) {
+  const text = String(message || '').trim();
+  if (!text) return fallback;
+  if (sensitiveSourcePatterns.some((pattern) => pattern.test(text))) return fallback;
+  return text;
 }

--- a/web/src/source-state.test.mjs
+++ b/web/src/source-state.test.mjs
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { sourceAvailable, sourceMessage } from './source-state.mjs';
+import {
+  sourceAvailable,
+  sourceMessage,
+  sourceStateForPanel,
+  sourceUnavailableFromError,
+  telemetrySourceState,
+} from './source-state.mjs';
 
 test('sourceAvailable only treats available source status as available', () => {
   assert.equal(sourceAvailable({ source_status: 'available' }), true);
@@ -16,4 +22,57 @@ test('sourceMessage returns specific customer-safe copy for unavailable states',
   assert.equal(sourceMessage({ source_status: 'unavailable' }, 'Fallback'), 'Source is unavailable.');
   assert.equal(sourceMessage({ source_status: 'unauthorized' }, 'Fallback'), 'Session expired; please sign in again.');
   assert.equal(sourceMessage({ source_status: 'unavailable', source_message: 'Stream source is unavailable.' }, 'Fallback'), 'Stream source is unavailable.');
+});
+
+test('sourceMessage suppresses raw upstream and platform-only details', () => {
+  assert.equal(
+    sourceMessage(
+      { source_status: 'unavailable', source_message: 'video_cloud_devid=vc-123 operation_id=op-9 raw_payload={"dead_lettered":true}' },
+      'Telemetry source is unavailable.',
+    ),
+    'Telemetry source is unavailable.',
+  );
+  assert.equal(
+    sourceMessage({ source_status: 'unavailable', source_message: 'Gateway returned 502 for device stream.' }, 'Fallback'),
+    'Gateway returned 502 for device stream.',
+  );
+});
+
+test('sourceStateForPanel covers loading, empty, filtered-empty, unavailable, gateway-error, and ready states', () => {
+  assert.deepEqual(
+    sourceStateForPanel({ loading: true, source: null, hasData: false, category: 'telemetry' }),
+    { kind: 'loading', title: 'Loading telemetry data', message: 'Loading telemetry data.' },
+  );
+  assert.equal(sourceStateForPanel({ source: { source_status: 'available' }, hasData: true }).kind, 'ready');
+  assert.equal(sourceStateForPanel({ source: { source_status: 'available' }, hasData: false }).kind, 'empty');
+  assert.equal(sourceStateForPanel({ source: { source_status: 'available' }, hasData: false, filtered: true }).kind, 'filtered-empty');
+  assert.equal(sourceStateForPanel({ source: { source_status: 'no_data' }, hasData: false }).kind, 'empty');
+  assert.equal(sourceStateForPanel({ source: { source_status: 'unavailable' }, hasData: false }).kind, 'source-unavailable');
+  assert.equal(sourceStateForPanel({ error: 'GET /api/fleet/health-summary failed with 502', hasData: false }).kind, 'gateway-error');
+});
+
+test('sourceUnavailableFromError creates customer-safe gateway source objects', () => {
+  const source = sourceUnavailableFromError('stream', new Error('/api/fleet/stream-stats failed with 502 and video_cloud_devid=vc-secret'));
+  assert.equal(source.source_status, 'unavailable');
+  assert.equal(source.source_kind, 'stream');
+  assert.equal(sourceMessage(source, 'Fallback'), 'Stream source could not be reached.');
+});
+
+test('telemetrySourceState preserves drawer identity context during telemetry failures', () => {
+  assert.deepEqual(
+    telemetrySourceState({
+      telemetry: null,
+      loading: false,
+      error: 'operation_id=op-1 video_cloud_devid=vc-1 upstream failed',
+    }),
+    {
+      kind: 'gateway-error',
+      title: 'Telemetry gateway error',
+      message: 'Telemetry source could not be reached.',
+    },
+  );
+  assert.equal(
+    telemetrySourceState({ telemetry: { telemetry_status: 'unavailable', unavailable_reason: 'No sample found.' } }).message,
+    'No sample found.',
+  );
 });


### PR DESCRIPTION
## Summary
- add reusable source-aware state helpers for loading, empty, filtered-empty, unavailable, gateway-error, and ready states
- sanitize source messages so Customer View does not render platform-only ids or raw upstream payload details
- degrade telemetry, firmware, and stream source fetch failures into panel-level unavailable states so safe page context remains visible

Closes #144

## Tests
- cd web && npm test
- cd web && npm run build
- git diff --check