### PR TITLE
Document Platform Dashboard metrics design

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,10 @@ Go BFF:
   Devices, Firmware & OTA, and Stream Health for the active organization only.
   Customer-facing pages must not expose platform-only audit, customer browsing,
   raw upstream payloads, or cross-tenant facts.
-- **Platform View** is for Tier 1 Platform Admins. It covers Service Health,
-  SSO Providers, Operations Log, Audit Log, and the planned Brand Clouds
-  management UI. Platform View data and navigation are role-gated away from
-  Customer View.
+- **Platform View** is for Tier 1 Platform Admins. It covers Platform
+  Dashboard, Service Health, SSO Providers, Operations Log, Audit Log, and the
+  planned Brand Clouds management UI. Platform View data and navigation are
+  role-gated away from Customer View.
 
 The design and implementation context is split across these documents:
 
@@ -86,8 +86,9 @@ The design and implementation context is split across these documents:
 - [`docs/webui-customer-view-design.md`](docs/webui-customer-view-design.md):
   approved Customer View design direction and visual concepts.
 - [`docs/admin-dashboard-redesign.md`](docs/admin-dashboard-redesign.md):
-  Platform View structure for service health, SSO providers, operations, and
-  audit.
+  Customer/Platform View split and Platform View structure.
+- [`docs/platform-view-dashboard-design.md`](docs/platform-view-dashboard-design.md):
+  Platform Dashboard metrics, Prometheus source mapping, and BFF boundary.
 - [`docs/platform-brand-cloud-management-design.md`](docs/platform-brand-cloud-management-design.md):
   draft Platform View Brand Clouds GUI and workflow design.
 - [`docs/webui-implementation-roadmap.md`](docs/webui-implementation-roadmap.md):

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -45,6 +45,8 @@ Included in v0.1:
   - provisioning/deactivation actions in the device drawer
   - readiness, health, firmware, telemetry, and stream status displays
 - Platform admin pages:
+  - Platform Dashboard with cross-tenant summary and curated Prometheus-backed
+    operational metrics
   - service health
   - SSO provider status and settings
   - backend/BFF brand-cloud management routes for future Platform View Brand
@@ -229,6 +231,8 @@ The WebUI design history is documented in:
   approved Customer View visual concepts and state requirements
 - [`admin-dashboard-redesign.md`](admin-dashboard-redesign.md) for Platform
   View structure
+- [`platform-view-dashboard-design.md`](platform-view-dashboard-design.md) for
+  the Platform Dashboard metrics and Prometheus-backed source mapping
 - [`platform-brand-cloud-management-design.md`](platform-brand-cloud-management-design.md)
   for the Platform View Brand Clouds GUI draft
 - [`webui-implementation-roadmap.md`](webui-implementation-roadmap.md) for the

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -28,7 +28,7 @@
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 89.8% |
-| `rtk_cloud_admin/internal/app` | 80.5% |
+| `rtk_cloud_admin/internal/app` | 80.6% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |

--- a/docs/admin-dashboard-redesign.md
+++ b/docs/admin-dashboard-redesign.md
@@ -89,6 +89,7 @@ sidebar.
 **Platform View** — Tier 1 Platform Admin only:
 
 ```
+Dashboard        →  cross-tenant summary + curated Prometheus-backed metrics
 Service Health   →  moved from customer view
 SSO Providers    →  Account Manager-backed provider status/settings
 Operations       →  operations log (existing, refined)
@@ -356,6 +357,18 @@ Platform View is the home for brand-cloud administration. The dedicated
 Brand Clouds design is tracked in
 [platform-brand-cloud-management-design.md](platform-brand-cloud-management-design.md)
 and should be treated as the product/UX source for that future WebUI work.
+The dedicated Platform Dashboard metrics design is tracked in
+[platform-view-dashboard-design.md](platform-view-dashboard-design.md); it
+defines the Tier 1 landing page and the Prometheus-backed metrics that can be
+summarized in this product UI.
+
+### Platform Dashboard (new)
+
+Platform Dashboard is the Tier 1 landing page. It summarizes cross-tenant
+device/operation footprint, service health, Prometheus scrape health,
+cross-service risk, and infrastructure status. It is implemented by Admin
+Console as a curated product dashboard, not as an embedded Grafana replacement
+or a raw Prometheus query UI.
 
 ### Service Health (moved from Customer View)
 
@@ -617,7 +630,7 @@ The following are intentionally deferred:
     ├── Devices Table (improved)
     ├── Firmware & OTA (new)
     ├── Stream Health (new)
-    └── Platform View (Service Health, SSO Providers, Operations Log, Audit Log)
+    └── Platform View (Platform Dashboard, Service Health, SSO Providers, Operations Log, Audit Log)
 ```
 
 Backend work in rtk_video_cloud is the critical path dependency for

