### PR TITLE
[codex] Add admin nginx Prometheus exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ If both admin bootstrap variables are set, startup creates the first local
 platform admin break-glass account if it does not already exist. Passwords are
 stored as bcrypt hashes. Session rows store metadata and upstream
 bearer/refresh tokens, never plaintext credentials.
+
+Linode Admin deployments install node and nginx Prometheus exporters for
+private Prometheus scraping. The nginx exporter uses local nginx `stub_status`
+on `127.0.0.1:8081` so the Admin service remains bound to `127.0.0.1:8080`.
 Break-glass login is rejected unless `ADMIN_BREAK_GLASS_ENABLED=true`, and
 customer password login is rejected unless
 `LEGACY_CUSTOMER_PASSWORD_LOGIN_ENABLED=true`.

--- a/deploy/linode/README.md
+++ b/deploy/linode/README.md
@@ -59,6 +59,7 @@ Remote Admin VM:
 - inbound `22/tcp` limited to operator CIDRs
 - inbound `80/tcp` and `443/tcp` public for certbot and dashboard HTTPS
 - outbound private VPC access to Prometheus on the Video Cloud infra VM
+- inbound private VPC access to Admin metrics ports `9100` and `9113`
 
 ## 1. Prepare Local Env
 
@@ -103,11 +104,16 @@ The deploy script:
 
 1. downloads or receives an explicit native release bundle
 2. uploads the release bundle to the VM
-3. installs nginx, certbot, and systemd units
+3. installs nginx, certbot, node exporter, nginx exporter, and systemd units
 4. writes `/etc/rtk_cloud_admin/admin.env`
 5. stores SQLite data under `/var/lib/rtk_cloud_admin`
 6. starts `rtk-cloud-admin.service`
 7. optionally obtains a Let's Encrypt certificate and redirects HTTP to HTTPS
+
+The nginx exporter listens on the Admin private IP by default when
+`ADMIN_LINODE_PRIVATE_IPV4` is set. It scrapes nginx `stub_status` through
+`127.0.0.1:8081/stub_status` so the Admin app can keep using
+`127.0.0.1:8080`.
 
 Release CI publishes native bundles to Linode Object Storage using the same
 layout as the Video Cloud release flow:

--- a/deploy/linode/deploy-admin-env-test.sh
+++ b/deploy/linode/deploy-admin-env-test.sh
@@ -49,6 +49,7 @@ RTK_TEST_CAPTURE_DIR="$capture" \
 ADMIN_LINODE_DOMAIN="admin.example.test" \
 ADMIN_LINODE_CERTBOT_EMAIL="admin@example.test" \
 ADMIN_LINODE_HOST="203.0.113.30" \
+ADMIN_LINODE_PRIVATE_IPV4="10.42.1.60" \
 ADMIN_LINODE_SSH_KEY="$ssh_key" \
 ADMIN_LINODE_RELEASE="test" \
 ADMIN_LINODE_RELEASE_BUNDLE="$release_bundle" \
@@ -61,5 +62,10 @@ ADMIN_BOOTSTRAP_PASSWORD="admin-password" \
   "$repo_root/deploy/linode/deploy-admin.sh" >/tmp/deploy-admin-env-test.out
 
 grep -q '^VIDEO_CLOUD_PROMETHEUS_BASE_URL=http://10.42.1.30:9090$' "$capture/admin.env"
+grep -q 'prometheus-nginx-exporter' "$capture/remote-install.sh"
+grep -q '127.0.0.1:8081/stub_status' "$capture/remote-install.sh"
+grep -q -- '-web.listen-address=$nginx_exporter_listen_addr' "$capture/remote-install.sh"
+grep -q '10.42.1.60:9113' "$capture/remote-install-args.txt"
+grep -q 'systemctl enable --now prometheus-nginx-exporter' "$capture/remote-install.sh"
 
 printf 'deploy-admin env test passed\n'

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -64,6 +64,10 @@ node_exporter_listen_addr="${ADMIN_PROMETHEUS_NODE_EXPORTER_LISTEN_ADDR:-127.0.0
 if [ -z "${ADMIN_PROMETHEUS_NODE_EXPORTER_LISTEN_ADDR:-}" ] && [ -n "${ADMIN_LINODE_PRIVATE_IPV4:-}" ]; then
   node_exporter_listen_addr="$ADMIN_LINODE_PRIVATE_IPV4:9100"
 fi
