### PR TITLE
Add Platform Dashboard route and nav

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -146,6 +146,7 @@ func (s *Server) routes() {
 		"/console/operations",
 		"/console/audit",
 		"/admin",
+		"/admin/health",
 		"/admin/ops",
 		"/admin/operations",
 		"/admin/audit",

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -54,6 +54,7 @@ func TestServerHealthAndHomeRedirect(t *testing.T) {
 		"/console/operations",
 		"/console/audit",
 		"/admin",
+		"/admin/health",
 		"/admin/ops",
 		"/admin/operations",
 		"/admin/audit",

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -547,6 +547,7 @@ function App() {
             onOpenDevice={selectDevice}
           />
         ) : null}
+        {!needsPlatformAccess && active === 'platform-dashboard' ? <PlatformDashboardLanding summary={summary} health={health} operations={operations} /> : null}
         {!needsPlatformAccess && active === 'platform-health' ? <PlatformHealth summary={summary} health={health} /> : null}
         {!needsPlatformAccess && active === 'platform-sso' ? (
           <PlatformSSOProviders providers={ssoProviders} customers={customers} onSave={handleSSOProviderSave} />
@@ -1424,6 +1425,41 @@ function PlatformAccessGate({ active, me, onSSOStart, onBreakGlassLogin }) {
           <p>Sign in with a platform admin session to open {titleFor(active)}.</p>
         </div>
       </section>
+    </>
+  );
+}
+
+function PlatformDashboardLanding({ summary, health, operations }) {
+  const customerCount = summary?.customers ?? '-';
+  const onlineDevices = summary?.online_devices ?? '-';
+  const openOperations = summary?.open_operations ?? '-';
+  const degradedServices = health.filter((item) => item.status !== 'ok' && item.status !== 'demo').length;
+  const failedOperations = operations.filter((operation) => operation.state === 'failed' || operation.state === 'dead_lettered').length;
+  return (
+    <>
+      <section className="panel split-panel">
+        <div>
+          <h2>Platform Dashboard</h2>
+          <p>Cross-tenant operating status for Platform Admins.</p>
+          <div className="admin-kpis">
+            <div><strong>{customerCount}</strong><span>Tenants</span></div>
+            <div><strong>{onlineDevices}</strong><span>Devices online</span></div>
+            <div><strong>{openOperations}</strong><span>Open ops</span></div>
+          </div>
+        </div>
+        <ServiceHealth health={health} compact />
+      </section>
+      <section className="panel">
+        <div className="panel-head">
+          <div>
+            <h2>Operation Risk</h2>
+            <p>Open and failed lifecycle activity across tenants.</p>
+          </div>
+          <StatusBadge value={failedOperations ? 'degraded' : 'ok'} />
+        </div>
+        <OperationList operations={operations.filter((operation) => operation.state !== 'succeeded').slice(0, 5)} detailed />
+      </section>
+      {degradedServices ? <section className="panel demo-banner"><p>{`${degradedServices} service checks need attention.`}</p></section> : null}
     </>
   );
 }

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -6,7 +6,8 @@ export const customerNavItems = [
 ];
 
 export const platformNavItems = [
-  { id: 'platform-health', label: 'Service Health', path: '/admin' },
+  { id: 'platform-dashboard', label: 'Platform Dashboard', path: '/admin' },
+  { id: 'platform-health', label: 'Service Health', path: '/admin/health' },
   { id: 'platform-sso', label: 'SSO Providers', path: '/admin/sso' },
   { id: 'platform-operations', label: 'Operations Log', path: '/admin/ops' },
   { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
@@ -36,6 +37,7 @@ export function titleFor(active) {
     devices: 'Devices',
     'firmware-ota': 'Firmware & OTA',
     'stream-health': 'Stream Health',
+    'platform-dashboard': 'Platform Dashboard',
     'platform-health': 'Service Health',
     'platform-sso': 'SSO Providers',
     'platform-operations': 'Operations',
@@ -47,12 +49,13 @@ export function routeFromPath(path) {
   if (path === '/signup' || path === '/signup/') return 'signup';
   if (path === '/signup/check-email' || path.startsWith('/signup/check-email/')) return 'signup-check-email';
   if (path === '/verify' || path.startsWith('/verify/')) return 'verify';
-  if (path === '/admin' || path === '/admin/') return 'platform-health';
+  if (path === '/admin' || path === '/admin/') return 'platform-dashboard';
+  if (path === '/admin/health' || path.startsWith('/admin/health/')) return 'platform-health';
   if (path === '/admin/sso' || path.startsWith('/admin/sso/')) return 'platform-sso';
   if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
   if (path === '/admin/operations' || path.startsWith('/admin/operations/')) return 'platform-operations';
   if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';
-  if (path.startsWith('/admin/')) return 'platform-health';
+  if (path.startsWith('/admin/')) return 'platform-dashboard';
   if (path === '/console' || path === '/console/' || path === '/console/overview' || path.startsWith('/console/overview/')) return 'overview';
   if (path === '/console/devices' || path.startsWith('/console/devices/')) return 'devices';
   if (path === '/console/firmware-ota' || path.startsWith('/console/firmware-ota/')) return 'firmware-ota';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -12,7 +12,8 @@ import {
 } from './routes.mjs';
 
 test('maps platform shell paths to platform routes', () => {
-  assert.equal(routeFromPath('/admin'), 'platform-health');
+  assert.equal(routeFromPath('/admin'), 'platform-dashboard');
+  assert.equal(routeFromPath('/admin/health'), 'platform-health');
   assert.equal(routeFromPath('/admin/sso'), 'platform-sso');
   assert.equal(routeFromPath('/admin/ops'), 'platform-operations');
   assert.equal(routeFromPath('/admin/operations'), 'platform-operations');
@@ -58,6 +59,17 @@ test('retired customer pages are not exposed in section navigation', () => {
   assert.equal(platformLabels.includes('Customers'), false);
 });
 
+test('platform nav follows the Platform Dashboard landing order', () => {
+  assert.deepEqual(
+    platformNavItems.map((item) => item.label),
+    ['Platform Dashboard', 'Service Health', 'SSO Providers', 'Operations Log', 'Audit Log'],
+  );
+  assert.deepEqual(
+    platformNavItems.map((item) => item.path),
+    ['/admin', '/admin/health', '/admin/sso', '/admin/ops', '/admin/audit'],
+  );
+});
+
 test('public auth routes stay outside Customer and Platform section navigation', () => {
   for (const route of ['signup', 'signup-check-email', 'verify']) {
     assert.equal(isPublicRouteId(route), true, route);
@@ -95,8 +107,8 @@ test('falls back unknown paths to the customer overview route', () => {
 });
 
 test('falls back unknown platform paths inside Platform View', () => {
-  assert.equal(routeFromPath('/admin/unknown'), 'platform-health');
-  assert.equal(routeFromPath('/admin/unknown/deep'), 'platform-health');
+  assert.equal(routeFromPath('/admin/unknown'), 'platform-dashboard');
+  assert.equal(routeFromPath('/admin/unknown/deep'), 'platform-dashboard');
 });
 
 test('provides titles for all public shell routes', () => {
@@ -108,6 +120,7 @@ test('provides titles for all public shell routes', () => {
     'devices',
     'firmware-ota',
     'stream-health',
+    'platform-dashboard',
     'platform-health',
     'platform-sso',
     'platform-operations',


### PR DESCRIPTION
## What changed

- Added `platform-dashboard` as the first Platform View route and mapped `/admin` to it.
- Moved Service Health navigation to `/admin/health` while keeping operations aliases intact.
- Kept unknown `/admin/*` paths inside Platform View by falling back to Platform Dashboard.
- Added `/admin/health` to the Go shell fallback routes.
- Added route/nav tests and a compact Platform Dashboard landing panel pending the full first-viewport UI in the next issue.

## Validation

- `go test ./internal/app -run TestServerHealthAndHomeRedirect`
- `go test ./...`
- `cd web && npm test`
- `cd web && npm run build`
- `cd web && npm run browser:smoke`

Closes #177