--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -114,8 +114,11 @@ Reference: `docs/assets/webui-design/customer-stream-health.png`
 ## Platform View Boundary
 
 - Customer View concept images do not complete Platform View design.
-- Platform View contains Service Health, SSO Providers, Operations Log, and Audit
-  Log for Tier 1 only.
+- Platform View contains Platform Dashboard, Service Health, SSO Providers,
+  Operations Log, and Audit Log for Tier 1 only.
+- Platform Dashboard follows `docs/platform-view-dashboard-design.md`: curated
+  cross-tenant metrics, Prometheus scrape health, and source-unavailable states,
+  not a raw Prometheus or Grafana replacement UI.
 - SSO Providers page shows organization provider status/settings through Account
   Manager-backed data, never stored provider secrets or raw IdP claims.
 - SSO Providers does not present SAML as implemented; OIDC is the first
@@ -137,7 +140,7 @@ Use this mapping when reviewing developer issues opened from
 | 5. Firmware & OTA read-only workflows | Firmware distribution, campaign summary/table, read-only drill-down, unsupported policies, firmware risk queue |
 | 6. Stream Health read-only workflows | Stream KPIs, trend, source-backed By Mode rows, per-device table, attention routing |
 | 7. Public auth, signup, verification, and quota UX polish | SSO-first login, signup/check-email/verify states, quota request states, break-glass secondary treatment |
-| 8. Platform View polish | Service Health, SSO Providers, Operations Log, Audit Log, Tier 1-only boundaries |
+| 8. Platform View polish | Platform Dashboard, Service Health, SSO Providers, Operations Log, Audit Log, Tier 1-only boundaries |
 | 9. Final WebUI browser QA and documentation signoff | Desktop/mobile browser smoke, visual checklist closure, documented remaining upstream blockers |
 
 ## Responsive Checks

