### PR TITLE
Polish Platform View protocol and audit copy

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -21,6 +21,7 @@ import {
 import { quotaRaiseErrorMessage, quotaUsageLabel, shouldShowBreakGlass } from './auth-state.mjs';
 import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
 import { firmwareCampaignDetailRows, firmwarePolicyLabel, firmwareRiskRows, firmwareVersionFilterValue } from './firmware.mjs';
+import { auditCoverageCopy, ssoProtocolLabel } from './platform-view.mjs';
 import {
   sourceAvailable,
   sourceMessage,
@@ -1479,7 +1480,7 @@ function PlatformSSOProviders({ providers, customers, onSave }) {
         </div>
         <div className="sso-note">
           <strong>Secret handling</strong>
-          <span>Client secrets are sent only to Account Manager and are never returned by this console.</span>
+          <span>Client secrets are sent only to Account Manager and are never returned by this console. OIDC is the first supported protocol; SAML is not implemented.</span>
         </div>
       </section>
       <section className="panel">
@@ -1528,6 +1529,7 @@ function SSOProviderCard({ provider, onSave }) {
         issuer,
         client_id: clientID,
         client_secret: clientSecret,
+        protocol: 'oidc',
         verified_domains: domains.split(',').map((domain) => domain.trim()).filter(Boolean),
         enabled,
       });
@@ -1543,6 +1545,7 @@ function SSOProviderCard({ provider, onSave }) {
         <div>
           <strong>{provider.organization || provider.organization_id}</strong>
           <small>{provider.organization_id}</small>
+          <small>{ssoProtocolLabel(provider.protocol)}</small>
         </div>
         <span className={`status-pill ${provider.enabled ? 'ok' : provider.configured ? 'warn' : 'neutral'}`}>
           {provider.enabled ? 'Enabled' : provider.configured ? 'Configured' : 'Not configured'}
@@ -2649,7 +2652,7 @@ function AuditLog({ audit, compact = false, loading = false }) {
       <div className="panel-head">
         <div>
           <h2>{compact ? 'Recent audit' : 'Audit log'}</h2>
-          <p>Local operator actions captured by the Go BFF.</p>
+          <p>{auditCoverageCopy()}</p>
         </div>
       </div>
       {loading && !audit.length ? (

--- a/web/src/platform-view.mjs
+++ b/web/src/platform-view.mjs
@@ -1,0 +1,10 @@
+export function ssoProtocolLabel(protocol) {
+  const normalized = String(protocol || 'oidc').toLowerCase();
+  if (normalized === 'oidc') return 'OIDC';
+  if (normalized === 'saml') return 'SAML not implemented';
+  return `Unsupported protocol: ${protocol}`;
+}
+
+export function auditCoverageCopy() {
+  return 'Local operator actions captured by the Go BFF. Current write coverage includes SSO, break-glass, session, and lifecycle request records; audit export and full upstream audit mirroring are not implemented.';
+}

--- a/web/src/platform-view.test.mjs
+++ b/web/src/platform-view.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { auditCoverageCopy, ssoProtocolLabel } from './platform-view.mjs';
+
+test('ssoProtocolLabel presents OIDC as supported and SAML as not implemented', () => {
+  assert.equal(ssoProtocolLabel('oidc'), 'OIDC');
+  assert.equal(ssoProtocolLabel('saml'), 'SAML not implemented');
+  assert.equal(ssoProtocolLabel('ldap'), 'Unsupported protocol: ldap');
+  assert.equal(ssoProtocolLabel(''), 'OIDC');
+});
+
+test('auditCoverageCopy documents current write-side limits', () => {
+  const copy = auditCoverageCopy();
+  assert.match(copy, /Current write coverage/);
+  assert.match(copy, /not implemented/);
+});


### PR DESCRIPTION
## Summary
- make SSO Providers explicitly OIDC-first and label SAML/unsupported protocols as not implemented
- keep provider secret handling copy clear and continue sending secrets only to Account Manager
- document current Audit Log write-side coverage and limitations in Platform View copy

Closes #150

## Tests
- cd web && npm test
- cd web && npm run build
- cd web && npm run browser:smoke
- git diff --check