### PR TITLE
Add Platform Dashboard secondary panels

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1626,7 +1626,26 @@ components:
       properties:
         id:
           type: string
-          enum: [scrape_targets_up, scrape_targets_down, exporter_freshness_seconds]
+          enum:
+            - scrape_targets_up
+            - scrape_targets_down
+            - exporter_freshness_seconds
+            - runtime_request_rate
+            - runtime_5xx_rate
+            - runtime_avg_latency_seconds
+            - app_up
+            - crossservice_consumer_backlog
+            - crossservice_dead_letters
+            - crossservice_publish_errors
+            - crossservice_consume_errors
+            - business_video_devices_online
+            - business_blob_utilization_percent
+            - business_exporter_success
+            - business_quota_requests
+            - business_eval_signups_24h
+            - infra_cpu_utilization_percent
+            - infra_memory_utilization_percent
+            - infra_disk_utilization_percent
         title:
           type: string
         source_status:

--- a/internal/app/platform_dashboard.go
+++ b/internal/app/platform_dashboard.go
@@ -44,6 +44,86 @@ var platformDashboardPrometheusQueries = []prometheusQueryDefinition{
 		StaleAfter:   5 * time.Minute,
 		StaleMessage: "Prometheus data is stale.",
 	},
+	{
+		ID:    "runtime_request_rate",
+		Title: "Runtime request rate",
+		Query: `sum by(service) (rate(http_requests_total[5m]))`,
+	},
+	{
+		ID:    "runtime_5xx_rate",
+		Title: "Runtime 5xx rate",
+		Query: `sum by(service) (rate(http_status_group_total{status="5xx"}[5m]))`,
+	},
+	{
+		ID:    "runtime_avg_latency_seconds",
+		Title: "Runtime average latency",
+		Query: `sum by(service) (rate(http_request_duration_seconds_sum[5m])) / sum by(service) (rate(http_request_duration_seconds_count[5m]))`,
+	},
+	{
+		ID:    "app_up",
+		Title: "Application up",
+		Query: `rtk_account_manager_up or rtk_cloud_admin_up or rtk_cloud_frontend_up`,
+	},
+	{
+		ID:    "crossservice_consumer_backlog",
+		Title: "Consumer backlog",
+		Query: `sum by(service) (crossservice_bus_consumer_pending_messages)`,
+	},
+	{
+		ID:    "crossservice_dead_letters",
+		Title: "Worker dead letters",
+		Query: `sum by(service) (increase(crossservice_worker_dead_letters_total[1h]))`,
+	},
+	{
+		ID:    "crossservice_publish_errors",
+		Title: "Publish errors",
+		Query: `sum by(service) (increase(crossservice_bus_publish_total{status="error"}[1h]))`,
+	},
+	{
+		ID:    "crossservice_consume_errors",
+		Title: "Consume errors",
+		Query: `sum by(service) (increase(crossservice_bus_consume_total{status="error"}[1h]))`,
+	},
+	{
+		ID:    "business_video_devices_online",
+		Title: "Video Cloud devices online",
+		Query: `video_cloud_devices_online`,
+	},
+	{
+		ID:    "business_blob_utilization_percent",
+		Title: "Blob utilization",
+		Query: `video_cloud_blob_capacity_utilization_percent`,
+	},
+	{
+		ID:    "business_exporter_success",
+		Title: "Exporter success",
+		Query: `video_cloud_exporter_last_collect_success`,
+	},
+	{
+		ID:    "business_quota_requests",
+		Title: "Quota requests",
+		Query: `rtk_account_manager_quota_raise_requests`,
+	},
+	{
+		ID:    "business_eval_signups_24h",
+		Title: "Evaluation signups",
+		Query: `increase(rtk_account_manager_eval_signups_total[24h])`,
+	},
+	{
+		ID:    "infra_cpu_utilization_percent",
+		Title: "CPU utilization",
+		Query: `100 - avg by(role) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100`,
+	},
+	{
+		ID:    "infra_memory_utilization_percent",
+		Title: "Memory utilization",
+		Query: `(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100`,
+	},
+	{
+		ID:    "infra_disk_utilization_percent",
+		Title: "Disk utilization",
+		Query: `(1 - (node_filesystem_avail_bytes{mountpoint="/"} / node_filesystem_size_bytes{mountpoint="/"})) * 100`,
+	},
 }
 
 type prometheusQueryDefinition struct {

--- a/internal/app/platform_dashboard_test.go
+++ b/internal/app/platform_dashboard_test.go
@@ -237,6 +237,77 @@ func TestAdminPlatformDashboardMissingSeriesFixture(t *testing.T) {
 	}
 }
 
