### PR TITLE
Finalize WebUI browser QA signoff

### DIFF
--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -147,3 +147,15 @@ Use this mapping when reviewing developer issues opened from
 - Tables scroll horizontally rather than clipping columns.
 - Drawer fits within viewport and remains scrollable.
 - Charts remain visible and do not overlap adjacent panels.
+
+## Final Signoff
+
+- Status: admin repo WebUI design scope is implementation-ready and smoke-tested
+  for the current mocked BFF contract.
+- Browser QA command: `cd web && npm run browser:smoke`.
+- Final smoke coverage includes desktop Customer View, Platform View, public
+  auth routes, and mobile Devices/signup checks. Screenshots are emitted to
+  `.artifacts/browser-smoke/`.
+- Remaining production validation blockers are upstream source availability for
+  telemetry, firmware rollout facts, and WebRTC session facts; these are tracked
+  separately from Customer View and Platform View UI completion.

--- a/docs/webui-browser-qa.md
+++ b/docs/webui-browser-qa.md
@@ -24,14 +24,18 @@ gitignored.
 ## Coverage
 
 - Desktop 1440px:
+  - Public auth routes: signup, check-email, and verify
   - Customer Overview
   - Devices with detail drawer open
   - Firmware & OTA campaign drill-down
   - Stream Health worst-device drill-down into Devices
   - Platform Operations Log
+  - Platform SSO Providers
+  - Platform Audit Log
 - Mobile 390px:
   - Customer sidebar/nav remains visible
   - Devices uses compact rows instead of rendering the full table
+  - Public signup remains usable on a narrow viewport
 
 The smoke test fails on app-level `console.error`, `console.warn`, or uncaught
 page errors.
@@ -42,6 +46,20 @@ The script uses deterministic mocked API responses for WebUI behavior only. It
 does not validate production upstream telemetry, firmware, stream, or account
 manager integrations. Those remain covered by backend contract tests and live
 environment validation.
+
+## Final Signoff Notes
+
+- Admin repo WebUI milestone coverage is complete for the documented scope:
+  Customer View four pages, public auth/signup/verification/quota states,
+  Platform View four pages, route guards, source-aware states, and read-only
+  customer workflows.
+- Remaining blockers are upstream production sources, not admin repo WebUI
+  completion: authoritative telemetry, firmware rollout facts, and WebRTC
+  session facts still require live-source validation outside this mocked smoke
+  test.
+- Browser smoke screenshots are repeatable review artifacts and should be
+  regenerated from the command above whenever WebUI layout or route behavior
+  changes.
 
 ## CI Use
 

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -364,6 +364,15 @@ async function runDesktopSmoke(page) {
   await expectText(page, 'Active Streams');
   await screenshot(page, 'desktop-overview.png');
 
+  await gotoAndAssert(page, '/signup', 'Sign up');
+  await expectText(page, 'evaluation-tier');
+  await expectText(page, 'Create account');
+  await gotoAndAssert(page, '/signup/check-email?email=fleet.manager%40example.com', 'Check your email');
+  await expectText(page, 'Resend');
+  await gotoAndAssert(page, '/verify', 'Verify email');
+  await expectText(page, 'Waiting for verification link');
+  await screenshot(page, 'desktop-public-auth.png');
+
   await gotoAndAssert(page, '/console/devices?device=dev-1002', 'Devices');
   await expectText(page, 'Dock Door 07');
   await expectText(page, 'Actions');
@@ -388,6 +397,14 @@ async function runDesktopSmoke(page) {
   await expectText(page, 'Provisioning succeeded');
   await expectText(page, 'Raw type: DeviceProvisionSucceeded');
   await screenshot(page, 'desktop-platform-operations.png');
+
+  await gotoAndAssert(page, '/admin/sso', 'SSO Providers');
+  await expectText(page, 'OIDC is the first supported protocol');
+  await screenshot(page, 'desktop-platform-sso.png');
+
+  await gotoAndAssert(page, '/admin/audit', 'Audit Log');
+  await expectText(page, 'Current write coverage');
+  await screenshot(page, 'desktop-platform-audit.png');
 }
 
 async function runMobileSmoke(browserContext) {
@@ -407,6 +424,10 @@ async function runMobileSmoke(browserContext) {
     throw new Error('Mobile Devices view must hide the full table and show compact rows.');
   }
   await screenshot(page, 'mobile-devices.png');
+
+  await gotoAndAssert(page, '/signup', 'Sign up');
+  await expectText(page, 'Create account');
+  await screenshot(page, 'mobile-public-signup.png');
 
   if (consoleIssues.length) {
     throw new Error(`Mobile console issues detected:\n${consoleIssues.join('\n')}`);


### PR DESCRIPTION
## Summary
- expand browser smoke coverage to public auth routes, Platform SSO, Platform Audit, and mobile signup in addition to Customer View flows
- update browser QA documentation with final desktop/mobile coverage and upstream blocker boundaries
- record final visual QA signoff status and repeatable smoke command

Closes #151

## Tests
- cd web && npm test
- cd web && npm run build
- cd web && npm run browser:smoke
- git diff --check