### PR TITLE
Compose Platform Dashboard payload

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.7% |
+| Go total coverage | 80.9% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,7 +28,7 @@
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 89.8% |
-| `rtk_cloud_admin/internal/app` | 80.9% |
+| `rtk_cloud_admin/internal/app` | 81.0% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |

--- a/docs/backend-api-gap-audit.md
+++ b/docs/backend-api-gap-audit.md
@@ -42,7 +42,7 @@ from Account Manager or Video Cloud before server validation is complete.
 | Fleet stream | `GET /api/fleet/stream-stats` | api shape implemented / production source pending | BFF route exists, but production validation requires WebRTC session event data from Video Cloud or an equivalent normalized read model, not local estimates. |
 | Firmware | `GET /api/fleet/firmware-distribution` | api shape implemented / production source pending | BFF route exists and proxies firmware endpoints when configured. Production validation requires observed firmware and rollout facts; generated fallback versions are not acceptable. |
 | Platform dashboard | `GET /api/admin/summary` | implemented | Platform-admin protected. Returns cross-tenant customer/device/operation summary. |
-| Platform dashboard | `GET /api/admin/platform-dashboard` | api shape implemented / composition pending | Platform-admin protected BFF boundary for existing summary data and allowlisted server-side Prometheus queries. Returns stable Prometheus source states instead of leaking raw upstream errors. |
+| Platform dashboard | `GET /api/admin/platform-dashboard` | implemented | Platform-admin protected BFF boundary for existing summary data, operation risk, KPI strip, grouped scrape health, and allowlisted server-side Prometheus queries. Returns stable source states instead of leaking raw upstream errors. |
 | Platform dashboard | `GET /api/admin/customers` | implemented | Platform-admin protected. Returns organization id/name, totals, readiness buckets, and last seen. |
 | Platform dashboard | `GET /api/admin/devices` | implemented | Platform-admin protected. Returns all device read models with organization, readiness, firmware, health, signal quality, and source facts. |
 | Platform operations | `GET /api/admin/operations` | implemented | Platform-admin protected. |
@@ -87,7 +87,9 @@ rejected and unauthenticated requests return `401`.
 `GET /api/admin/platform-dashboard` is the server-side Prometheus boundary for
 Platform Dashboard. It uses `VIDEO_CLOUD_PROMETHEUS_BASE_URL` from the BFF,
 runs only repo-owned allowlisted query definitions, and returns source states
-`configured`, `unconfigured`, `unavailable`, `empty`, or `stale`.
+`configured`, `unconfigured`, `unavailable`, `empty`, or `stale`. The payload
+also composes deterministic KPI, service/scrape health, and operation-risk
+sections from Admin BFF read models plus those Prometheus results.
 
 The device read model is additive and includes customer organization, readiness,
 firmware version, source facts, health, signal quality, last seen, and updated

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1520,11 +1520,25 @@ components:
           format: date-time
     PlatformDashboard:
       type: object
-      required: [summary, sources, prometheus]
+      required: [summary, kpis, service_scrape_health, operation_risk, sources, panel_sources, prometheus]
       properties:
         summary:
           $ref: "#/components/schemas/Summary"
+        kpis:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformDashboardKPI"
+        service_scrape_health:
+          type: array
+          items:
+            $ref: "#/components/schemas/PlatformDashboardServiceScrapeHealth"
+        operation_risk:
+          $ref: "#/components/schemas/PlatformDashboardOperationRisk"
         sources:
+          type: object
+          additionalProperties:
+            $ref: "#/components/schemas/PlatformDashboardSource"
+        panel_sources:
           type: object
           additionalProperties:
             $ref: "#/components/schemas/PlatformDashboardSource"
@@ -1542,6 +1556,62 @@ components:
         checked_at:
           type: string
           format: date-time