+func TestAdminPlatformDashboardRepresentativeMetricFamilies(t *testing.T) {
+	t.Parallel()
+
+	seen := map[string]bool{}
+	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query().Get("query")
+		seen[query] = true
+		metric := map[string]any{"job": "video_cloud_app", "service": "api", "role": "app", "device_id": "dev-secret", "instance": "10.0.0.1:9100"}
+		value := "1"
+		if strings.Contains(query, "node_cpu") || strings.Contains(query, "node_memory") || strings.Contains(query, "node_filesystem") || strings.Contains(query, "blob_capacity") {
+			metric = map[string]any{"job": "node", "role": "infra", "instance": "10.0.0.1:9100"}
+			value = "42"
+		}
+		if strings.Contains(query, "consumer_pending") || strings.Contains(query, "dead_letters") || strings.Contains(query, "publish_total") || strings.Contains(query, "consume_total") {
+			metric = map[string]any{"job": "video_cloud_app", "service": "crossservice", "consumer": "sensitive-consumer"}
+			value = "2"
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"status": "success",
+			"data": map[string]any{
+				"resultType": "vector",
+				"result": []map[string]any{{
+					"metric": metric,
+					"value":  []any{1780369304, value},
+				}},
+			},
+		})
+	}))
+	defer prometheus.Close()
+
+	payload := getPlatformDashboardForPrometheus(t, prometheus.URL)
+	queries := map[string]contracts.PlatformDashboardPrometheusQuery{}
+	for _, query := range payload.Prometheus.Queries {
+		queries[query.ID] = query
+	}
+	for _, id := range []string{
+		"runtime_request_rate",
+		"runtime_5xx_rate",
+		"runtime_avg_latency_seconds",
+		"app_up",
+		"crossservice_consumer_backlog",
+		"crossservice_dead_letters",
+		"crossservice_publish_errors",
+		"crossservice_consume_errors",
+		"business_video_devices_online",
+		"business_blob_utilization_percent",
+		"business_exporter_success",
+		"business_quota_requests",
+		"business_eval_signups_24h",
+		"infra_cpu_utilization_percent",
+		"infra_memory_utilization_percent",
+		"infra_disk_utilization_percent",
+	} {
+		if queries[id].SourceStatus != "configured" {
+			t.Fatalf("%s source_status = %q, want configured", id, queries[id].SourceStatus)
+		}
+	}
+	if len(seen) != len(platformDashboardPrometheusQueries) {
+		t.Fatalf("seen query count = %d, want %d", len(seen), len(platformDashboardPrometheusQueries))
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	for _, leaked := range []string{"device_id", "dev-secret", "instance", "10.0.0.1", "sensitive-consumer"} {
+		if strings.Contains(string(body), leaked) {
+			t.Fatalf("payload leaked disallowed label %q: %s", leaked, body)
+		}
+	}
+}
+
 func TestAdminPlatformDashboardPrometheusConfiguredAndStale(t *testing.T) {
 	t.Parallel()
 

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -278,7 +278,26 @@ const platformDashboard = {
     service_scrape_health: { source_status: 'configured', checked_at: '2026-05-13T11:59:00Z' },
     operation_risk: { source_status: 'configured', checked_at: '2026-05-13T11:59:00Z' },
   },
-  prometheus: { queries: [] },
+  prometheus: {
+    queries: [
+      { id: 'runtime_request_rate', source_status: 'configured', series: [{ labels: { service: 'api' }, value: 18.4 }] },
+      { id: 'runtime_5xx_rate', source_status: 'configured', series: [{ labels: { service: 'api' }, value: 0 }] },
+      { id: 'runtime_avg_latency_seconds', source_status: 'configured', series: [{ labels: { service: 'api' }, value: 0.08 }] },
+      { id: 'app_up', source_status: 'configured', series: [{ labels: { job: 'cloud_admin_app' }, value: 1 }] },
+      { id: 'crossservice_consumer_backlog', source_status: 'configured', series: [{ labels: { service: 'crossservice' }, value: 4 }] },
+      { id: 'crossservice_dead_letters', source_status: 'configured', series: [{ labels: { service: 'crossservice' }, value: 0 }] },
+      { id: 'crossservice_publish_errors', source_status: 'configured', series: [{ labels: { service: 'crossservice' }, value: 0 }] },
+      { id: 'crossservice_consume_errors', source_status: 'configured', series: [{ labels: { service: 'crossservice' }, value: 0 }] },
+      { id: 'business_video_devices_online', source_status: 'configured', series: [{ labels: { job: 'metricsexporter' }, value: 1 }] },
+      { id: 'business_blob_utilization_percent', source_status: 'configured', series: [{ labels: { job: 'metricsexporter' }, value: 37 }] },
+      { id: 'business_exporter_success', source_status: 'configured', series: [{ labels: { job: 'metricsexporter' }, value: 1 }] },
+      { id: 'business_quota_requests', source_status: 'configured', series: [{ labels: { service: 'account-manager' }, value: 2 }] },
+      { id: 'business_eval_signups_24h', source_status: 'configured', series: [{ labels: { service: 'account-manager' }, value: 3 }] },
+      { id: 'infra_cpu_utilization_percent', source_status: 'configured', series: [{ labels: { role: 'api' }, value: 42 }] },
+      { id: 'infra_memory_utilization_percent', source_status: 'configured', series: [{ labels: { role: 'api' }, value: 61 }] },
+      { id: 'infra_disk_utilization_percent', source_status: 'configured', series: [{ labels: { role: 'api' }, value: 55 }] },
+    ],
+  },
 };
 
 const customers = [{
@@ -430,6 +449,8 @@ async function runDesktopSmoke(page) {
   await expectText(page, 'Scrape Targets Down');
   await expectText(page, 'Service & Scrape Health');
   await expectText(page, 'Tenant & Device Footprint');
+  await expectText(page, 'Runtime Health');
+  await expectText(page, 'Infrastructure Health');
   await screenshot(page, 'desktop-platform-dashboard.png');
 
   await gotoAndAssert(page, '/admin/ops', 'Operations');

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1453,6 +1453,33 @@ function PlatformDashboardLanding({ dashboard, summary, health, operations }) {
     ['Failed', dashboard?.summary?.failed_devices ?? summary?.failed_devices ?? 0],
   ];
   const openOps = operations.filter((operation) => operation.state !== 'succeeded').slice(0, 5);
+  const queries = dashboardQueriesByID(dashboard);
+  const runtimeRows = [
+    metricPanelRow('Request rate', queries.runtime_request_rate, { suffix: '/s' }),
+    metricPanelRow('5xx rate', queries.runtime_5xx_rate, { suffix: '/s' }),
+    metricPanelRow('Avg latency', queries.runtime_avg_latency_seconds, { suffix: 's' }),
+    metricPanelRow('App up', queries.app_up),
+  ];
+  const crossServiceRows = [
+    metricPanelRow('Consumer backlog', queries.crossservice_consumer_backlog),
+    metricPanelRow('Dead letters', queries.crossservice_dead_letters),
+    metricPanelRow('Publish errors', queries.crossservice_publish_errors),
+    metricPanelRow('Consume errors', queries.crossservice_consume_errors),
+  ];
+  const businessRows = [
+    metricPanelRow('Video devices online', queries.business_video_devices_online),
+    metricPanelRow('Blob utilization', queries.business_blob_utilization_percent, { suffix: '%' }),
+    metricPanelRow('Exporter success', queries.business_exporter_success),
+    metricPanelRow('Quota requests', queries.business_quota_requests),
+    metricPanelRow('Eval signups 24h', queries.business_eval_signups_24h),
+  ];
+  const infrastructureRows = [
+    metricPanelRow('CPU utilization', queries.infra_cpu_utilization_percent, { suffix: '%' }),
+    metricPanelRow('Memory utilization', queries.infra_memory_utilization_percent, { suffix: '%' }),
+    metricPanelRow('Disk utilization', queries.infra_disk_utilization_percent, { suffix: '%' }),
+    metricPanelRow('Gateway targets', dashboardGroup(serviceGroups, 'gateway')),
+    metricPanelRow('Broker targets', dashboardGroup(serviceGroups, 'broker')),
+  ];
   return (
     <section className="platform-dashboard">
       <div className="platform-dashboard-head">
@@ -1540,8 +1567,34 @@ function PlatformDashboardLanding({ dashboard, summary, health, operations }) {
           </div>
           <ServiceHealth health={health} compact />
         </article>
+
+        <PlatformMetricPanel title="Runtime Health" rows={runtimeRows} />
+        <PlatformMetricPanel title="Cross-Service Risk" rows={crossServiceRows} />
+        <PlatformMetricPanel title="Business Signals" rows={businessRows} secondary />
+        <PlatformMetricPanel title="Infrastructure Health" rows={infrastructureRows} />
       </section>
     </section>
+  );
+}
+
+function PlatformMetricPanel({ title, rows, secondary = false }) {
+  return (
+    <article className={`panel platform-dashboard-panel ${secondary ? 'platform-dashboard-panel-secondary' : ''}`}>
+      <div className="panel-head">
+        <div>
+          <h2>{title}</h2>
+        </div>
+        <StatusBadge value={rows.some((row) => row.status === 'configured') ? 'ok' : 'empty'} label={rows.some((row) => row.status === 'configured') ? 'Configured' : 'Empty'} />
+      </div>
+      <div className="metric-row-list">
+        {rows.map((row) => (
+          <div className="metric-row" key={row.label}>
+            <span>{row.label}</span>
+            <strong>{row.value}</strong>
+          </div>
+        ))}
+      </div>
+    </article>
   );
 }
 
@@ -1581,6 +1634,38 @@ function platformKPIHint(kpi) {
   if (kpi.id === 'devices_online') return 'count / online rate';
   if (kpi.source_status && kpi.source_status !== 'configured') return toTitleCase(kpi.source_status);
   return kpi.unit || 'current';
+}
+
+function dashboardQueriesByID(dashboard) {
+  const byID = {};
+  for (const query of dashboard?.prometheus?.queries || []) {
+    byID[query.id] = query;
+  }
+  return byID;
+}
+
+function metricPanelRow(label, item, { suffix = '' } = {}) {
+  if (!item) return { label, value: 'Empty', status: 'empty' };
+  if (item.source_status && item.source_status !== 'configured' && item.source_status !== 'stale') {
+    return { label, value: toTitleCase(item.source_status), status: item.source_status };
+  }
+  if (item.targets_total !== undefined) {
+    return { label, value: `${item.targets_up} up / ${item.targets_down} down`, status: item.source_status || 'configured' };
+  }
+  const total = (item.series || []).reduce((sum, series) => sum + Number(series.value || 0), 0);
+  if (!item.series?.length) return { label, value: toTitleCase(item.source_status || 'empty'), status: item.source_status || 'empty' };
+  return { label, value: `${formatCompactNumber(total)}${suffix}`, status: item.source_status || 'configured' };
+}
+
+function dashboardGroup(groups, id) {
+  return groups.find((group) => group.id === id) || null;
+}
+
+function formatCompactNumber(value) {
+  const number = Number(value || 0);
+  if (Math.abs(number) >= 1000) return number.toLocaleString(undefined, { maximumFractionDigits: 0 });
+  if (Math.abs(number) >= 10) return number.toLocaleString(undefined, { maximumFractionDigits: 1 });
+  return number.toLocaleString(undefined, { maximumFractionDigits: 2 });
 }
 
 function PlatformHealth({ summary, health }) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -613,6 +613,40 @@ p {
   font-size: 22px;
 }
 
+.metric-row-list {
+  display: grid;
+  gap: 10px;
+}
+
+.metric-row {
+  align-items: center;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  min-height: 36px;
+  padding: 4px 0 10px;
+}
+
+.metric-row:last-child {
+  border-bottom: 0;
+  padding-bottom: 0;
+}
+
+.metric-row span {
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.metric-row strong {
+  color: var(--navy);
+  font-size: 16px;
+  text-align: right;
+}
+
+.platform-dashboard-panel-secondary {
+  background: rgba(255, 255, 255, 0.78);
+}
+
 .overview-lower-grid {
   display: grid;
   gap: 18px;


### PR DESCRIPTION
## What changed

- Added representative Prometheus allowlisted query families for runtime, cross-service, business, and infrastructure signals.
- Rendered secondary Platform Dashboard panels for Runtime Health, Cross-Service Risk, Business Signals, and Infrastructure Health.
- Preserved stable empty/unconfigured states for missing metric families and continued label allowlisting to avoid sensitive/high-cardinality label display.
- Extended backend fixture tests and browser smoke fixtures/assertions for the new panels.
- Updated OpenAPI query ID documentation.

## Validation

- `go test ./internal/app -run TestAdminPlatformDashboard`
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`
- `cd web && npm test`
- `cd web && npm run build`
- `cd web && npm run browser:smoke`

Closes #179
