### PR TITLE
Polish public auth error states

### DIFF
--- a/web/src/http.mjs
+++ b/web/src/http.mjs
@@ -46,5 +46,46 @@ export function userFacingSSOError(error) {
   if (message.includes('SSO start did not return a redirect URL')) {
     return 'SSO could not start because the identity provider did not return a redirect URL.';
   }
+  if (/callback|state|nonce|verification/i.test(message)) {
+    return 'SSO callback could not be verified. Try signing in again.';
+  }
+  if (/gateway|temporarily unavailable|timeout|network|502|503|504/i.test(message)) {
+    return 'SSO is temporarily unavailable. Please try again later.';
+  }
+  if (containsSensitiveDetails(message)) {
+    return 'SSO sign-in could not be started. Please try again.';
+  }
   return message;
+}
+
+export function userFacingSignupError(error) {
+  const message = String(error?.message || error || '');
+  if (/validation|email|password|captcha|terms|400|422/i.test(message)) {
+    return 'Check the signup fields and try again.';
+  }
+  if (/gateway|account manager|temporarily unavailable|timeout|network|502|503|504/i.test(message)) {
+    return 'Evaluation signup is temporarily unavailable. Please try again later.';
+  }
+  return 'Evaluation signup could not be completed. Please try again.';
+}
+
+export function userFacingVerificationError(error) {
+  const message = String(error?.message || error || '');
+  if (/expired/i.test(message)) {
+    return 'Verification link expired. Request a new verification email.';
+  }
+  if (/already verified|already_verified/i.test(message)) {
+    return 'Email is already verified. Sign in to continue.';
+  }
+  if (/invalid|malformed|token|400|404|422/i.test(message) && !containsSensitiveDetails(message)) {
+    return 'Verification token is invalid. Check the link and try again.';
+  }
+  if (/gateway|account manager|temporarily unavailable|timeout|network|502|503|504/i.test(message)) {
+    return 'Verification service is temporarily unavailable. Please try again later.';
+  }
+  return 'Verification could not be completed. Please try again.';
+}
+
+function containsSensitiveDetails(message) {
+  return /video_cloud_devid|operation_id|upstream_operation_id|raw_payload|\{.*\}/i.test(String(message || ''));
 }

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -1,6 +1,13 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
+import {
+  postJSON,
+  putJSON,
+  startSSOLogin,
+  userFacingSignupError,
+  userFacingSSOError,
+  userFacingVerificationError,
+} from './http.mjs';
 
 test('postJSON throws on failed verification responses', async () => {
   const originalFetch = globalThis.fetch;
@@ -167,5 +174,47 @@ test('userFacingSSOError maps auth and malformed redirect failures to operator-s
   assert.equal(
     userFacingSSOError(new Error('SSO start did not return a redirect URL')),
     'SSO could not start because the identity provider did not return a redirect URL.',
+  );
+  assert.equal(
+    userFacingSSOError(new Error('callback state verification failed')),
+    'SSO callback could not be verified. Try signing in again.',
+  );
+  assert.equal(
+    userFacingSSOError(new Error('video_cloud_devid=vc raw_payload={"error":"boom"}')),
+    'SSO sign-in could not be started. Please try again.',
+  );
+});
+
+test('public signup errors use evaluation-tier safe copy', () => {
+  assert.equal(
+    userFacingSignupError(new Error('email validation failed with 400')),
+    'Check the signup fields and try again.',
+  );
+  assert.equal(
+    userFacingSignupError(new Error('Account Manager unavailable with 503')),
+    'Evaluation signup is temporarily unavailable. Please try again later.',
+  );
+  assert.equal(
+    userFacingSignupError(new Error('raw_payload={"internal":"secret"}')),
+    'Evaluation signup could not be completed. Please try again.',
+  );
+});
+
+test('verification errors distinguish token and service states without raw payloads', () => {
+  assert.equal(
+    userFacingVerificationError(new Error('expired verification token')),
+    'Verification link expired. Request a new verification email.',
+  );
+  assert.equal(
+    userFacingVerificationError(new Error('already verified')),
+    'Email is already verified. Sign in to continue.',
+  );
+  assert.equal(
+    userFacingVerificationError(new Error('invalid verification token')),
+    'Verification token is invalid. Check the link and try again.',
+  );
+  assert.equal(
+    userFacingVerificationError(new Error('raw_payload={"token":"secret"}')),
+    'Verification could not be completed. Please try again.',
   );
 });

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -10,7 +10,14 @@ import {
   routeFromLocation,
   titleFor,
 } from './routes.mjs';
-import { postJSON, putJSON, startSSOLogin, userFacingSSOError } from './http.mjs';
+import {
+  postJSON,
+  putJSON,
+  startSSOLogin,
+  userFacingSignupError,
+  userFacingSSOError,
+  userFacingVerificationError,
+} from './http.mjs';
 import { quotaRaiseErrorMessage, quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
 import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
 import { firmwareCampaignDetailRows, firmwarePolicyLabel, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
@@ -335,7 +342,7 @@ function App() {
       setRefreshTick((tick) => tick + 1);
       return result;
     } catch (err) {
-      setError(err.message);
+      setError(userFacingSignupError(err));
       throw err;
     }
   }
@@ -351,7 +358,7 @@ function App() {
       }
       return result;
     } catch (err) {
-      setError(err.message);
+      setError(userFacingVerificationError(err));
       throw err;
     }
   }
