### PR TITLE
Complete Devices table drawer workflow

### DIFF
--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -366,6 +366,8 @@ async function runDesktopSmoke(page) {
 
   await gotoAndAssert(page, '/console/devices?device=dev-1002', 'Devices');
   await expectText(page, 'Dock Door 07');
+  await expectText(page, 'Actions');
+  await expectText(page, 'Inspect');
   await expectText(page, 'Provision device');
   await screenshot(page, 'desktop-devices-drawer.png');
 

--- a/web/src/device-actions.test.mjs
+++ b/web/src/device-actions.test.mjs
@@ -25,6 +25,20 @@ test('deviceActionState uses explicit capabilities for lifecycle writes', () => 
 
   const allowed = deviceActionState({ readiness: 'registered' }, 'provision', { capabilities: ['customer.devices.provision'] });
   assert.equal(allowed.enabled, true);
+
+  const wrongActionCapability = deviceActionState({ readiness: 'activated' }, 'deactivate', { capabilities: ['customer.devices.provision'] });
+  assert.equal(wrongActionCapability.enabled, false);
+  assert.match(wrongActionCapability.reason, /permission/);
+});
+
+test('deviceActionState keeps observer write gates even with lifecycle capabilities', () => {
+  const state = deviceActionState(
+    { readiness: 'registered' },
+    'provision',
+    { readOnly: true, capabilities: ['customer.devices.provision'] },
+  );
+  assert.equal(state.enabled, false);
+  assert.match(state.reason, /Read-only Observer/);
 });
 
 test('deviceActionState disables actions when telemetry source is unavailable', () => {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -2013,7 +2013,25 @@ function Devices({ active, devices, selectedDevice, deviceDrawerOpen, me, setSel
       value: (device) => device.last_seen_at,
       render: (device) => device.last_seen_at ? <time title={device.last_seen_at}>{formatRelativeTime(device.last_seen_at)}</time> : 'No transport evidence',
     },
-  ], []);
+    {
+      key: 'actions',
+      label: 'Actions',
+      sortable: false,
+      value: () => '',
+      render: (device) => (
+        <button
+          type="button"
+          className="table-action-button"
+          onClick={(event) => {
+            event.stopPropagation();
+            setSelectedDeviceId(device.id);
+          }}
+        >
+          Inspect
+        </button>
+      ),
+    },
+  ], [setSelectedDeviceId]);
 
   const selectedTelemetry = selectedDevice ? telemetryById[selectedDevice.id] || null : null;
   const telemetryBusy = deviceDrawerOpen && selectedDevice?.id && telemetryLoadingId === selectedDevice.id && !selectedTelemetry;
@@ -2117,6 +2135,7 @@ function Devices({ active, devices, selectedDevice, deviceDrawerOpen, me, setSel
                 <StatusBadge value={normalizeStatusKey(device.readiness)} label={device.readiness_display} />
               </span>
               <time title={device.last_seen_at || ''}>{device.last_seen_at ? formatRelativeTime(device.last_seen_at) : 'No transport evidence'}</time>
+              <span className="mobile-row-action">Inspect</span>
             </button>
           )) : <p className="empty-state">No devices match the current filter.</p>}
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2056,6 +2056,21 @@ tbody tr:hover,
   background: rgba(0, 104, 183, 0.06);
 }
 
+.table-action-button {
+  background: #fff;
+  border: 1px solid rgba(0, 104, 183, 0.22);
+  border-radius: 7px;
+  color: var(--brand);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+  padding: 7px 10px;
+}
+
+.table-action-button:hover {
+  background: rgba(0, 104, 183, 0.08);
+}
+
 th {
   color: var(--muted);
   font-size: 12px;
@@ -2435,6 +2450,11 @@ th {
   .mobile-device-row small,
   .mobile-device-row time {
     color: var(--muted);
+  }
+
+  .mobile-row-action {
+    color: var(--brand);
+    font-weight: 700;
   }
 
   .topbar,


### PR DESCRIPTION
## Summary
- add the required Devices table Actions column with an Inspect control that opens the detail drawer
- keep the compact mobile device workflow explicit with an Inspect action cue
- add lifecycle action guard coverage for wrong-capability and read-only observer cases, and extend browser smoke to verify the table action workflow

Closes #146

## Tests
- cd web && npm test
- cd web && npm run build
- cd web && npm run browser:smoke
- git diff --check