### PR TITLE
Complete firmware read-only policy states

### DIFF
--- a/web/src/firmware.mjs
+++ b/web/src/firmware.mjs
@@ -7,9 +7,21 @@ const statusPriority = {
   applied: 5,
 };
 
+const supportedPolicies = new Set(['normal', 'staged', 'maintenance_window', 'manual']);
+
 export function firmwareVersionFilterValue(version) {
   const normalized = String(version || '').trim();
   return normalized && normalized.toLowerCase() !== 'unknown' ? normalized : 'unknown';
+}
+
+export function firmwarePolicyLabel(policy) {
+  const normalized = String(policy || 'normal').trim().toLowerCase();
+  if (!normalized) return 'Normal';
+  if (!supportedPolicies.has(normalized)) return `Unsupported policy: ${policy}`;
+  return normalized
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
 }
 
 export function firmwareCampaignDetailRows(campaign = {}) {

--- a/web/src/firmware.test.mjs
+++ b/web/src/firmware.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { firmwareCampaignDetailRows, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
+import { firmwareCampaignDetailRows, firmwarePolicyLabel, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
 
 const campaign = {
   campaign_id: 'campaign-1',
@@ -32,8 +32,19 @@ test('firmwareRiskRows includes unknown firmware as operational risk', () => {
   assert.deepEqual(rows.map((row) => row.device_id), ['dev-d', 'dev-c', 'dev-b']);
 });
 
+test('firmwareRiskRows handles empty campaign data', () => {
+  assert.deepEqual(firmwareRiskRows([], 10), []);
+});
+
 test('firmwareVersionFilterValue preserves unknown firmware filter', () => {
   assert.equal(firmwareVersionFilterValue(''), 'unknown');
   assert.equal(firmwareVersionFilterValue('Unknown'), 'unknown');
   assert.equal(firmwareVersionFilterValue('v1.2.4'), 'v1.2.4');
+});
+
+test('firmwarePolicyLabel marks unsupported policy values explicitly', () => {
+  assert.equal(firmwarePolicyLabel('staged'), 'Staged');
+  assert.equal(firmwarePolicyLabel('normal'), 'Normal');
+  assert.equal(firmwarePolicyLabel('region_canary'), 'Unsupported policy: region_canary');
+  assert.equal(firmwarePolicyLabel(''), 'Normal');
 });

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -13,7 +13,7 @@ import {
 import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
 import { quotaRaiseErrorMessage, quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
 import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
-import { firmwareCampaignDetailRows, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
+import { firmwareCampaignDetailRows, firmwarePolicyLabel, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
 import {
   sourceAvailable,
   sourceMessage,
@@ -1022,7 +1022,7 @@ function FirmwareOTAPage({ loading, distribution, onViewDevices }) {
                     >
                       <strong>{campaign.campaign_id}</strong>
                       <span>{campaign.target_version}</span>
-                      <span>{campaign.policy || 'normal'}</span>
+                      <span>{firmwarePolicyLabel(campaign.policy)}</span>
                       <StatusBadge value={normalizeStatusKey(campaign.state)} label={toTitleCase(campaign.state || 'unknown')} />
                       <span>{campaign.applied} ({formatPercent(campaign.total ? campaign.applied / campaign.total * 100 : 0)})</span>
                       <span>{campaign.pending} ({formatPercent(campaign.total ? campaign.pending / campaign.total * 100 : 0)})</span>
@@ -1113,7 +1113,7 @@ function FirmwareCampaignSummary({ campaign }) {
       <div className="panel-head">
         <div>
           <h3>Rollout Campaign Summary</h3>
-          <p>Target {campaign.target_version} / {campaign.policy || 'normal'} / {campaign.started_at ? formatRelativeTime(campaign.started_at) : 'not started'}</p>
+          <p>Target {campaign.target_version} / {firmwarePolicyLabel(campaign.policy)} / {campaign.started_at ? formatRelativeTime(campaign.started_at) : 'not started'}</p>
         </div>
         <StatusBadge value={normalizeStatusKey(campaign.state)} label={toTitleCase(campaign.state || 'unknown')} />
       </div>


### PR DESCRIPTION
## Summary
- mark unsupported Firmware & OTA rollout policy values explicitly instead of displaying them as supported workflows
- keep campaign summary and read-only campaign table on the same policy label helper
- add firmware tests for empty risk data, unsupported policy labels, unknown firmware, and drill-down-safe helpers

Closes #147

## Tests
- cd web && npm test
- cd web && npm run build
- cd web && npm run browser:smoke
- git diff --check