+    PlatformDashboardKPI:
+      type: object
+      required: [id, label, value, source_status]
+      properties:
+        id:
+          type: string
+          enum: [tenants, devices_online, open_operations, scrape_targets_down]
+        label:
+          type: string
+        value:
+          type: number
+          format: double
+        unit:
+          type: string
+        secondary_label:
+          type: string
+        secondary_value:
+          type: number
+          format: double
+        source_status:
+          type: string
+          enum: [configured, unconfigured, unavailable, empty, stale]
+    PlatformDashboardServiceScrapeHealth:
+      type: object
+      required: [id, name, status, targets_up, targets_down, targets_total, source_status]
+      properties:
+        id:
+          type: string
+          enum: [app, host, data, broker, gateway]
+        name:
+          type: string
+        status:
+          type: string
+          enum: [ok, degraded, configured, unconfigured, unavailable, empty, stale]
+        targets_up:
+          type: integer
+        targets_down:
+          type: integer
+        targets_total:
+          type: integer
+        source_status:
+          type: string
+          enum: [configured, unconfigured, unavailable, empty, stale]
+    PlatformDashboardOperationRisk:
+      type: object
+      required: [open_operations, failed_operations, dead_lettered_operations, source_status]
+      properties:
+        open_operations:
+          type: integer
+        failed_operations:
+          type: integer
+        dead_lettered_operations:
+          type: integer
+        source_status:
+          type: string
+          enum: [configured, unconfigured, unavailable, empty, stale]
     PlatformDashboardPrometheus:
       type: object
       required: [queries]

