### PR TITLE
Add Platform Dashboard BFF boundary

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -136,6 +136,8 @@ Public and shared routes:
 - `GET /api/me`: current user, memberships, active organization, and demo/auth state.
 - `POST /api/me/active-org`: switches active organization for the current session.
 - `GET /api/summary`: customer and platform dashboard summary.
+- `GET /api/admin/platform-dashboard`: platform-admin protected Platform
+  Dashboard BFF contract with server-side allowlisted Prometheus queries.
 - `GET /api/devices`: device list from cache/demo or upstream aggregation.
 - `GET /api/devices/{id}`: device detail.
 - `POST /api/devices/{id}/provision`: starts or simulates provisioning.

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.5% |
+| Go total coverage | 80.7% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,7 +28,7 @@
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 89.8% |
-| `rtk_cloud_admin/internal/app` | 80.6% |
+| `rtk_cloud_admin/internal/app` | 80.9% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |

--- a/docs/backend-api-gap-audit.md
+++ b/docs/backend-api-gap-audit.md
@@ -42,6 +42,7 @@ from Account Manager or Video Cloud before server validation is complete.
 | Fleet stream | `GET /api/fleet/stream-stats` | api shape implemented / production source pending | BFF route exists, but production validation requires WebRTC session event data from Video Cloud or an equivalent normalized read model, not local estimates. |
 | Firmware | `GET /api/fleet/firmware-distribution` | api shape implemented / production source pending | BFF route exists and proxies firmware endpoints when configured. Production validation requires observed firmware and rollout facts; generated fallback versions are not acceptable. |
 | Platform dashboard | `GET /api/admin/summary` | implemented | Platform-admin protected. Returns cross-tenant customer/device/operation summary. |
+| Platform dashboard | `GET /api/admin/platform-dashboard` | api shape implemented / composition pending | Platform-admin protected BFF boundary for existing summary data and allowlisted server-side Prometheus queries. Returns stable Prometheus source states instead of leaking raw upstream errors. |
 | Platform dashboard | `GET /api/admin/customers` | implemented | Platform-admin protected. Returns organization id/name, totals, readiness buckets, and last seen. |
 | Platform dashboard | `GET /api/admin/devices` | implemented | Platform-admin protected. Returns all device read models with organization, readiness, firmware, health, signal quality, and source facts. |
 | Platform operations | `GET /api/admin/operations` | implemented | Platform-admin protected. |
@@ -76,11 +77,17 @@ Status: implemented.
 The platform admin dashboard can read:
 
 - `GET /api/admin/summary`
+- `GET /api/admin/platform-dashboard`
 - `GET /api/admin/customers`
 - `GET /api/admin/devices`
 
 These endpoints are guarded by `platform_admin` sessions. Customer sessions are
 rejected and unauthenticated requests return `401`.
+
+`GET /api/admin/platform-dashboard` is the server-side Prometheus boundary for
+Platform Dashboard. It uses `VIDEO_CLOUD_PROMETHEUS_BASE_URL` from the BFF,
+runs only repo-owned allowlisted query definitions, and returns source states
+`configured`, `unconfigured`, `unavailable`, `empty`, or `stale`.
 
 The device read model is additive and includes customer organization, readiness,
 firmware version, source facts, health, signal quality, last seen, and updated

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -368,6 +368,28 @@ paths:
         "502":
           $ref: "#/components/responses/PlainTextError"
 
+  /api/admin/platform-dashboard:
+    get:
+      tags: [Platform Admin]
+      summary: Platform Dashboard BFF payload
+      description: |
+        Platform-admin protected dashboard boundary. The BFF composes existing
+        admin read-model summary data and server-side allowlisted Prometheus
+        queries. Browser clients never receive a raw Prometheus passthrough.
+      responses:
+        "200":
+          description: Platform Dashboard payload with per-source states.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PlatformDashboard"
+        "401":
+          $ref: "#/components/responses/PlainTextError"
+        "403":
+          $ref: "#/components/responses/PlainTextError"
+        "502":
+          $ref: "#/components/responses/PlainTextError"
+
   /api/customers:
     get:
       tags: [Customer]
@@ -1496,6 +1518,69 @@ components:
         updated_at:
           type: string
           format: date-time
