### PR TITLE
[codex] Fix contracts doc submodule URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
           git config --global \
             url."https://x-access-token:${CONTRACTS_REPO_TOKEN}@github.com/hkt999rtk/rtk_cloud_contracts_doc.git".insteadOf \
             "https://github.com/hkt999rtk/rtk_cloud_contracts_doc.git"
+          git config --global --add \
+            url."https://x-access-token:${CONTRACTS_REPO_TOKEN}@github.com/hkt999rtk/rtk_cloud_contracts_doc.git".insteadOf \
+            "git@github.com-work:hkt999rtk/rtk_cloud_contracts_doc.git"
           git submodule update --init --depth=1 rtk_cloud_contracts_doc
 
       - uses: actions/setup-go@v5

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rtk_cloud_contracts_doc"]
 	path = rtk_cloud_contracts_doc
-	url = https://github.com/hkt999rtk/rtk_cloud_contracts_doc.git
+	url = git@github.com-work:hkt999rtk/rtk_cloud_contracts_doc.git


### PR DESCRIPTION
## Summary
- Update the nested contracts-doc submodule URL to use the github.com-work SSH alias.
- Avoid recursive pulls falling back to GitHub HTTPS credentials.

## Root cause
The nested .gitmodules entry used https://github.com/hkt999rtk/rtk_cloud_contracts_doc.git while the workspace uses git@github.com-work:hkt999rtk/... remotes. Recursive submodule fetches could therefore prompt for HTTPS credentials.

## Validation
- Ran `git submodule sync --recursive`.
- Ran `git fetch --recurse-submodules` successfully.