### PR TITLE
[codex] Document Cloud Admin service logging migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ The console is tenant-first:
 The product and integration contracts live in the
 `rtk_cloud_contracts_doc` submodule.
 
+The service logging migration to `rtk_cloud_logger` zap and central journald
+forwarding is documented in
+[`docs/SERVICE_LOGGING_MIGRATION.md`](docs/SERVICE_LOGGING_MIGRATION.md).
+
 ## Current Scope
 
 Implemented in this first version:

--- a/docs/SERVICE_LOGGING_MIGRATION.md
+++ b/docs/SERVICE_LOGGING_MIGRATION.md
@@ -1,0 +1,33 @@
+# Service Logging Migration
+
+Status: implementation handoff.
+
+Owner: `rtk_cloud_admin`.
+
+## Goal
+
+Use `rtk_cloud_logger` zap logging for the Cloud Admin BFF/server so operator
+workflows can be traced across the dashboard, Account Manager, and Video Cloud.
+
+## Required Changes
+
+- Build the root logger with `rtk_cloud_logger`.
+- Emit JSON logs to stdout/stderr only.
+- Wrap server routes with zap request logging.
+- Preserve or generate `request_id` for browser/API calls.
+- Propagate `trace_id`, `request_id`, and `operation_id` to upstream Account
+  Manager and Video Cloud requests when those calls are part of a workflow.
+- Use structured fields for upstream failures, cache refresh failures,
+  service-health checks, and admin operations.
+- Keep local SQLite/audit records as durable audit data; do not replace them
+  with service logs.
+
+## Acceptance Criteria
+
+- The native `rtk-cloud-admin.service` emits single-line JSON zap logs.
+- Request logs include sanitized path, status, duration, remote address, and
+  request id.
+- Upstream calls can be correlated with Account Manager and Video Cloud logs.
+- Secrets such as `VIDEO_CLOUD_ADMIN_TOKEN`, bootstrap password, cookies, and
+  bearer tokens never appear in logs.
+- `go test ./...` and web tests continue to pass.

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -11,6 +11,7 @@ environment.
 Recommended production layout:
 
 - run the Go server as a native systemd service
+- emit `rtk_cloud_logger` zap JSON logs to stdout/stderr for journald collection
 - place it behind a reverse proxy that terminates TLS
 - mount a persistent SQLite volume for `DATABASE_PATH`
 - configure upstream Account Manager and Video Cloud endpoints explicitly


### PR DESCRIPTION
## Summary\n- add Cloud Admin handoff doc for rtk_cloud_logger zap request logging and upstream correlation\n- document audit/logging boundary and secret redaction expectations\n- update README and private-cloud deployment profile references\n\n## Validation\n- rg "SERVICE_LOGGING|rtk_cloud_logger|journald" README.md docs