+    PlatformDashboard:
+      type: object
+      required: [summary, sources, prometheus]
+      properties:
+        summary:
+          $ref: "#/components/schemas/Summary"
+        sources:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/PlatformDashboardSource"
+        prometheus:
+          $ref: "#/components/schemas/PlatformDashboardPrometheus"
+    PlatformDashboardSource:
+      type: object
+      required: [source_status]
+      properties:
+        source_status:
+          type: string
+          enum: [configured, unconfigured, unavailable, empty, stale]
+        source_message:
+          type: string
+        checked_at:
+          type: string
+          format: date-time
+    PlatformDashboardPrometheus:
+      type: object
+      required: [queries]
+      properties:
+        queries:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformDashboardPrometheusQuery"
+    PlatformDashboardPrometheusQuery:
+      type: object
+      required: [id, title, source_status, series]
+      properties:
+        id:
+          type: string
+          enum: [scrape_targets_up, scrape_targets_down, exporter_freshness_seconds]
+        title:
+          type: string
+        source_status:
+          type: string
+          enum: [configured, unconfigured, unavailable, empty, stale]
+        checked_at:
+          type: string
+          format: date-time
+        series:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformDashboardPrometheusSeries"
+    PlatformDashboardPrometheusSeries:
+      type: object
+      required: [labels, value]
+      properties:
+        labels:
+          type: object
+          description: Allowlisted Prometheus labels only: job, service, and role.
+          additionalProperties:
+            type: string
+        value:
+          type: number
+          format: double
     ServiceHealth:
       type: object
       required: [name, status, detail]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -93,6 +93,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /metrics/prometheus", s.metricsPrometheus)
 	s.mux.HandleFunc("GET /api/summary", s.apiSummary)
 	s.mux.HandleFunc("GET /api/admin/summary", s.apiAdminSummary)
+	s.mux.HandleFunc("GET /api/admin/platform-dashboard", s.apiAdminPlatformDashboard)
 	s.mux.HandleFunc("GET /api/me", s.apiMe)
 	s.mux.HandleFunc("POST /api/me/active-org", s.apiActiveOrg)
 	s.mux.HandleFunc("POST /api/auth/customer/signup", s.apiCustomerSignup)

