### PR TITLE
Complete Stream Health source-backed workflows

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -21,7 +21,7 @@ import {
   sourceUnavailableFromError,
   telemetrySourceState,
 } from './source-state.mjs';
-import { streamWorstDeviceRows } from './stream.mjs';
+import { streamAttentionRows, streamModeRows, streamWorstDeviceRows } from './stream.mjs';
 import './styles.css';
 
 const DEFAULT_PAGE_SIZE = 8;
@@ -1189,6 +1189,7 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
   const modeTrends = stats?.trend_by_mode || [];
   const worstDevices = streamWorstDeviceRows(stats?.worst_devices || []);
   const byMode = stats?.by_mode || {};
+  const modeRows = streamModeRows(byMode);
   const available = sourceAvailable(stats);
   const pageState = sourceStateForPanel({
     loading,
@@ -1318,8 +1319,8 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
             )}
 
             <div className="stream-mode-summary">
-              {['webrtc'].map((mode) => {
-                const statsForMode = byMode[mode] || {};
+              {modeRows.length ? modeRows.map((statsForMode) => {
+                const mode = statsForMode.mode;
                 return (
                   <div key={mode} className="stream-mode-summary__item">
                     <span>{streamModeLabel(mode)}</span>
@@ -1327,7 +1328,9 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
                     <small>{statsForMode.requests ?? 0} requests</small>
                   </div>
                 );
-              })}
+              }) : (
+                <p className="empty-state">No source-backed stream mode data in selected window.</p>
+              )}
             </div>
           </section>
 
@@ -1364,7 +1367,7 @@ function StreamHealthPage({ devices, loading, stats, streamWindow, setWindow, on
               <p className="empty-state">No stream requests in selected window.</p>
             )}
           </section>
-          <StreamAttentionPanel devices={devices} onOpenDevice={onOpenDevice} />
+          <StreamAttentionPanel stats={stats} onOpenDevice={onOpenDevice} />
         </div>
       ) : (
         <p className="empty-state">{unavailableText}</p>
@@ -1827,8 +1830,8 @@ function AttentionQueuePanel({ loading, items, onOpenDevice }) {
   );
 }
 
-function StreamAttentionPanel({ devices, onOpenDevice }) {
-  const items = buildStreamAttentionItems(devices);
+function StreamAttentionPanel({ stats, onOpenDevice }) {
+  const items = streamAttentionRows(stats);
   return (
     <section className="panel stream-attention-panel">
       <div className="panel-head">
@@ -3020,21 +3023,6 @@ function buildAttentionQueue(devices, alerts) {
     })
     .filter(Boolean)
     .sort((left, right) => right.score - left.score || left.device_name.localeCompare(right.device_name));
-}
-
-function buildStreamAttentionItems(devices) {
-  return devices
-    .map((device) => {
-      const health = String(device.health || 'unknown').toLowerCase();
-      const signal = String(device.signal_quality || '').toLowerCase();
-      const readiness = String(device.readiness || '').toLowerCase();
-      if (health === 'critical') return { device_id: device.id, device_name: device.name, health, issue: 'Low success rate or offline risk' };
-      if (signal === 'poor') return { device_id: device.id, device_name: device.name, health, issue: 'Intermittent stream signal' };
-      if (readiness !== 'online' && readiness !== 'activated') return { device_id: device.id, device_name: device.name, health, issue: 'Never streamed or not ready' };
-      return null;
-    })
-    .filter(Boolean)
-    .slice(0, 5);
 }
 
 function formatTierLabel(tier) {

--- a/web/src/stream.mjs
+++ b/web/src/stream.mjs
@@ -10,6 +10,48 @@ export function streamWorstDeviceRows(devices = []) {
   });
 }
 