+nginx_exporter_listen_addr="${ADMIN_PROMETHEUS_NGINX_EXPORTER_LISTEN_ADDR:-127.0.0.1:9113}"
+if [ -z "${ADMIN_PROMETHEUS_NGINX_EXPORTER_LISTEN_ADDR:-}" ] && [ -n "${ADMIN_LINODE_PRIVATE_IPV4:-}" ]; then
+  nginx_exporter_listen_addr="$ADMIN_LINODE_PRIVATE_IPV4:9113"
+fi
 release_bundle="${ADMIN_LINODE_RELEASE_BUNDLE:-}"
 remote_bundle="${ADMIN_LINODE_REMOTE_BUNDLE:-/tmp/rtk-cloud-admin-${release}.tar.gz}"
 data_dir="${ADMIN_LINODE_DATA_DIR:-/var/lib/rtk_cloud_admin}"
@@ -162,7 +166,7 @@ if [ -n "$cert_cache_dir" ]; then
 fi
 
 printf '[admin-deploy] installing runtime on %s\n' "$remote" >&2
-ssh "${ssh_opts[@]}" "$remote" bash -s -- "$domain" "$certbot_email" "$release" "$remote_bundle" "$data_dir" "$env_path" "$certbot_enable" "$http_only" "$cert_cache_dir" "$node_exporter_listen_addr" <<'REMOTE'
+ssh "${ssh_opts[@]}" "$remote" bash -s -- "$domain" "$certbot_email" "$release" "$remote_bundle" "$data_dir" "$env_path" "$certbot_enable" "$http_only" "$cert_cache_dir" "$node_exporter_listen_addr" "$nginx_exporter_listen_addr" <<'REMOTE'
 set -euo pipefail
 
 domain="$1"
@@ -175,6 +179,7 @@ certbot_enable="$7"
 http_only="$8"
 cert_cache_dir="${9:-}"
 node_exporter_listen_addr="${10:-127.0.0.1:9100}"
+nginx_exporter_listen_addr="${11:-127.0.0.1:9113}"
 service_user="rtk-cloud-admin"
 release_root="/opt/rtk_cloud_admin/releases"
 release_dir="$release_root/$release"
@@ -182,8 +187,14 @@ current_dir="/opt/rtk_cloud_admin/current"
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y curl systemd ca-certificates gnupg2 lsb-release ubuntu-keyring prometheus-node-exporter
+apt-get install -y curl systemd ca-certificates gnupg2 lsb-release ubuntu-keyring prometheus-node-exporter prometheus-nginx-exporter
 printf 'ARGS="--web.listen-address=%s"\n' "$node_exporter_listen_addr" > /etc/default/prometheus-node-exporter
+mkdir -p /etc/systemd/system/prometheus-nginx-exporter.service.d
+cat > /etc/systemd/system/prometheus-nginx-exporter.service.d/override.conf <<EXPORTER
+[Service]
+ExecStart=
+ExecStart=/usr/bin/prometheus-nginx-exporter -nginx.scrape-uri=http://127.0.0.1:8081/stub_status -web.listen-address=$nginx_exporter_listen_addr
+EXPORTER
 curl -fsS https://nginx.org/keys/nginx_signing.key | gpg --dearmor -o /usr/share/keyrings/nginx-archive-keyring.gpg.tmp
 mv /usr/share/keyrings/nginx-archive-keyring.gpg.tmp /usr/share/keyrings/nginx-archive-keyring.gpg
 printf 'deb [signed-by=/usr/share/keyrings/nginx-archive-keyring.gpg] http://nginx.org/packages/ubuntu %s nginx\n' "$(lsb_release -cs)" > /etc/apt/sources.list.d/nginx-org.list