--- a/internal/app/platform_dashboard.go
+++ b/internal/app/platform_dashboard.go
@@ -1,0 +1,279 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"rtk_cloud_admin/internal/contracts"
+	"rtk_cloud_admin/internal/store"
+)
+
+const (
+	platformDashboardSourceConfigured   = "configured"
+	platformDashboardSourceUnconfigured = "unconfigured"
+	platformDashboardSourceUnavailable  = "unavailable"
+	platformDashboardSourceEmpty        = "empty"
+	platformDashboardSourceStale        = "stale"
+
+	platformDashboardPrometheusSource = "prometheus"
+)
+
+var platformDashboardPrometheusQueries = []prometheusQueryDefinition{
+	{
+		ID:    "scrape_targets_up",
+		Title: "Scrape targets up",
+		Query: `sum by(job, service, role) (up)`,
+	},
+	{
+		ID:    "scrape_targets_down",
+		Title: "Scrape targets down",
+		Query: `sum by(job, service, role) (up == 0)`,
+	},
+	{
+		ID:           "exporter_freshness_seconds",
+		Title:        "Exporter freshness",
+		Query:        `time() - video_cloud_exporter_last_collect_timestamp_seconds`,
+		StaleAfter:   5 * time.Minute,
+		StaleMessage: "Prometheus data is stale.",
+	},
+}
+
+type prometheusQueryDefinition struct {
+	ID           string
+	Title        string
+	Query        string
+	StaleAfter   time.Duration
+	StaleMessage string
+}
+
+type prometheusClient struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+func (s *Server) apiAdminPlatformDashboard(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requirePlatformAdmin(w, r)
+	if !ok {
+		return
+	}
+	summary, err := s.platformDashboardSummary(r.Context(), session)
+	if err != nil {
+		s.writeUpstreamReadError(w, err)
+		return
+	}
+	writeJSON(w, s.platformDashboard(r.Context(), summary))
+}
+
+func (s *Server) platformDashboardSummary(ctx context.Context, session store.Session) (contracts.Summary, error) {
+	if s.usePlatformAdminUpstream(session) {
+		return s.platformAdminSummary(ctx, session)
+	}
+	return s.store.Summary()
+}
+
+func (s *Server) platformDashboard(ctx context.Context, summary contracts.Summary) contracts.PlatformDashboard {
+	checkedAt := time.Now().UTC().Format(time.RFC3339)
+	source := contracts.PlatformDashboardSource{
+		SourceStatus:  platformDashboardSourceUnconfigured,
+		SourceMessage: "Prometheus is not configured.",
+		CheckedAt:     checkedAt,
+	}
+	queries := make([]contracts.PlatformDashboardPrometheusQuery, 0, len(platformDashboardPrometheusQueries))
+	client := newPrometheusClient(s.cfg.VideoCloudPrometheusBaseURL)
+	if !client.configured() {
+		for _, def := range platformDashboardPrometheusQueries {
+			queries = append(queries, contracts.PlatformDashboardPrometheusQuery{
+				ID:           def.ID,
+				Title:        def.Title,
+				SourceStatus: platformDashboardSourceUnconfigured,
+				CheckedAt:    checkedAt,
+				Series:       []contracts.PlatformDashboardPrometheusSeries{},
+			})
+		}
+		return contracts.PlatformDashboard{
+			Summary: summary,
+			Sources: map[string]contracts.PlatformDashboardSource{
+				platformDashboardPrometheusSource: source,
+			},
+			Prometheus: contracts.PlatformDashboardPrometheus{Queries: queries},
+		}
+	}
+
+	source.SourceStatus = platformDashboardSourceConfigured
+	source.SourceMessage = ""
+	anyUnavailable := false
+	anyStale := false
+	anyConfigured := false
+	anyEmpty := false
+	for _, def := range platformDashboardPrometheusQueries {
+		result, err := client.query(ctx, def)
+		if err != nil {
+			anyUnavailable = true
+			queries = append(queries, unavailablePlatformDashboardQuery(def, checkedAt))
+			continue
+		}
+		switch result.SourceStatus {
+		case platformDashboardSourceStale:
+			anyStale = true
+		case platformDashboardSourceConfigured:
+			anyConfigured = true
+		case platformDashboardSourceEmpty:
+			anyEmpty = true
+		}
+		queries = append(queries, result)
+	}
+	switch {
+	case anyUnavailable:
+		source.SourceStatus = platformDashboardSourceUnavailable
+		source.SourceMessage = "Prometheus source is unavailable."
+	case anyStale:
+		source.SourceStatus = platformDashboardSourceStale
+		source.SourceMessage = "Prometheus data is stale."
+	case anyConfigured:
+		source.SourceStatus = platformDashboardSourceConfigured
+	case anyEmpty:
+		source.SourceStatus = platformDashboardSourceEmpty
+		source.SourceMessage = "Prometheus returned no dashboard data."
+	}
+	source.CheckedAt = checkedAt
+	return contracts.PlatformDashboard{
+		Summary: summary,
+		Sources: map[string]contracts.PlatformDashboardSource{
+			platformDashboardPrometheusSource: source,
+		},
+		Prometheus: contracts.PlatformDashboardPrometheus{Queries: queries},
+	}
+}
+
+func newPrometheusClient(baseURL string) prometheusClient {
+	return prometheusClient{
+		baseURL: strings.TrimRight(strings.TrimSpace(baseURL), "/"),
+		httpClient: &http.Client{
+			Timeout: 2 * time.Second,
+		},
+	}
+}
+
+func (c prometheusClient) configured() bool {
+	return c.baseURL != ""
+}
+
+func (c prometheusClient) query(ctx context.Context, def prometheusQueryDefinition) (contracts.PlatformDashboardPrometheusQuery, error) {
+	if !c.configured() {
+		return contracts.PlatformDashboardPrometheusQuery{}, errors.New("prometheus is not configured")
+	}
+	endpoint, err := url.Parse(c.baseURL + "/api/v1/query")
+	if err != nil {
+		return contracts.PlatformDashboardPrometheusQuery{}, err
+	}
+	query := endpoint.Query()
+	query.Set("query", def.Query)
+	endpoint.RawQuery = query.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint.String(), nil)
+	if err != nil {
+		return contracts.PlatformDashboardPrometheusQuery{}, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return contracts.PlatformDashboardPrometheusQuery{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return contracts.PlatformDashboardPrometheusQuery{}, fmt.Errorf("prometheus query failed with status %d", resp.StatusCode)
+	}
+	var body prometheusQueryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return contracts.PlatformDashboardPrometheusQuery{}, err
+	}
+	if body.Status != "success" || body.Data.ResultType != "vector" {
+		return contracts.PlatformDashboardPrometheusQuery{}, errors.New("prometheus returned an unsupported response")
+	}
+
+	checkedAt := time.Now().UTC().Format(time.RFC3339)
+	result := contracts.PlatformDashboardPrometheusQuery{
+		ID:           def.ID,
+		Title:        def.Title,
+		SourceStatus: platformDashboardSourceConfigured,
+		CheckedAt:    checkedAt,
+		Series:       []contracts.PlatformDashboardPrometheusSeries{},
+	}
+	for _, item := range body.Data.Result {
+		value, ok := item.floatValue()
+		if !ok {
+			continue
+		}
+		result.Series = append(result.Series, contracts.PlatformDashboardPrometheusSeries{
+			Labels: allowlistedPrometheusLabels(item.Metric),
+			Value:  value,
+		})
+	}
+	if len(result.Series) == 0 {
+		result.SourceStatus = platformDashboardSourceEmpty
+		return result, nil
+	}
+	if def.StaleAfter > 0 {
+		for _, series := range result.Series {
+			if series.Value > def.StaleAfter.Seconds() {
+				result.SourceStatus = platformDashboardSourceStale
+				return result, nil
+			}
+		}
+	}
+	return result, nil
+}
+
+func unavailablePlatformDashboardQuery(def prometheusQueryDefinition, checkedAt string) contracts.PlatformDashboardPrometheusQuery {
+	return contracts.PlatformDashboardPrometheusQuery{
+		ID:           def.ID,
+		Title:        def.Title,
+		SourceStatus: platformDashboardSourceUnavailable,
+		CheckedAt:    checkedAt,
+		Series:       []contracts.PlatformDashboardPrometheusSeries{},
+	}
+}
+
+func allowlistedPrometheusLabels(labels map[string]string) map[string]string {
+	out := map[string]string{}
+	for _, key := range []string{"job", "service", "role"} {
+		if value := strings.TrimSpace(labels[key]); value != "" {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+type prometheusQueryResponse struct {
+	Status string `json:"status"`
+	Data   struct {
+		ResultType string                 `json:"resultType"`
+		Result     []prometheusVectorItem `json:"result"`
+	} `json:"data"`
+}
+
+type prometheusVectorItem struct {
+	Metric map[string]string `json:"metric"`
+	Value  []any             `json:"value"`
+}
+
+func (v prometheusVectorItem) floatValue() (float64, bool) {
+	if len(v.Value) < 2 {
+		return 0, false
+	}
+	switch value := v.Value[1].(type) {
+	case string:
+		parsed, err := strconv.ParseFloat(value, 64)
+		return parsed, err == nil
+	case float64:
+		return value, true
+	default:
+		return 0, false
+	}
+}

--- a/internal/app/platform_dashboard_test.go
+++ b/internal/app/platform_dashboard_test.go
@@ -1,0 +1,222 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"rtk_cloud_admin/internal/config"
+	"rtk_cloud_admin/internal/contracts"
+)
+
+func TestAdminPlatformDashboardRequiresPlatformSession(t *testing.T) {
+	t.Parallel()
+
+	st := mustOpenStore(t)
+	srv := New(st)
+
+	unauthenticated := httptest.NewRecorder()
+	srv.ServeHTTP(unauthenticated, httptest.NewRequest(http.MethodGet, "/api/admin/platform-dashboard", nil))
+	if unauthenticated.Code != http.StatusUnauthorized {
+		t.Fatalf("unauthenticated status = %d, want %d", unauthenticated.Code, http.StatusUnauthorized)
+	}
+
+	customer, err := st.CreateSession("customer", "u1", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession customer returned error: %v", err)
+	}
+	customerReq := httptest.NewRequest(http.MethodGet, "/api/admin/platform-dashboard", nil)
+	customerReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: customer.ID})
+	customerRec := httptest.NewRecorder()
+	srv.ServeHTTP(customerRec, customerReq)
+	if customerRec.Code != http.StatusForbidden {
+		t.Fatalf("customer status = %d, want %d; body=%s", customerRec.Code, http.StatusForbidden, customerRec.Body.String())
+	}
+}
+
+func TestAdminPlatformDashboardUnconfiguredPrometheusReturnsSummary(t *testing.T) {
+	t.Parallel()
+
+	st := mustOpenStore(t)
+	srv := New(st)
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	payload := getPlatformDashboard(t, srv, session.ID)
+	if payload.Summary.TotalDevices == 0 || payload.Summary.Customers == 0 {
+		t.Fatalf("summary did not include BFF data: %+v", payload.Summary)
+	}
+	source := payload.Sources["prometheus"]
+	if source.SourceStatus != "unconfigured" {
+		t.Fatalf("prometheus source_status = %q, want unconfigured", source.SourceStatus)
+	}
+	if len(payload.Prometheus.Queries) == 0 {
+		t.Fatalf("prometheus queries are empty")
+	}
+	for _, query := range payload.Prometheus.Queries {
+		if query.SourceStatus != "unconfigured" {
+			t.Fatalf("%s source_status = %q, want unconfigured", query.ID, query.SourceStatus)
+		}
+	}
+}
+
+func TestAdminPlatformDashboardPrometheusUnavailableIsRedacted(t *testing.T) {
+	t.Parallel()
+
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `upstream_operation_id=op-9 raw_payload={"secret":true}`, http.StatusBadGateway)
+	}))
+	defer prometheus.Close()
+
+	st := mustOpenStore(t)
+	srv := NewWithOptions(st, Options{Config: config.Config{VideoCloudPrometheusBaseURL: prometheus.URL}})
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	payload := getPlatformDashboard(t, srv, session.ID)
+	if payload.Summary.TotalDevices == 0 {
+		t.Fatalf("summary degraded with prometheus failure: %+v", payload.Summary)
+	}
+	source := payload.Sources["prometheus"]
+	if source.SourceStatus != "unavailable" {
+		t.Fatalf("prometheus source_status = %q, want unavailable", source.SourceStatus)
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	for _, leaked := range []string{"raw_payload", "op-9", "secret", "upstream_operation_id"} {
+		if strings.Contains(string(body), leaked) {
+			t.Fatalf("payload leaked %q: %s", leaked, body)
+		}
+	}
+}
+
+func TestAdminPlatformDashboardPrometheusEmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer prometheus.Close()
+
+	st := mustOpenStore(t)
+	srv := NewWithOptions(st, Options{Config: config.Config{VideoCloudPrometheusBaseURL: prometheus.URL}})
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	payload := getPlatformDashboard(t, srv, session.ID)
+	if payload.Sources["prometheus"].SourceStatus != "empty" {
+		t.Fatalf("prometheus source_status = %q, want empty", payload.Sources["prometheus"].SourceStatus)
+	}
+	for _, query := range payload.Prometheus.Queries {
+		if query.SourceStatus != "empty" {
+			t.Fatalf("%s source_status = %q, want empty", query.ID, query.SourceStatus)
+		}
+	}
+}
+
+func TestAdminPlatformDashboardPrometheusConfiguredAndStale(t *testing.T) {
+	t.Parallel()
+
+	seenQueries := map[string]bool{}
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		seenQueries[query] = true
+		if strings.Contains(query, "exporter_last_collect") {
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"metricsexporter","device_id":"dev-secret","instance":"10.0.0.1:9100"},"value":[1780369304,"900"]}]}}`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app","device_id":"dev-secret","instance":"10.0.0.1:9100"},"value":[1780369304,"1"]}]}}`))
+	}))
+	defer prometheus.Close()
+
+	st := mustOpenStore(t)
+	srv := NewWithOptions(st, Options{Config: config.Config{VideoCloudPrometheusBaseURL: prometheus.URL}})
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+
+	payload := getPlatformDashboard(t, srv, session.ID)
+	if payload.Sources["prometheus"].SourceStatus != "stale" {
+		t.Fatalf("prometheus source_status = %q, want stale", payload.Sources["prometheus"].SourceStatus)
+	}
+	for _, want := range []string{
+		`sum by(job, service, role) (up)`,
+		`sum by(job, service, role) (up == 0)`,
+		`time() - video_cloud_exporter_last_collect_timestamp_seconds`,
+	} {
+		if !seenQueries[want] {
+			t.Fatalf("prometheus did not receive allowlisted query %q; got %#v", want, seenQueries)
+		}
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	for _, leaked := range []string{"device_id", "dev-secret", "instance", "10.0.0.1"} {
+		if strings.Contains(string(body), leaked) {
+			t.Fatalf("payload leaked disallowed label %q: %s", leaked, body)
+		}
+	}
+}
+
+func getPlatformDashboard(t *testing.T, srv http.Handler, sessionID string) contracts.PlatformDashboard {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/platform-dashboard", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: sessionID})
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("platform dashboard status = %d, want %d; body=%s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload contracts.PlatformDashboard
+	if err := json.NewDecoder(rec.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode platform dashboard: %v", err)
+	}
+	return payload
+}
+
+func TestPrometheusClientRejectsInvalidBaseURL(t *testing.T) {
+	t.Parallel()
+
+	client := newPrometheusClient("://bad-url")
+	if _, err := client.query(t.Context(), platformDashboardPrometheusQueries[0]); err == nil {
+		t.Fatalf("query returned nil error for invalid URL")
+	}
+}
+
+func TestPrometheusClientUsesQueryEndpoint(t *testing.T) {
+	t.Parallel()
+
+	var gotPath string
+	var gotQuery string
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.Query().Get("query")
+		_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+	}))
+	defer prometheus.Close()
+
+	client := newPrometheusClient(strings.TrimRight(prometheus.URL, "/") + "/")
+	if _, err := client.query(t.Context(), platformDashboardPrometheusQueries[0]); err != nil {
+		t.Fatalf("query returned error: %v", err)
+	}
+	if gotPath != "/api/v1/query" {
+		t.Fatalf("path = %q, want /api/v1/query", gotPath)
+	}
+	if _, err := url.ParseQuery("query=" + url.QueryEscape(gotQuery)); err != nil || gotQuery != platformDashboardPrometheusQueries[0].Query {
+		t.Fatalf("query = %q, want %q", gotQuery, platformDashboardPrometheusQueries[0].Query)
+	}
+}

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -104,6 +104,35 @@ type Summary struct {
 	Customers        int `json:"customers"`
 }
 