@@ -361,7 +368,7 @@ function App() {
     try {
       return await postJSON('/api/auth/customer/resend-verification', { email });
     } catch (err) {
-      setError(err.message);
+      setError(userFacingVerificationError(err));
       throw err;
     }
   }
@@ -584,6 +591,7 @@ function SignupForm({ onSignup }) {
   const [captchaToken, setCaptchaToken] = useState('');
   const [acceptTerms, setAcceptTerms] = useState(false);
   const [honeypot, setHoneypot] = useState('');
+  const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
   const strength = passwordStrength(password);
 
@@ -591,6 +599,7 @@ function SignupForm({ onSignup }) {
     event.preventDefault();
     if (!acceptTerms || honeypot) return;
     setBusy(true);
+    setLocalError('');
     try {
       await onSignup({
         email,
@@ -599,8 +608,8 @@ function SignupForm({ onSignup }) {
         organization_name: organizationName,
         captcha_token: captchaToken,
       });
-    } catch (_) {
-      return;
+    } catch (err) {
+      setLocalError(userFacingSignupError(err));
     } finally {
       setBusy(false);
     }
@@ -641,6 +650,7 @@ function SignupForm({ onSignup }) {
         I accept the evaluation-tier terms.
       </label>
       <button type="submit" disabled={busy || !acceptTerms || !!honeypot}>Create account</button>
+      {error ? <p className="error">{error}</p> : null}
     </form>
   );
 }
@@ -662,8 +672,8 @@ function CheckEmailInterstitial({ email, onResendVerification }) {
         return;
       }
       setStatus('Verification link requested again.');
-    } catch (_) {
-      setLocalError('Failed to request a new verification link.');
+    } catch (err) {
+      setLocalError(userFacingVerificationError(err));
     } finally {
       setBusy(false);
     }
@@ -704,7 +714,7 @@ function VerifyForm({ token, onVerify }) {
           setStatus('Email verified. Sign in to continue.');
         }
       })
-      .catch(() => setLocalError('Verification failed. Check the token and try again.'))
+      .catch((err) => setLocalError(userFacingVerificationError(err)))
       .finally(() => setBusy(false));
   }, [attempted, onVerify, value]);
 
@@ -721,8 +731,8 @@ function VerifyForm({ token, onVerify }) {
       } else {
         setStatus('Email verified. Sign in to continue.');
       }
-    } catch (_) {
-      setLocalError('Verification failed. Check the token and try again.');
+    } catch (err) {
+      setLocalError(userFacingVerificationError(err));
     } finally {
       setBusy(false);
     }


### PR DESCRIPTION
## Summary
- add user-facing error mappers for SSO, evaluation signup, verification, and resend flows
- prevent raw upstream payload/internal identifiers from surfacing in public auth UI states
- keep signup and verification local form errors aligned with global public auth copy

Closes #149

## Tests
- cd web && npm test
- cd web && npm run build
- cd web && npm run browser:smoke
- git diff --check