+export function streamModeRows(byMode = {}) {
+  return Object.entries(byMode || {})
+    .filter(([, stats]) => stats && (Number.isFinite(Number(stats.requests)) || Number.isFinite(Number(stats.success_rate_pct))))
+    .map(([mode, stats]) => ({
+      mode,
+      success_rate_pct: numeric(stats.success_rate_pct, 0),
+      requests: numeric(stats.requests, 0),
+    }))
+    .sort((left, right) => {
+      if (left.mode === 'webrtc') return -1;
+      if (right.mode === 'webrtc') return 1;
+      if (left.requests !== right.requests) return right.requests - left.requests;
+      return left.mode.localeCompare(right.mode);
+    });
+}
+
+export function streamAttentionRows(stats = {}, limit = 5) {
+  const attentionDevices = Array.isArray(stats.attention_devices) ? stats.attention_devices : [];
+  if (attentionDevices.length) {
+    return attentionDevices
+      .map((device) => ({
+        device_id: device.device_id || '',
+        device_name: device.device_name || device.device_id || '',
+        health: device.health || 'warning',
+        issue: device.issue || 'Stream attention required',
+        priority: numeric(device.priority, 0),
+      }))
+      .sort((left, right) => right.priority - left.priority || left.device_name.localeCompare(right.device_name))
+      .slice(0, limit);
+  }
+  return streamWorstDeviceRows(stats.worst_devices || [])
+    .filter((device) => numeric(device.success_rate_pct, 100) < 100 || numeric(device.failures, 0) > 0)
+    .map((device) => ({
+      device_id: device.device_id || '',
+      device_name: device.device_name || device.device_id || '',
+      health: numeric(device.success_rate_pct, 100) <= 50 ? 'warning' : 'unknown',
+      issue: numeric(device.requests, 0) === 0 ? 'No stream sessions reported' : 'Low stream success rate',
+      priority: 100 - numeric(device.success_rate_pct, 100),
+    }))
+    .slice(0, limit);
+}
+
 function numeric(value, fallback) {
   return Number.isFinite(Number(value)) ? Number(value) : fallback;
 }

--- a/web/src/stream.test.mjs
+++ b/web/src/stream.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { streamWorstDeviceRows } from './stream.mjs';
+import { streamAttentionRows, streamModeRows, streamWorstDeviceRows } from './stream.mjs';
 
 test('streamWorstDeviceRows sorts worst devices by failure priority', () => {
   const rows = streamWorstDeviceRows([
@@ -17,4 +17,43 @@ test('streamWorstDeviceRows keeps customer-safe drawer target fields', () => {
   const [row] = streamWorstDeviceRows([{ device_id: 'dev-a', device_name: 'A', success_rate_pct: 0, requests: 1 }]);
   assert.equal(row.device_id, 'dev-a');
   assert.equal(row.device_name, 'A');
+});
+
+test('streamModeRows only shows source-backed modes', () => {
+  const rows = streamModeRows({
+    webrtc: { success_rate_pct: 90, requests: 10 },
+    rtsp: { success_rate_pct: 40, requests: 2 },
+    hls: null,
+  });
+  assert.deepEqual(rows.map((row) => row.mode), ['webrtc', 'rtsp']);
+  assert.deepEqual(streamModeRows({}), []);
+});
+
+test('streamAttentionRows uses source-backed attention facts before worst-device fallback', () => {
+  const rows = streamAttentionRows({
+    attention_devices: [
+      { device_id: 'dev-a', device_name: 'A', issue: 'Session failures', health: 'warning', priority: 20 },
+      { device_id: 'dev-b', device_name: 'B', issue: 'Never streamed', health: 'critical', priority: 50 },
+    ],
+    worst_devices: [
+      { device_id: 'dev-c', device_name: 'C', success_rate_pct: 0, requests: 10 },
+    ],
+  });
+  assert.deepEqual(rows.map((row) => row.device_id), ['dev-b', 'dev-a']);
+});
+
+test('streamAttentionRows falls back to source-backed worst-device facts', () => {
+  const rows = streamAttentionRows({
+    worst_devices: [
+      { device_id: 'dev-a', device_name: 'A', success_rate_pct: 100, requests: 3 },
+      { device_id: 'dev-b', device_name: 'B', success_rate_pct: 20, requests: 8, failures: 6 },
+    ],
+  });
+  assert.deepEqual(rows, [{
+    device_id: 'dev-b',
+    device_name: 'B',
+    health: 'warning',
+    issue: 'Low stream success rate',
+    priority: 80,
+  }]);
 });


### PR DESCRIPTION
## Summary
- drive Stream Health mode rows from source-backed by_mode facts instead of hard-coded mode claims
- drive Devices Needing Stream Attention from stream-stats attention/worst-device facts rather than general device health inference
- add focused stream tests for source-backed modes, attention routing inputs, empty mode windows, and worst-device fallback

Closes #148

## Tests
- cd web && npm test
- cd web && npm run build
- cd web && npm run browser:smoke
- git diff --check