+type PlatformDashboard struct {
+	Summary    Summary                            `json:"summary"`
+	Sources    map[string]PlatformDashboardSource `json:"sources"`
+	Prometheus PlatformDashboardPrometheus        `json:"prometheus"`
+}
+
+type PlatformDashboardSource struct {
+	SourceStatus  string `json:"source_status"`
+	SourceMessage string `json:"source_message,omitempty"`
+	CheckedAt     string `json:"checked_at,omitempty"`
+}
+
+type PlatformDashboardPrometheus struct {
+	Queries []PlatformDashboardPrometheusQuery `json:"queries"`
+}
+
+type PlatformDashboardPrometheusQuery struct {
+	ID           string                              `json:"id"`
+	Title        string                              `json:"title"`
+	SourceStatus string                              `json:"source_status"`
+	CheckedAt    string                              `json:"checked_at,omitempty"`
+	Series       []PlatformDashboardPrometheusSeries `json:"series"`
+}
+
+type PlatformDashboardPrometheusSeries struct {
+	Labels map[string]string `json:"labels"`
+	Value  float64           `json:"value"`
+}
+
 type CustomerSummary struct {
 	OrganizationID   string `json:"organization_id"`
 	Organization     string `json:"organization"`


### PR DESCRIPTION
## What changed

- Added `GET /api/admin/platform-dashboard` behind the existing platform-admin session guard.
- Added a server-side Prometheus query client using `VIDEO_CLOUD_PROMETHEUS_BASE_URL` with fixed allowlisted query definitions only.
- Added stable Prometheus source states for configured, unconfigured, unavailable, empty, and stale data.
- Redacted upstream Prometheus errors and allowlisted returned labels to `job`, `service`, and `role`.
- Documented the new BFF contract in OpenAPI, SPEC, and the backend API audit.

## Validation

- `go test ./...`

Closes #175
