### PR TITLE
Implement Platform Dashboard first viewport

### DIFF
--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -248,6 +248,39 @@ const platformOperations = [
   },
 ];
 
+const platformDashboard = {
+  summary,
+  kpis: [
+    { id: 'tenants', label: 'Tenants', value: 1, source_status: 'configured' },
+    { id: 'devices_online', label: 'Devices Online', value: 1, secondary_label: 'online_rate_pct', secondary_value: 50, source_status: 'configured' },
+    { id: 'open_operations', label: 'Open Operations', value: 1, source_status: 'configured' },
+    { id: 'scrape_targets_down', label: 'Scrape Targets Down', value: 0, source_status: 'configured' },
+  ],
+  service_scrape_health: [
+    { id: 'app', name: 'App', status: 'ok', targets_up: 4, targets_down: 0, targets_total: 4, source_status: 'configured' },
+    { id: 'host', name: 'Host', status: 'ok', targets_up: 5, targets_down: 0, targets_total: 5, source_status: 'configured' },
+    { id: 'data', name: 'Data', status: 'ok', targets_up: 2, targets_down: 0, targets_total: 2, source_status: 'configured' },
+    { id: 'broker', name: 'Broker', status: 'ok', targets_up: 2, targets_down: 0, targets_total: 2, source_status: 'configured' },
+    { id: 'gateway', name: 'Gateway', status: 'ok', targets_up: 2, targets_down: 0, targets_total: 2, source_status: 'configured' },
+  ],
+  operation_risk: {
+    open_operations: 1,
+    failed_operations: 1,
+    dead_lettered_operations: 0,
+    source_status: 'configured',
+  },
+  sources: {
+    prometheus: { source_status: 'configured', checked_at: '2026-05-13T11:59:00Z' },
+    admin_read_models: { source_status: 'configured', checked_at: '2026-05-13T11:59:00Z' },
+  },
+  panel_sources: {
+    kpis: { source_status: 'configured', checked_at: '2026-05-13T11:59:00Z' },
+    service_scrape_health: { source_status: 'configured', checked_at: '2026-05-13T11:59:00Z' },
+    operation_risk: { source_status: 'configured', checked_at: '2026-05-13T11:59:00Z' },
+  },
+  prometheus: { queries: [] },
+};
+
 const customers = [{
   organization_id: 'org-acme',
   organization: 'Acme Smart Camera',
@@ -326,6 +359,7 @@ async function installApiMocks(page) {
     if (pathName === '/api/fleet/health-summary') return route.fulfill({ json: fleetHealth });
     if (pathName === '/api/fleet/stream-stats') return route.fulfill({ json: streamStats });
     if (pathName === '/api/fleet/firmware-distribution') return route.fulfill({ json: firmwareDistribution });
+    if (pathName === '/api/admin/platform-dashboard') return route.fulfill({ json: platformDashboard });
     if (pathName === '/api/admin/service-health') return route.fulfill({ json: platformHealth });
     if (pathName === '/api/admin/operations') return route.fulfill({ json: platformOperations });
     if (pathName === '/api/admin/audit') return route.fulfill({ json: audit });
@@ -392,6 +426,12 @@ async function runDesktopSmoke(page) {
   await expectText(page, 'Provision device');
   await screenshot(page, 'desktop-stream-open-device.png');
 
+  await gotoAndAssert(page, '/admin', 'Platform Dashboard');
+  await expectText(page, 'Scrape Targets Down');
+  await expectText(page, 'Service & Scrape Health');
+  await expectText(page, 'Tenant & Device Footprint');
+  await screenshot(page, 'desktop-platform-dashboard.png');
+
   await gotoAndAssert(page, '/admin/ops', 'Operations');
   await expectText(page, 'Lifecycle operations');
   await expectText(page, 'Provisioning succeeded');
@@ -424,6 +464,10 @@ async function runMobileSmoke(browserContext) {
     throw new Error('Mobile Devices view must hide the full table and show compact rows.');
   }
   await screenshot(page, 'mobile-devices.png');
+
+  await gotoAndAssert(page, '/admin', 'Platform Dashboard');
+  await expectText(page, 'Tenant & Device Footprint');
+  await screenshot(page, 'mobile-platform-dashboard.png');
 
   await gotoAndAssert(page, '/signup', 'Sign up');
   await expectText(page, 'Create account');

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -46,6 +46,7 @@ function App() {
   const [operations, setOperations] = useState([]);
   const [health, setHealth] = useState([]);
   const [audit, setAudit] = useState([]);
+  const [platformDashboard, setPlatformDashboard] = useState(null);
   const [ssoProviders, setSSOProviders] = useState([]);
   const [firmwareDistribution, setFirmwareDistribution] = useState(null);
   const [selectedDeviceId, setSelectedDeviceId] = useState('');
@@ -89,6 +90,7 @@ function App() {
           setOperations([]);
           setHealth([]);
           setAudit([]);
+          setPlatformDashboard(null);
           setSSOProviders([]);
           setFirmwareDistribution(null);
           setLoading(false);
@@ -104,6 +106,7 @@ function App() {
           setOperations([]);
           setHealth([]);
           setAudit([]);
+          setPlatformDashboard(null);
           setSSOProviders([]);
           setLoading(false);
           return;
@@ -118,6 +121,7 @@ function App() {
               fetchJSON(`${prefix}/operations`),
               fetchJSON(`${prefix}/service-health`),
               fetchJSON(`${prefix}/audit`),
+              fetchJSON(`${prefix}/platform-dashboard`),
             ]
           : [
               fetchJSON(`${prefix}/summary`),
@@ -126,8 +130,9 @@ function App() {
               Promise.resolve([]),
               Promise.resolve([]),
               Promise.resolve([]),
+              Promise.resolve(null),
             ];
-        const [nextSummary, nextCustomers, nextDevices, nextOperations, nextHealth, nextAudit] = await Promise.all(baseRequests);
+        const [nextSummary, nextCustomers, nextDevices, nextOperations, nextHealth, nextAudit, nextPlatformDashboard] = await Promise.all(baseRequests);
         if (!alive) return;
         setSummary(nextSummary);
         setCustomers(nextCustomers);
@@ -135,6 +140,7 @@ function App() {
         setOperations(nextOperations);
         setHealth(nextHealth);
         setAudit(nextAudit);
+        setPlatformDashboard(nextPlatformDashboard);
         if (useAdminApi && active === 'platform-sso') {
           const nextSSOProviders = await fetchJSON('/api/admin/sso/providers');
           if (!alive) return;
@@ -547,7 +553,7 @@ function App() {
             onOpenDevice={selectDevice}
           />
         ) : null}
-        {!needsPlatformAccess && active === 'platform-dashboard' ? <PlatformDashboardLanding summary={summary} health={health} operations={operations} /> : null}
+        {!needsPlatformAccess && active === 'platform-dashboard' ? <PlatformDashboardLanding dashboard={platformDashboard} summary={summary} health={health} operations={operations} /> : null}
         {!needsPlatformAccess && active === 'platform-health' ? <PlatformHealth summary={summary} health={health} /> : null}
         {!needsPlatformAccess && active === 'platform-sso' ? (
           <PlatformSSOProviders providers={ssoProviders} customers={customers} onSave={handleSSOProviderSave} />
@@ -1429,39 +1435,152 @@ function PlatformAccessGate({ active, me, onSSOStart, onBreakGlassLogin }) {
   );
 }
 
-function PlatformDashboardLanding({ summary, health, operations }) {
-  const customerCount = summary?.customers ?? '-';
-  const onlineDevices = summary?.online_devices ?? '-';
-  const openOperations = summary?.open_operations ?? '-';
-  const degradedServices = health.filter((item) => item.status !== 'ok' && item.status !== 'demo').length;
-  const failedOperations = operations.filter((operation) => operation.state === 'failed' || operation.state === 'dead_lettered').length;
+function PlatformDashboardLanding({ dashboard, summary, health, operations }) {
+  const source = dashboard?.sources?.prometheus || null;
+  const kpis = dashboard?.kpis?.length ? dashboard.kpis : fallbackPlatformKPIs(summary);
+  const serviceGroups = dashboard?.service_scrape_health || [];
+  const risk = dashboard?.operation_risk || {
+    open_operations: summary?.open_operations ?? 0,
+    failed_operations: operations.filter((operation) => operation.state === 'failed').length,
+    dead_lettered_operations: operations.filter((operation) => operation.state === 'dead_lettered').length,
+    source_status: 'configured',
+  };
+  const footprintRows = [
+    ['Tenants', dashboard?.summary?.customers ?? summary?.customers ?? 0],
+    ['Total devices', dashboard?.summary?.total_devices ?? summary?.total_devices ?? 0],
+    ['Activated', dashboard?.summary?.activated_devices ?? summary?.activated_devices ?? 0],
+    ['Pending', dashboard?.summary?.pending_devices ?? summary?.pending_devices ?? 0],
+    ['Failed', dashboard?.summary?.failed_devices ?? summary?.failed_devices ?? 0],
+  ];
+  const openOps = operations.filter((operation) => operation.state !== 'succeeded').slice(0, 5);
   return (
-    <>
-      <section className="panel split-panel">
+    <section className="platform-dashboard">
+      <div className="platform-dashboard-head">
         <div>
           <h2>Platform Dashboard</h2>
           <p>Cross-tenant operating status for Platform Admins.</p>
-          <div className="admin-kpis">
-            <div><strong>{customerCount}</strong><span>Tenants</span></div>
-            <div><strong>{onlineDevices}</strong><span>Devices online</span></div>
-            <div><strong>{openOperations}</strong><span>Open ops</span></div>
-          </div>
         </div>
-        <ServiceHealth health={health} compact />
+        <SourceStatusPill source={source} />
+      </div>
+
+      <section className="platform-kpi-strip">
+        {kpis.map((kpi) => (
+          <article className="platform-kpi" key={kpi.id}>
+            <span>{kpi.label}</span>
+            <strong>{formatPlatformKPIValue(kpi)}</strong>
+            <small>{platformKPIHint(kpi)}</small>
+          </article>
+        ))}
       </section>
-      <section className="panel">
-        <div className="panel-head">
-          <div>
-            <h2>Operation Risk</h2>
-            <p>Open and failed lifecycle activity across tenants.</p>
+
+      <section className="platform-dashboard-grid">
+        <article className="panel platform-dashboard-panel">
+          <div className="panel-head">
+            <div>
+              <h2>Service & Scrape Health</h2>
+              <p>Grouped target health from the admin Prometheus boundary.</p>
+            </div>
+            <SourceStatusPill source={dashboard?.panel_sources?.service_scrape_health || source} />
           </div>
-          <StatusBadge value={failedOperations ? 'degraded' : 'ok'} />
-        </div>
-        <OperationList operations={operations.filter((operation) => operation.state !== 'succeeded').slice(0, 5)} detailed />
+          <div className="scrape-group-list">
+            {serviceGroups.map((group) => (
+              <div className="scrape-group-row" key={group.id}>
+                <div>
+                  <strong>{group.name}</strong>
+                  <small>{group.targets_up} up / {group.targets_down} down</small>
+                </div>
+                <StatusBadge value={normalizeStatusKey(group.status)} label={toTitleCase(group.status)} />
+              </div>
+            ))}
+            {!serviceGroups.length ? <p className="empty-state">No scrape group data available.</p> : null}
+          </div>
+        </article>
+
+        <article className="panel platform-dashboard-panel">
+          <div className="panel-head">
+            <div>
+              <h2>Tenant & Device Footprint</h2>
+              <p>Admin read-model totals across customer organizations.</p>
+            </div>
+            <StatusBadge value="ok" label="Configured" />
+          </div>
+          <div className="footprint-list">
+            {footprintRows.map(([label, value]) => (
+              <div key={label}>
+                <span>{label}</span>
+                <strong>{value}</strong>
+              </div>
+            ))}
+          </div>
+        </article>
+
+        <article className="panel platform-dashboard-panel">
+          <div className="panel-head">
+            <div>
+              <h2>Operation Risk</h2>
+              <p>Lifecycle activity that may need operator attention.</p>
+            </div>
+            <StatusBadge value={risk.failed_operations || risk.dead_lettered_operations ? 'degraded' : 'ok'} />
+          </div>
+          <div className="risk-strip">
+            <div><strong>{risk.open_operations}</strong><span>Open</span></div>
+            <div><strong>{risk.failed_operations}</strong><span>Failed</span></div>
+            <div><strong>{risk.dead_lettered_operations}</strong><span>Dead letters</span></div>
+          </div>
+          <OperationList operations={openOps} detailed />
+        </article>
+
+        <article className="panel platform-dashboard-panel">
+          <div className="panel-head">
+            <div>
+              <h2>Platform Activity</h2>
+              <p>Current service checks and recent operations summary.</p>
+            </div>
+            <StatusBadge value={health.some((item) => item.status === 'unavailable' || item.status === 'degraded') ? 'degraded' : 'ok'} />
+          </div>
+          <ServiceHealth health={health} compact />
+        </article>
       </section>
-      {degradedServices ? <section className="panel demo-banner"><p>{`${degradedServices} service checks need attention.`}</p></section> : null}
-    </>
+    </section>
   );
+}
+
+function SourceStatusPill({ source }) {
+  const status = source?.source_status || 'unconfigured';
+  return (
+    <span className={`source-pill source-pill-${normalizeStatusKey(status)}`}>
+      {toTitleCase(status)}
+    </span>
+  );
+}
+
+function fallbackPlatformKPIs(summary) {
+  return [
+    { id: 'tenants', label: 'Tenants', value: summary?.customers ?? 0, source_status: 'configured' },
+    {
+      id: 'devices_online',
+      label: 'Devices Online',
+      value: summary?.online_devices ?? 0,
+      secondary_label: 'online_rate_pct',
+      secondary_value: summary?.total_devices ? (summary.online_devices / summary.total_devices) * 100 : 0,
+      source_status: 'configured',
+    },
+    { id: 'open_operations', label: 'Open Operations', value: summary?.open_operations ?? 0, source_status: 'configured' },
+    { id: 'scrape_targets_down', label: 'Scrape Targets Down', value: 0, source_status: 'unconfigured' },
+  ];
+}
+
+function formatPlatformKPIValue(kpi) {
+  if (kpi.id === 'devices_online' && kpi.secondary_label === 'online_rate_pct') {
+    return `${Number(kpi.value || 0).toLocaleString()} / ${formatPercent(kpi.secondary_value || 0)}`;
+  }
+  return Number(kpi.value || 0).toLocaleString();
+}
+
+function platformKPIHint(kpi) {
+  if (kpi.id === 'devices_online') return 'count / online rate';
+  if (kpi.source_status && kpi.source_status !== 'configured') return toTitleCase(kpi.source_status);
+  return kpi.unit || 'current';
 }
 
 function PlatformHealth({ summary, health }) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -488,6 +488,131 @@ p {
   grid-template-columns: minmax(0, 1.45fr) minmax(320px, 0.9fr);
 }
 
+.platform-dashboard {
+  display: grid;
+  gap: 16px;
+}
+
+.platform-dashboard-head {
+  align-items: flex-start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+}
+
+.platform-dashboard-head h2 {
+  font-size: 24px;
+  margin-bottom: 4px;
+}
+
+.platform-kpi-strip {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.platform-kpi {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow-soft);
+  min-height: 112px;
+  padding: 16px;
+}
+
+.platform-kpi span,
+.platform-kpi small,
+.footprint-list span,
+.risk-strip span,
+.scrape-group-row small {
+  color: var(--muted);
+  display: block;
+  font-size: 12px;
+}
+
+.platform-kpi strong {
+  color: var(--navy);
+  display: block;
+  font-size: 26px;
+  margin: 8px 0 4px;
+}
+
+.platform-dashboard-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: minmax(0, 1.12fr) minmax(0, 0.88fr);
+}
+
+.platform-dashboard-panel {
+  min-height: 256px;
+}
+
+.source-pill {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--brand-dark);
+  flex: 0 0 auto;
+  font-size: 12px;
+  font-weight: 800;
+  padding: 7px 10px;
+}
+
+.source-pill-unavailable,
+.source-pill-unconfigured {
+  background: #fff8f1;
+  border-color: rgba(180, 35, 24, 0.2);
+  color: #7c3f06;
+}
+
+.source-pill-stale,
+.source-pill-empty {
+  background: #fffbea;
+  border-color: rgba(247, 144, 9, 0.24);
+  color: #7a4b00;
+}
+
+.scrape-group-list,
+.footprint-list,
+.risk-strip {
+  display: grid;
+  gap: 10px;
+}
+
+.scrape-group-row,
+.footprint-list div,
+.risk-strip div {
+  align-items: center;
+  background: #f8fbfd;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: flex;
+  justify-content: space-between;
+  min-height: 48px;
+  padding: 10px 12px;
+}
+
+.scrape-group-row strong,
+.footprint-list strong,
+.risk-strip strong {
+  color: var(--navy);
+}
+
+.risk-strip {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 12px;
+}
+
+.risk-strip div {
+  align-items: flex-start;
+  display: grid;
+  gap: 2px;
+}
+
+.risk-strip strong {
+  font-size: 22px;
+}
+
 .overview-lower-grid {
   display: grid;
   gap: 18px;
@@ -2334,6 +2459,7 @@ th {
 .status-pending,
 .status-retrying,
 .status-stale,
+.status-degraded,
 .status-missing {
   background: rgba(109, 206, 221, 0.16);
   color: var(--navy);
@@ -2397,6 +2523,21 @@ th {
 
   .metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .platform-kpi-strip,
+  .platform-dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .platform-dashboard-head,
+  .platform-dashboard .panel-head {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .risk-strip {
+    grid-template-columns: 1fr;
   }
 
   .device-workspace {


### PR DESCRIPTION
## What changed

- Replaced the placeholder Platform Dashboard with the composed first viewport from `/api/admin/platform-dashboard`.
- Added KPI strip, Service & Scrape Health, Tenant & Device Footprint, Operation Risk, and Platform Activity panels.
- Added source status pills and responsive dashboard styles for desktop and mobile.
- Extended browser smoke mocks and screenshots to cover `/admin` on desktop and mobile.

## Validation

- `cd web && npm test`
- `cd web && npm run build`
- `cd web && npm run browser:smoke`

Closes #178