--- a/docs/platform-view-dashboard-design.md
+++ b/docs/platform-view-dashboard-design.md
@@ -1,0 +1,310 @@
+# Platform View Dashboard Design
+
+Status: draft for product, UX, SRE, and developer review.
+
+Date: 2026-06-02
+
+Audience:
+
+- `rtk_cloud_admin` frontend and backend developers
+- SRE / operators maintaining Video Cloud Prometheus
+- product / QA reviewers for Platform View
+
+Related documents:
+
+- [SPEC.md](SPEC.md)
+- [ROLES.md](ROLES.md)
+- [admin-dashboard-redesign.md](admin-dashboard-redesign.md)
+- [backend-api-gap-audit.md](backend-api-gap-audit.md)
+- [private-cloud-deployment.md](private-cloud-deployment.md)
+- [rtk_cloud_contracts_doc/METRICS_EXPORT.md](../rtk_cloud_contracts_doc/METRICS_EXPORT.md)
+
+## Summary
+
+Platform Dashboard is the Tier 1 landing page for Realtek Platform Admins. It
+is a productized operations dashboard implemented in `rtk_cloud_admin`, not a
+Grafana replacement and not a public Prometheus browser.
+
+Grafana or Prometheus-native dashboards may still be useful for deep SRE
+debugging, alert authoring, and raw time-series exploration. The Platform
+Dashboard should instead show a curated, role-gated, product-aware overview:
+tenant/device footprint, service status, scrape health, cross-service risk,
+and a small set of infrastructure signals that help Platform Admins decide
+where to investigate next.
+
+`rtk_cloud_admin` owns the WebUI and BFF. Account Manager, Video Cloud, and
+Prometheus remain the sources of truth for their respective facts.
+
+## Product Goals
+
+- Give Tier 1 Platform Admins a first-screen answer to whether the platform is
+  healthy enough for tenant operations.
+- Summarize cross-tenant fleet footprint without exposing Customer View-only
+  workflows or tenant write actions.
+- Surface Prometheus scrape health and core operational metrics in product
+  language.
+- Link from summary cards to existing Platform View drill-down pages:
+  Service Health, SSO Providers, Operations Log, Audit Log, and future Brand
+  Clouds.
+- Keep raw Prometheus labels, host details, and arbitrary query construction
+  out of the product UI.
+
+## Non-Goals
+
+- Replacing Grafana for raw observability, ad hoc PromQL, alert rule authoring,
+  or host-level forensic debugging.
+- Showing customer-visible Insights from raw Prometheus metrics.
+- Exposing Prometheus publicly or querying Prometheus directly from browser
+  JavaScript.
+- Adding tenant impersonation, lifecycle write actions, or device operations
+  from Platform View.
+- Showing high-cardinality or sensitive labels such as device id, user id,
+  email, IP address, request id, serial number, MAC address, access token, or
+  session id.
+
+## Navigation Placement
+
+Recommended Platform View nav order:
+
+1. Platform Dashboard
+2. Service Health
+3. Brand Clouds
+4. SSO Providers
+5. Operations Log
+6. Audit Log
+
+`Service Health` remains a dedicated drill-down page. `Platform Dashboard`
+summarizes service and metrics health at a higher level and links to deeper
+surfaces.
+
+## Page Layout
+
+```
+Platform View / Platform Dashboard
+Cross-tenant operating status for Realtek Platform Admins.
+
+[Tenants] [Devices Online] [Open Operations] [Scrape Targets Down]
+
+Service & Scrape Health
+| Account Manager | Video Cloud API | Cloud Admin | Prometheus | SQLite |
+
+Tenant & Device Footprint                         Operation Risk
+| Readiness distribution | top customer risks |    | open ops | failed ops | dead letters |
+
+Runtime Health                                    Infrastructure Health
+| request rate / 5xx / latency by service |       | CPU | memory | disk | nginx | postgres | redis | nats | emqx |
+
+Business Signals                                  Recent Platform Activity
+| quota requests | eval signups | blob use |       | audit + ops links |
+```
+
+The page should use the existing Realtek Ops Console visual system:
+compact KPI strip, dense tables, restrained status labels, and right-side
+drill-down links. Do not use marketing hero sections or decorative charts.
+
+## Data Sources
+
+| Source | Used for | Access path |
+| --- | --- | --- |
+| Admin BFF read models | tenants, devices, readiness counts, open operations | `/api/admin/summary`, `/api/admin/customers`, `/api/admin/devices`, `/api/admin/operations` |
+| Admin BFF service health | Account Manager, Video Cloud, SQLite status | `/api/admin/service-health` |
+| Admin BFF audit | recent platform activity | `/api/admin/audit` |
+| Account Manager | SSO setup status, quota requests, brand-cloud ownership | Account Manager-backed BFF routes |
+| Video Cloud Prometheus | runtime, cross-service, device aggregate, infrastructure metrics | server-side query through `VIDEO_CLOUD_PROMETHEUS_BASE_URL` |
+
+Prometheus queries must run from the Go BFF with short timeouts and stable
+allowlisted query definitions. The browser should call Admin Console JSON
+routes, not Prometheus directly.
+
+## Current Prometheus Scrape Inventory
+
+This inventory is based on the repo-owned current configured scrape inventory
+in `rtk_cloud_workspace/repos/rtk_video_cloud/docs/prometheus-metrics-inventory.md`
+and the Admin deployment docs in this repo. Live verification should still use
+the Prometheus API after deployment:
+
+```sh
+curl -fsS http://10.42.1.30:9090/api/v1/targets
+curl -fsS http://10.42.1.30:9090/api/v1/label/__name__/values
+```
+
+Current configured targets:
+
+| Job | Target | Path | Dashboard use |
+| --- | --- | --- | --- |
+| `prometheus` | `10.42.1.30:9090` | `/metrics` | Prometheus self-health |
+| `nats` | `10.42.1.30:8222` | `/metrics` | message bus / JetStream health |
+| `nginx` role `edge` | `10.42.1.5:9113` | `/metrics` | public gateway health |
+| `nginx` role `admin` | `10.42.1.60:9113` | `/metrics` | Admin gateway health |
+| `postgres` role `infra` | `10.42.1.30:9187` | `/metrics` | database exporter health |
+| `redis` role `infra` | `10.42.1.30:9121` | `/metrics` | cache exporter health |
+| `emqx` role `mqtt` | `10.42.1.40:18083` | `/api/v5/prometheus/stats` | MQTT broker health |
+| `video_cloud_app` service `api` | `10.42.1.10:18080` | `/metrics/prometheus` | Video Cloud API runtime |
+| `video_cloud_app` service `crossservice` | `10.42.1.10:18180` | `/metrics/prometheus` | bus/worker runtime |
+| `video_cloud_app` service `turnregistry` | `10.42.1.10:18190` | `/metrics/prometheus` | TURN registry runtime |
+| `video_cloud_app` service `metricsexporter` | `10.42.1.10:19200` | `/metrics/prometheus` | aggregate device/blob metrics |
+| `video_cloud_app` service `logingester` | `10.42.1.10:19300` | `/metrics/prometheus` | device log ingestion |
+| `node` role `edge` | `10.42.1.5:9100` | `/metrics` | edge host health |
+| `node` role `api` | `10.42.1.10:9100` | `/metrics` | api host health |
+| `node` role `infra` | `10.42.1.30:9100` | `/metrics` | infra host health |
+| `node` role `mqtt` | `10.42.1.40:9100` | `/metrics` | mqtt host health |
+| `node` role `admin` | `10.42.1.60:9100` | `/metrics` | admin host health |
+| `account_manager_app` | `10.42.1.20:18081` | `/metrics/prometheus` | Account Manager app signals |
+| `cloud_admin_app` | `10.42.1.60:8080` | `/metrics/prometheus` | Admin app up signal |
+| `cloud_frontend_app` | `10.42.1.70:8080` | `/metrics/prometheus` | marketing/signup frontend signals |
+
+Do not show this table as a raw target list in the first UI. Convert it into
+aggregated health groups and drill-down rows.
+
+## Dashboard Metrics
+
+### KPI Strip
+
+| KPI | Primary source | Notes |
+| --- | --- | --- |
+| Tenants | `/api/admin/summary.customers` | Cross-tenant count. |
+| Devices Online | `/api/admin/summary.online_devices / total_devices` | Show count and rate. |
+| Open Operations | `/api/admin/summary.open_operations` | Link to Operations Log filtered to non-succeeded states. |
+| Scrape Targets Down | Prometheus `up == 0` by allowlisted jobs | Link to Service Health / Prometheus status panel. |
+
+### Service And Scrape Health
+
+| Metric | Prometheus query shape | UI treatment |
+| --- | --- | --- |
+| Target availability | `sum by(job, service, role) (up)` | Group into App, Host, Data, Broker, Gateway. |
+| Targets down | `sum by(job, service, role) (up == 0)` | Red/yellow count with affected group names. |
+| Scrape duration | `scrape_duration_seconds` | Warning only when unusually high. |
+| Samples scraped | `scrape_samples_scraped` | Support detail; not a primary KPI. |
+
+### Runtime Health
+
+| Metric | Prometheus query shape | UI treatment |
+| --- | --- | --- |
+| Request rate | `sum by(service) (rate(http_requests_total[5m]))` | Compact service table. |
+| 5xx rate | `sum by(service) (rate(http_status_group_total{status="5xx"}[5m]))` | Highlight services with non-zero 5xx. |
+| Average latency | `sum by(service) (rate(http_request_duration_seconds_sum[5m])) / sum by(service) (rate(http_request_duration_seconds_count[5m]))` | Show pithy "avg latency" value; avoid implying p95. |
+| App up | `rtk_account_manager_up`, `rtk_cloud_admin_up`, `rtk_cloud_frontend_up` | Use as app endpoint status. |
+
+### Cross-Service Risk
+
+| Metric | Prometheus query shape | UI treatment |
+| --- | --- | --- |
+| Consumer backlog | `crossservice_bus_consumer_pending_messages` | Show worst streams/consumers. |
+| Worker outcomes | `increase(crossservice_worker_outcomes_total[1h])` | Summarize succeeded/failed/pending. |
+| Dead letters | `increase(crossservice_worker_dead_letters_total[1h])` | High-priority risk card and Operations Log link. |
+| Publish/consume errors | `increase(crossservice_bus_publish_total{status="error"}[1h])`, `increase(crossservice_bus_consume_total{status="error"}[1h])` | Show only aggregate counts and service context. |
+
+### Domain And Business Signals
+
+| Metric | Prometheus query shape | UI treatment |
+| --- | --- | --- |
+| Video Cloud devices | `video_cloud_devices_online`, `video_cloud_devices_activated`, `video_cloud_devices_connected` | Compare with Admin BFF readiness counts; mark discrepancy as investigation item. |
+| Blob utilization | `video_cloud_blob_capacity_utilization_percent` | Capacity risk card. |
+| Exporter freshness | `time() - video_cloud_exporter_last_collect_timestamp_seconds` | Show stale/healthy state. |
+| Exporter success | `video_cloud_exporter_last_collect_success` | Show last collect failed as source issue. |
+| Account Manager quota requests | `rtk_account_manager_quota_raise_requests` | Pending quota review indicator. |
+| Evaluation signups | `increase(rtk_account_manager_eval_signups_total[24h])` | Optional business signal; keep below operational panels. |
+| Lifecycle operation counts | `rtk_account_manager_lifecycle_operations` | Compare against Operations Log shape when useful. |
+| Frontend leads | `rtk_cloud_frontend_leads_total` | Optional marketing/signup context, not an operations KPI. |
+
+### Infrastructure Health
+
+| Metric group | Query approach | UI treatment |
+| --- | --- | --- |
+| CPU | Node exporter `node_cpu_*` aggregated by `role` | Show role-level utilization only. |
+| Memory | Node exporter memory available/total by `role` | Show role-level utilization only. |
+| Disk | Node filesystem utilization by `role` and mount | Show warning for high root/data utilization. |
+| nginx | `nginx_up`, `nginx_connections_*`, `nginx_http_requests_total` | Gateway status summary. |
+| PostgreSQL | `up{job="postgres"}` plus exporter-specific `pg_*` detail | Primary card is availability; deep DB charts remain Grafana/SRE. |
+| Redis | `up{job="redis"}` plus exporter-specific `redis_*` detail | Primary card is availability. |
+| NATS | `up{job="nats"}` plus NATS/JetStream families | Primary card is availability and backlog risk. |
+| EMQX | `up{job="emqx"}` plus broker/client/session families | Primary card is availability and broker pressure. |
+
+## Drill-Down Behavior
+
+- `Tenants` links to the customer/tenant list when available.
+- `Devices Online` links to the cross-tenant device read model or to a
+  role-gated future cross-tenant device detail surface.
+- `Open Operations` links to Operations Log filtered to active or failed states.
+- `Scrape Targets Down` links to the Service Health panel with affected jobs.
+- SSO setup warnings link to SSO Providers.
+- Brand-cloud setup warnings link to Brand Clouds after that UI is implemented.
+
+## Page States
+
+- Loading: skeleton KPI cards and panel-level loading rows.
+- Prometheus not configured: show the BFF/admin read-model sections and a
+  "Prometheus source unavailable" panel. Do not hide the whole dashboard.
+- Prometheus query failed: show a retryable source-unavailable state with the
+  source category, not raw upstream payloads.
+- No series returned: show "No metrics reported for this query window" and keep
+  the relevant BFF data visible.
+- Partial source unavailable: degrade only the affected panel.
+- Wrong role: show Platform View access gate; never render Customer View data as
+  fallback.
+
+## Backend/BFF Requirements
+
+Add a small, allowlisted Platform metrics BFF surface instead of exposing
+Prometheus directly:
+
+- `GET /api/admin/platform-dashboard`: composed dashboard payload for the page.
+- Optional `GET /api/admin/platform-dashboard/prometheus-status`: scrape target
+  health summary for service-health drill-downs.
+
+Implementation requirements:
+
+- Require Account Manager-backed or break-glass Platform Admin session according
+  to the existing Platform View guard rules.
+- Query only configured Prometheus base URL from `VIDEO_CLOUD_PROMETHEUS_BASE_URL`.
+- Use short timeouts and return stable source-unavailable states.
+- Keep PromQL definitions server-side and allowlisted.
+- Cache dashboard Prometheus results briefly to avoid refreshing multiple panels
+  with duplicate queries.
+- Redact raw upstream errors before returning browser payloads.
+
+## Acceptance Criteria
+
+- Platform Dashboard is visible only to Tier 1 Platform Admin sessions.
+- Customer users cannot see Platform Dashboard data or nav.
+- The first viewport shows tenant/device footprint, open operation risk, and
+  scrape health.
+- Prometheus-backed panels clearly distinguish configured, unavailable, stale,
+  and empty states.
+- Prometheus data is grouped into product/SRE-friendly panels, not shown as raw
+  target or series dumps.
+- No browser code calls Prometheus directly.
+- No high-cardinality or sensitive labels are displayed.
+- Grafana remains optional deep observability tooling; it is not presented as
+  the Platform Admin product UI.
+
+## Required Tests
+
+Implementation PRs should include:
+
+- Backend tests for Platform Admin guard behavior.
+- Backend tests for Prometheus query timeout/unavailable handling.
+- Backend tests for allowed query composition and redacted errors.
+- Frontend tests for loading, unavailable, empty, and partial source states.
+- `cd web && npm test`
+- `cd web && npm run build`
+- `go test ./...` when backend code changes.
+
+Manual QA should verify:
+
+- Platform Admin with Prometheus configured.
+- Platform Admin with Prometheus unset.
+- Platform Admin with Prometheus returning one down target.
+- Customer user route guard.
+- Mobile-width layout without table/control overflow.
+
+## Open Questions
+
+1. Should the visible page label be `Platform Dashboard`, `Platform Overview`,
+   or `Operations Dashboard`?
+2. Should break-glass Platform Admin sessions see Prometheus-backed panels, or
+   only Account Manager-backed Platform Admin sessions?
+3. Which source should win when Admin BFF readiness counts and
+   `video_cloud_devices_*` aggregate metrics disagree?
+4. Should SRE-only host detail links point to a future Grafana URL when Grafana
+   exists, or remain text-only in this product UI?

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -105,6 +105,9 @@ state.
 In production, upstream failures must be visible. The dashboard should surface
 gateway errors instead of silently falling back when a configured upstream is
 unreachable.