--- a/internal/app/platform_dashboard.go
+++ b/internal/app/platform_dashboard.go
@@ -23,6 +23,7 @@ const (
 	platformDashboardSourceStale        = "stale"
 
 	platformDashboardPrometheusSource = "prometheus"
+	platformDashboardReadModelSource  = "admin_read_models"
 )
 
 var platformDashboardPrometheusQueries = []prometheusQueryDefinition{
@@ -63,23 +64,43 @@ func (s *Server) apiAdminPlatformDashboard(w http.ResponseWriter, r *http.Reques
 	if !ok {
 		return
 	}
-	summary, err := s.platformDashboardSummary(r.Context(), session)
+	summary, operations, err := s.platformDashboardReadModels(r.Context(), session)
 	if err != nil {
 		s.writeUpstreamReadError(w, err)
 		return
 	}
-	writeJSON(w, s.platformDashboard(r.Context(), summary))
+	writeJSON(w, s.platformDashboard(r.Context(), summary, operations))
 }
 
-func (s *Server) platformDashboardSummary(ctx context.Context, session store.Session) (contracts.Summary, error) {
+func (s *Server) platformDashboardReadModels(ctx context.Context, session store.Session) (contracts.Summary, []contracts.Operation, error) {
 	if s.usePlatformAdminUpstream(session) {
-		return s.platformAdminSummary(ctx, session)
+		devices, err := s.platformAdminDevices(ctx, session)
+		if err != nil {
+			return contracts.Summary{}, nil, err
+		}
+		operations, err := s.platformAdminOperations(ctx, session)
+		if err != nil {
+			return contracts.Summary{}, nil, err
+		}
+		return summaryFromReadModels(devices, operations), operations, nil
 	}
-	return s.store.Summary()
+	summary, err := s.store.Summary()
+	if err != nil {
+		return contracts.Summary{}, nil, err
+	}
+	operations, err := s.store.ListOperations()
+	if err != nil {
+		return contracts.Summary{}, nil, err
+	}
+	return summary, operations, nil
 }
 
-func (s *Server) platformDashboard(ctx context.Context, summary contracts.Summary) contracts.PlatformDashboard {
+func (s *Server) platformDashboard(ctx context.Context, summary contracts.Summary, operations []contracts.Operation) contracts.PlatformDashboard {
 	checkedAt := time.Now().UTC().Format(time.RFC3339)
+	adminSource := contracts.PlatformDashboardSource{
+		SourceStatus: platformDashboardSourceConfigured,
+		CheckedAt:    checkedAt,
+	}
 	source := contracts.PlatformDashboardSource{
 		SourceStatus:  platformDashboardSourceUnconfigured,
 		SourceMessage: "Prometheus is not configured.",
@@ -99,10 +120,20 @@ func (s *Server) platformDashboard(ctx context.Context, summary contracts.Summar
 		}
 		return contracts.PlatformDashboard{
 			Summary: summary,
+			KPIs: buildPlatformDashboardKPIs(summary, map[string]contracts.PlatformDashboardPrometheusQuery{
+				"scrape_targets_down": {
+					SourceStatus: platformDashboardSourceUnconfigured,
+					Series:       []contracts.PlatformDashboardPrometheusSeries{},
+				},
+			}),
+			ServiceScrapeHealth: buildPlatformDashboardServiceScrapeHealth(queries),
+			OperationRisk:       buildPlatformDashboardOperationRisk(summary, operations),
 			Sources: map[string]contracts.PlatformDashboardSource{
 				platformDashboardPrometheusSource: source,
+				platformDashboardReadModelSource:  adminSource,
 			},
-			Prometheus: contracts.PlatformDashboardPrometheus{Queries: queries},
+			PanelSources: platformDashboardPanelSources(adminSource, source),
+			Prometheus:   contracts.PlatformDashboardPrometheus{Queries: queries},
 		}
 	}
 
@@ -143,13 +174,202 @@ func (s *Server) platformDashboard(ctx context.Context, summary contracts.Summar
 		source.SourceMessage = "Prometheus returned no dashboard data."
 	}
 	source.CheckedAt = checkedAt
+	queriesByID := platformDashboardQueriesByID(queries)
 	return contracts.PlatformDashboard{
-		Summary: summary,
+		Summary:             summary,
+		KPIs:                buildPlatformDashboardKPIs(summary, queriesByID),
+		ServiceScrapeHealth: buildPlatformDashboardServiceScrapeHealth(queries),
+		OperationRisk:       buildPlatformDashboardOperationRisk(summary, operations),
 		Sources: map[string]contracts.PlatformDashboardSource{
 			platformDashboardPrometheusSource: source,
+			platformDashboardReadModelSource:  adminSource,
 		},
-		Prometheus: contracts.PlatformDashboardPrometheus{Queries: queries},
+		PanelSources: platformDashboardPanelSources(adminSource, source),
+		Prometheus:   contracts.PlatformDashboardPrometheus{Queries: queries},
 	}
+}
+
+func platformDashboardPanelSources(adminSource, prometheusSource contracts.PlatformDashboardSource) map[string]contracts.PlatformDashboardSource {
+	return map[string]contracts.PlatformDashboardSource{
+		"kpis":                  mixedPanelSource(adminSource, prometheusSource),
+		"service_scrape_health": prometheusSource,
+		"operation_risk":        adminSource,
+	}
+}
+
+func mixedPanelSource(primary, secondary contracts.PlatformDashboardSource) contracts.PlatformDashboardSource {
+	if secondary.SourceStatus == platformDashboardSourceConfigured {
+		return primary
+	}
+	source := secondary
+	source.SourceMessage = fallback(source.SourceMessage, "Some dashboard data is unavailable.")
+	return source
+}
+
+func buildPlatformDashboardKPIs(summary contracts.Summary, queriesByID map[string]contracts.PlatformDashboardPrometheusQuery) []contracts.PlatformDashboardKPI {
+	scrapeTargetsDown := queriesByID["scrape_targets_down"]
+	return []contracts.PlatformDashboardKPI{
+		{
+			ID:           "tenants",
+			Label:        "Tenants",
+			Value:        float64(summary.Customers),
+			SourceStatus: platformDashboardSourceConfigured,
+		},
+		{
+			ID:             "devices_online",
+			Label:          "Devices Online",
+			Value:          float64(summary.OnlineDevices),
+			Unit:           "devices",
+			SecondaryLabel: "online_rate_pct",
+			SecondaryValue: percent(summary.OnlineDevices, summary.TotalDevices),
+			SourceStatus:   platformDashboardSourceConfigured,
+		},
+		{
+			ID:           "open_operations",
+			Label:        "Open Operations",
+			Value:        float64(summary.OpenOperations),
+			SourceStatus: platformDashboardSourceConfigured,
+		},
+		{
+			ID:           "scrape_targets_down",
+			Label:        "Scrape Targets Down",
+			Value:        sumPrometheusSeries(scrapeTargetsDown),
+			SourceStatus: fallback(scrapeTargetsDown.SourceStatus, platformDashboardSourceUnconfigured),
+		},
+	}
+}
+
+func buildPlatformDashboardOperationRisk(summary contracts.Summary, operations []contracts.Operation) contracts.PlatformDashboardOperationRisk {
+	risk := contracts.PlatformDashboardOperationRisk{
+		OpenOperations: summary.OpenOperations,
+		SourceStatus:   platformDashboardSourceConfigured,
+	}
+	for _, op := range operations {
+		switch op.State {
+		case contracts.OperationFailed:
+			risk.FailedOperations++
+		case contracts.OperationDeadLettered:
+			risk.DeadLetteredOperations++
+		}
+	}
+	return risk
+}
+
+func buildPlatformDashboardServiceScrapeHealth(queries []contracts.PlatformDashboardPrometheusQuery) []contracts.PlatformDashboardServiceScrapeHealth {
+	queriesByID := platformDashboardQueriesByID(queries)
+	up := queriesByID["scrape_targets_up"]
+	down := queriesByID["scrape_targets_down"]
+	groups := []contracts.PlatformDashboardServiceScrapeHealth{
+		{ID: "app", Name: "App", SourceStatus: combinedPrometheusQueryStatus(up, down)},
+		{ID: "host", Name: "Host", SourceStatus: combinedPrometheusQueryStatus(up, down)},
+		{ID: "data", Name: "Data", SourceStatus: combinedPrometheusQueryStatus(up, down)},
+		{ID: "broker", Name: "Broker", SourceStatus: combinedPrometheusQueryStatus(up, down)},
+		{ID: "gateway", Name: "Gateway", SourceStatus: combinedPrometheusQueryStatus(up, down)},
+	}
+	for i := range groups {
+		groups[i].TargetsUp = int(sumPrometheusSeriesForGroup(up, groups[i].ID))
+		groups[i].TargetsDown = int(sumPrometheusSeriesForGroup(down, groups[i].ID))
+		groups[i].TargetsTotal = groups[i].TargetsUp + groups[i].TargetsDown
+		groups[i].Status = platformDashboardScrapeGroupStatus(groups[i])
+	}
+	return groups
+}
+
+func platformDashboardQueriesByID(queries []contracts.PlatformDashboardPrometheusQuery) map[string]contracts.PlatformDashboardPrometheusQuery {
+	byID := make(map[string]contracts.PlatformDashboardPrometheusQuery, len(queries))
+	for _, query := range queries {
+		byID[query.ID] = query
+	}
+	return byID
+}
+
+func sumPrometheusSeries(query contracts.PlatformDashboardPrometheusQuery) float64 {
+	var total float64
+	for _, series := range query.Series {
+		total += series.Value
+	}
+	return total
+}
+
+func sumPrometheusSeriesForGroup(query contracts.PlatformDashboardPrometheusQuery, groupID string) float64 {
+	var total float64
+	for _, series := range query.Series {
+		if platformDashboardScrapeGroup(series.Labels) == groupID {
+			total += series.Value
+		}
+	}
+	return total
+}
+
+func platformDashboardScrapeGroup(labels map[string]string) string {
+	job := strings.ToLower(labels["job"])
+	role := strings.ToLower(labels["role"])
+	switch {
+	case job == "node":
+		return "host"
+	case job == "postgres" || job == "redis":
+		return "data"
+	case job == "nats" || job == "emqx" || role == "mqtt":
+		return "broker"
+	case job == "nginx" || role == "edge" || role == "gateway":
+		return "gateway"
+	default:
+		return "app"
+	}
+}
+
+func platformDashboardScrapeGroupStatus(group contracts.PlatformDashboardServiceScrapeHealth) string {
+	switch {
+	case group.SourceStatus == platformDashboardSourceUnconfigured || group.SourceStatus == platformDashboardSourceUnavailable:
+		return group.SourceStatus
+	case group.SourceStatus == platformDashboardSourceEmpty || group.TargetsTotal == 0:
+		return platformDashboardSourceEmpty
+	case group.TargetsDown > 0:
+		return "degraded"
+	default:
+		return "ok"
+	}
+}
+
+func combinedPrometheusQueryStatus(queries ...contracts.PlatformDashboardPrometheusQuery) string {
+	anyUnavailable := false
+	anyStale := false
+	anyConfigured := false
+	anyEmpty := false
+	for _, query := range queries {
+		switch query.SourceStatus {
+		case platformDashboardSourceUnavailable, platformDashboardSourceUnconfigured:
+			anyUnavailable = query.SourceStatus == platformDashboardSourceUnavailable || anyUnavailable
+			if query.SourceStatus == platformDashboardSourceUnconfigured {
+				return platformDashboardSourceUnconfigured
+			}
+		case platformDashboardSourceStale:
+			anyStale = true
+		case platformDashboardSourceConfigured:
+			anyConfigured = true
+		case platformDashboardSourceEmpty:
+			anyEmpty = true
+		}
+	}
+	switch {
+	case anyUnavailable:
+		return platformDashboardSourceUnavailable
+	case anyStale:
+		return platformDashboardSourceStale
+	case anyConfigured:
+		return platformDashboardSourceConfigured
+	case anyEmpty:
+		return platformDashboardSourceEmpty
+	default:
+		return platformDashboardSourceEmpty
+	}
+}
+
+func percent(numerator, denominator int) float64 {
+	if denominator <= 0 {
+		return 0
+	}
+	return toTwoDecimal(float64(numerator) / float64(denominator) * 100)
 }
 
 func newPrometheusClient(baseURL string) prometheusClient {

--- a/internal/app/platform_dashboard_test.go
+++ b/internal/app/platform_dashboard_test.go
@@ -59,6 +59,23 @@ func TestAdminPlatformDashboardUnconfiguredPrometheusReturnsSummary(t *testing.T
 	if len(payload.Prometheus.Queries) == 0 {
 		t.Fatalf("prometheus queries are empty")
 	}
+	if kpiValue(payload.KPIs, "tenants") != float64(payload.Summary.Customers) {
+		t.Fatalf("tenants KPI = %v, want %d", kpiValue(payload.KPIs, "tenants"), payload.Summary.Customers)
+	}
+	if kpiStatus(payload.KPIs, "scrape_targets_down") != "unconfigured" {
+		t.Fatalf("scrape_targets_down KPI status = %q, want unconfigured", kpiStatus(payload.KPIs, "scrape_targets_down"))
+	}
+	if len(payload.ServiceScrapeHealth) != 5 {
+		t.Fatalf("service scrape group count = %d, want 5", len(payload.ServiceScrapeHealth))
+	}
+	for _, group := range payload.ServiceScrapeHealth {
+		if group.SourceStatus != "unconfigured" || group.Status != "unconfigured" {
+			t.Fatalf("group %s source/status = %s/%s, want unconfigured/unconfigured", group.ID, group.SourceStatus, group.Status)
+		}
+	}
+	if payload.PanelSources["service_scrape_health"].SourceStatus != "unconfigured" {
+		t.Fatalf("service_scrape_health panel source = %q, want unconfigured", payload.PanelSources["service_scrape_health"].SourceStatus)
+	}
 	for _, query := range payload.Prometheus.Queries {
 		if query.SourceStatus != "unconfigured" {
 			t.Fatalf("%s source_status = %q, want unconfigured", query.ID, query.SourceStatus)
@@ -124,6 +141,100 @@ func TestAdminPlatformDashboardPrometheusEmptyResponse(t *testing.T) {
 			t.Fatalf("%s source_status = %q, want empty", query.ID, query.SourceStatus)
 		}
 	}
+	for _, group := range payload.ServiceScrapeHealth {
+		if group.Status != "empty" {
+			t.Fatalf("%s status = %q, want empty", group.ID, group.Status)
+		}
+	}
+}
+
+func TestAdminPlatformDashboardAllTargetsUpFixture(t *testing.T) {
+	t.Parallel()
+
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch query := r.URL.Query().Get("query"); {
+		case query == `sum by(job, service, role) (up)`:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"2"]},{"metric":{"job":"node","role":"api"},"value":[1780369304,"1"]},{"metric":{"job":"postgres","role":"infra"},"value":[1780369304,"1"]},{"metric":{"job":"nats","role":"broker"},"value":[1780369304,"1"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"1"]}]}}`))
+		case query == `sum by(job, service, role) (up == 0)`:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"0"]},{"metric":{"job":"node","role":"api"},"value":[1780369304,"0"]},{"metric":{"job":"postgres","role":"infra"},"value":[1780369304,"0"]},{"metric":{"job":"nats","role":"broker"},"value":[1780369304,"0"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"0"]}]}}`))
+		default:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"metricsexporter"},"value":[1780369304,"60"]}]}}`))
+		}
+	}))
+	defer prometheus.Close()
+
+	payload := getPlatformDashboardForPrometheus(t, prometheus.URL)
+	if payload.Sources["prometheus"].SourceStatus != "configured" {
+		t.Fatalf("prometheus source = %q, want configured", payload.Sources["prometheus"].SourceStatus)
+	}
+	if kpiValue(payload.KPIs, "scrape_targets_down") != 0 {
+		t.Fatalf("scrape_targets_down KPI = %v, want 0", kpiValue(payload.KPIs, "scrape_targets_down"))
+	}
+	wantTotals := map[string]int{"app": 2, "host": 1, "data": 1, "broker": 1, "gateway": 1}
+	for _, group := range payload.ServiceScrapeHealth {
+		if group.Status != "ok" {
+			t.Fatalf("%s status = %q, want ok", group.ID, group.Status)
+		}
+		if group.TargetsTotal != wantTotals[group.ID] {
+			t.Fatalf("%s targets_total = %d, want %d", group.ID, group.TargetsTotal, wantTotals[group.ID])
+		}
+	}
+}
+
+func TestAdminPlatformDashboardOneTargetDownFixture(t *testing.T) {
+	t.Parallel()
+
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch query := r.URL.Query().Get("query"); {
+		case query == `sum by(job, service, role) (up)`:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"1"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"1"]}]}}`))
+		case query == `sum by(job, service, role) (up == 0)`:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"1"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"0"]}]}}`))
+		default:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"metricsexporter"},"value":[1780369304,"60"]}]}}`))
+		}
+	}))
+	defer prometheus.Close()
+
+	payload := getPlatformDashboardForPrometheus(t, prometheus.URL)
+	if kpiValue(payload.KPIs, "scrape_targets_down") != 1 {
+		t.Fatalf("scrape_targets_down KPI = %v, want 1", kpiValue(payload.KPIs, "scrape_targets_down"))
+	}
+	app := scrapeGroup(payload.ServiceScrapeHealth, "app")
+	if app.Status != "degraded" || app.TargetsUp != 1 || app.TargetsDown != 1 || app.TargetsTotal != 2 {
+		t.Fatalf("app group = %+v, want degraded 1 up / 1 down / 2 total", app)
+	}
+	gateway := scrapeGroup(payload.ServiceScrapeHealth, "gateway")
+	if gateway.Status != "ok" || gateway.TargetsDown != 0 {
+		t.Fatalf("gateway group = %+v, want ok with 0 down", gateway)
+	}
+}
+
+func TestAdminPlatformDashboardMissingSeriesFixture(t *testing.T) {
+	t.Parallel()
+
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch query := r.URL.Query().Get("query"); {
+		case query == `sum by(job, service, role) (up)`:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"1"]}]}}`))
+		case query == `sum by(job, service, role) (up == 0)`:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"0"]}]}}`))
+		default:
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"metricsexporter"},"value":[1780369304,"60"]}]}}`))
+		}
+	}))
+	defer prometheus.Close()
+
+	payload := getPlatformDashboardForPrometheus(t, prometheus.URL)
+	if scrapeGroup(payload.ServiceScrapeHealth, "app").Status != "ok" {
+		t.Fatalf("app group = %+v, want ok", scrapeGroup(payload.ServiceScrapeHealth, "app"))
+	}
+	for _, id := range []string{"host", "data", "broker", "gateway"} {
+		group := scrapeGroup(payload.ServiceScrapeHealth, id)
+		if group.Status != "empty" || group.TargetsTotal != 0 {
+			t.Fatalf("%s group = %+v, want empty with no targets", id, group)
+		}
+	}
 }
 
 func TestAdminPlatformDashboardPrometheusConfiguredAndStale(t *testing.T) {
@@ -186,6 +297,44 @@ func getPlatformDashboard(t *testing.T, srv http.Handler, sessionID string) cont
 		t.Fatalf("decode platform dashboard: %v", err)
 	}
 	return payload
+}
+
+func getPlatformDashboardForPrometheus(t *testing.T, prometheusBaseURL string) contracts.PlatformDashboard {
+	t.Helper()
+	st := mustOpenStore(t)
+	srv := NewWithOptions(st, Options{Config: config.Config{VideoCloudPrometheusBaseURL: prometheusBaseURL}})
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	return getPlatformDashboard(t, srv, session.ID)
+}
+
+func kpiValue(kpis []contracts.PlatformDashboardKPI, id string) float64 {
+	for _, kpi := range kpis {
+		if kpi.ID == id {
+			return kpi.Value
+		}
+	}
+	return -1
+}
+
+func kpiStatus(kpis []contracts.PlatformDashboardKPI, id string) string {
+	for _, kpi := range kpis {
+		if kpi.ID == id {
+			return kpi.SourceStatus
+		}
+	}
+	return ""
+}
+
+func scrapeGroup(groups []contracts.PlatformDashboardServiceScrapeHealth, id string) contracts.PlatformDashboardServiceScrapeHealth {
+	for _, group := range groups {
+		if group.ID == id {
+			return group
+		}
+	}
+	return contracts.PlatformDashboardServiceScrapeHealth{}
 }
 
 func TestPrometheusClientRejectsInvalidBaseURL(t *testing.T) {

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -105,15 +105,46 @@ type Summary struct {
 }
 
 type PlatformDashboard struct {
-	Summary    Summary                            `json:"summary"`
-	Sources    map[string]PlatformDashboardSource `json:"sources"`
-	Prometheus PlatformDashboardPrometheus        `json:"prometheus"`
+	Summary             Summary                                `json:"summary"`
+	KPIs                []PlatformDashboardKPI                 `json:"kpis"`
+	ServiceScrapeHealth []PlatformDashboardServiceScrapeHealth `json:"service_scrape_health"`
+	OperationRisk       PlatformDashboardOperationRisk         `json:"operation_risk"`
+	Sources             map[string]PlatformDashboardSource     `json:"sources"`
+	PanelSources        map[string]PlatformDashboardSource     `json:"panel_sources"`
+	Prometheus          PlatformDashboardPrometheus            `json:"prometheus"`
 }
 
 type PlatformDashboardSource struct {
 	SourceStatus  string `json:"source_status"`
 	SourceMessage string `json:"source_message,omitempty"`
 	CheckedAt     string `json:"checked_at,omitempty"`
+}
+
+type PlatformDashboardKPI struct {
+	ID             string  `json:"id"`
+	Label          string  `json:"label"`
+	Value          float64 `json:"value"`
+	Unit           string  `json:"unit,omitempty"`
+	SecondaryLabel string  `json:"secondary_label,omitempty"`
+	SecondaryValue float64 `json:"secondary_value,omitempty"`
+	SourceStatus   string  `json:"source_status"`
+}
+
+type PlatformDashboardServiceScrapeHealth struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Status       string `json:"status"`
+	TargetsUp    int    `json:"targets_up"`
+	TargetsDown  int    `json:"targets_down"`
+	TargetsTotal int    `json:"targets_total"`
+	SourceStatus string `json:"source_status"`
+}
+
+type PlatformDashboardOperationRisk struct {
+	OpenOperations         int    `json:"open_operations"`
+	FailedOperations       int    `json:"failed_operations"`
+	DeadLetteredOperations int    `json:"dead_lettered_operations"`
+	SourceStatus           string `json:"source_status"`
 }
 
 type PlatformDashboardPrometheus struct {


### PR DESCRIPTION
## What changed

- Composed `/api/admin/platform-dashboard` into a deterministic dashboard payload with KPI strip, service/scrape health groups, operation risk, and per-panel source metadata.
- Derived admin read-model sections from existing summary and operations data without changing the existing admin summary, service-health, operations, or audit routes.
- Aggregated allowlisted Prometheus query results into App, Host, Data, Broker, and Gateway scrape-health groups.
- Added fixture tests for unconfigured Prometheus, all targets up, one target down, missing series, empty responses, stale data, and upstream redaction.
- Updated OpenAPI, backend API audit notes, and the tracked test report.

## Validation

- `go test ./...`
- `go test ./... -coverprofile=coverage.out`
- `go build -o .artifacts/rtk-cloud-admin ./cmd/server`
- `go tool cover -func=coverage.out`

Closes #176