@@ -245,6 +256,17 @@ UNIT
 
 cat > /etc/nginx/sites-available/rtk-cloud-admin.conf <<NGINX
 server {
+    listen 127.0.0.1:8081;
+    server_name localhost;
+
+    location = /stub_status {
+        stub_status;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+
+server {
     listen 80;
     server_name $domain;
 
@@ -275,6 +297,9 @@ systemctl daemon-reload
 systemctl enable --now prometheus-node-exporter
 systemctl restart prometheus-node-exporter
 systemctl is-active prometheus-node-exporter
+systemctl enable --now prometheus-nginx-exporter
+systemctl restart prometheus-nginx-exporter
+systemctl is-active prometheus-nginx-exporter
 for _ in $(seq 1 10); do
   if ss -lnt | grep -F "$node_exporter_listen_addr" >/dev/null; then
     node_exporter_ready=1
@@ -283,6 +308,17 @@ for _ in $(seq 1 10); do
   sleep 1
 done
 if [ "${node_exporter_ready:-0}" != "1" ]; then
+  ss -lnt >&2 || true
+  exit 1
+fi
+for _ in $(seq 1 10); do
+  if ss -lnt | grep -F "$nginx_exporter_listen_addr" >/dev/null; then
+    nginx_exporter_ready=1
+    break
+  fi
+  sleep 1
+done
+if [ "${nginx_exporter_ready:-0}" != "1" ]; then
   ss -lnt >&2 || true
   exit 1
 fi
@@ -339,6 +375,17 @@ RENEWAL
     sed -i "s/^account =.*/account = $account/" "$renewal_conf"
   fi
   cat > /etc/nginx/sites-available/rtk-cloud-admin.conf <<NGINX
+server {
+    listen 127.0.0.1:8081;
+    server_name localhost;
+
+    location = /stub_status {
+        stub_status;
+        allow 127.0.0.1;
+        deny all;
+    }
+}
+
 server {
     listen 80;
     server_name $domain;

--- a/deploy/linode/provision-admin-vm-test.sh
+++ b/deploy/linode/provision-admin-vm-test.sh
@@ -99,6 +99,14 @@ jq -e '
   .interfaces[1].ipv4.vpc == "10.42.1.60"
 ' "$capture/linode-create.json" >/dev/null
 
+jq -e '
+  [.rules.inbound[] | select(.label == "vpc-metrics")] as $rules |
+  ($rules | length) == 1 and
+  $rules[0].protocol == "TCP" and
+  $rules[0].ports == "9100,9113" and
+  $rules[0].addresses.ipv4 == ["10.42.1.0/24"]
+' "$capture/firewall-create.json" >/dev/null
+
 grep -q '^ADMIN_LINODE_PRIVATE_IPV4=10.42.1.60$' "$state"
 
 printf 'provision-admin-vm VPC test passed\n'

--- a/deploy/linode/provision-admin-vm.sh
+++ b/deploy/linode/provision-admin-vm.sh
@@ -115,7 +115,8 @@ firewall_payload="$(jq -cn --arg label "$firewall_label" --arg cidrs "$allowed_s
     inbound: [
       {label:"ssh", action:"ACCEPT", protocol:"TCP", ports:"22", addresses:{ipv4:($cidrs|split(","))}},
       {label:"http", action:"ACCEPT", protocol:"TCP", ports:"80", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}},
-      {label:"https", action:"ACCEPT", protocol:"TCP", ports:"443", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}}
+      {label:"https", action:"ACCEPT", protocol:"TCP", ports:"443", addresses:{ipv4:["0.0.0.0/0"], ipv6:["::/0"]}},
+      {label:"vpc-metrics", action:"ACCEPT", protocol:"TCP", ports:"9100,9113", addresses:{ipv4:[$vpc_cidr]}}
     ],
     outbound: []
   }

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -45,9 +45,11 @@ rtk_cloud_admin
 
 The operator-local scripts live under [`deploy/linode/`](../deploy/linode/):
 
-- `provision-admin-vm.sh` creates the public-only Linode VM and firewall.
+- `provision-admin-vm.sh` creates the public+VPC Linode VM and firewall,
+  including private metrics access for node and nginx exporters.
 - `deploy-admin.sh` uploads the selected native release bundle, installs nginx,
-  writes the systemd unit, and starts the service.
+  installs node/nginx exporters, writes the systemd unit, and starts the
+  service.
 - `verify-admin.sh` checks the deployed HTTP surface.
 - `backup-admin-db.sh` pulls a timestamped SQLite backup.
 
@@ -85,6 +87,8 @@ Operational expectations:
   operator's proxy stack
 - keep the session cookie `HttpOnly` and treat it as an authenticated browser
   session, not an API token
+- expose node and nginx exporter ports only on the Admin private IP; nginx
+  `stub_status` is local-only and uses `127.0.0.1:8081` to avoid the app port
 
 ## Data Ownership
 


### PR DESCRIPTION
## Summary
- install and configure the Admin VM nginx Prometheus exporter on the private VPC listener
- add VPC-only firewall access for Admin node/nginx exporter ports
- update Admin deployment docs for private exporter scraping

## Validation
- `bash deploy/linode/provision-admin-vm-test.sh`
- `bash deploy/linode/deploy-admin-env-test.sh`
- `git diff --check`