+Platform Dashboard Prometheus panels are sourced through the Admin BFF using
+`VIDEO_CLOUD_PROMETHEUS_BASE_URL`; browser JavaScript must not call Prometheus
+directly, and Prometheus must remain private to the VPC.
 
 ## Backup, Restore, And Rollback
 

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -12,6 +12,7 @@ Related documents:
 
 - [webui-customer-view-design.md](webui-customer-view-design.md)
 - [admin-dashboard-redesign.md](admin-dashboard-redesign.md)
+- [platform-view-dashboard-design.md](platform-view-dashboard-design.md)
 - [platform-brand-cloud-management-design.md](platform-brand-cloud-management-design.md)
 - [customer-view-visual-qa-checklist.md](customer-view-visual-qa-checklist.md)
 - [backend-api-gap-audit.md](backend-api-gap-audit.md)
@@ -29,9 +30,10 @@ production data work in `rtk_video_cloud` or `rtk_account_manager` is tracked as
 a dependency note only; do not open upstream issues as part of this batch.
 
 This roadmap tracks the completed first WebUI implementation sequence for
-Customer View, auth, and the initial Platform View pages. Brand Clouds is the
-next Platform View design extension; its GUI draft and future issue breakdown
-live in
+Customer View, auth, and the initial Platform View pages. Platform Dashboard
+metrics and Brand Clouds are subsequent Platform View design extensions; their
+drafts live in
+[platform-view-dashboard-design.md](platform-view-dashboard-design.md) and
 [platform-brand-cloud-management-design.md](platform-brand-cloud-management-design.md).
 
 ## Issue Body Template
@@ -473,6 +475,8 @@ Platform View separation.
 ## Scope
 
 - Polish Service Health, including Platform-only demo mode banner behavior.
+- Add Platform Dashboard as the Tier 1 landing page when the metrics BFF surface
+  is implemented; follow `platform-view-dashboard-design.md`.
 - Complete SSO Providers status/settings surface through Account Manager-backed
   data.
 - Complete Operations Log with Friendly Summary, raw type/state as Platform-only


### PR DESCRIPTION
## Summary

- add a Platform View dashboard design/spec for Tier 1 operators
- map configured Prometheus scrape targets and metric families to dashboard panels
- update README, SPEC, Platform View, QA, deployment, and roadmap docs to reference the new dashboard design

## Notes

- This is docs-only.
- Staging Prometheus live target verification was attempted but SSH to the staging edge timed out, so the spec labels the scrape list as repo-owned configured inventory and includes live verification commands.

## Validation

- git diff --check origin/main..HEAD