### PR TITLE
Sign off Platform Dashboard QA docs

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -374,8 +374,10 @@ paths:
       summary: Platform Dashboard BFF payload
       description: |
         Platform-admin protected dashboard boundary. The BFF composes existing
-        admin read-model summary data and server-side allowlisted Prometheus
-        queries. Browser clients never receive a raw Prometheus passthrough.
+        admin read-model summary data, KPI strip, operation-risk data, grouped
+        scrape health, and server-side allowlisted Prometheus queries for
+        runtime, cross-service, business, and infrastructure panels. Browser
+        clients never receive a raw Prometheus passthrough.
       responses:
         "200":
           description: Platform Dashboard payload with per-source states.

--- a/docs/webui-browser-qa.md
+++ b/docs/webui-browser-qa.md
@@ -29,12 +29,15 @@ gitignored.
   - Devices with detail drawer open
   - Firmware & OTA campaign drill-down
   - Stream Health worst-device drill-down into Devices
+  - Platform Dashboard with Prometheus configured, KPI strip, scrape health,
+    runtime, cross-service, business, and infrastructure panels
   - Platform Operations Log
   - Platform SSO Providers
   - Platform Audit Log
 - Mobile 390px:
   - Customer sidebar/nav remains visible
   - Devices uses compact rows instead of rendering the full table
+  - Platform Dashboard remains navigable and readable on a narrow viewport
   - Public signup remains usable on a narrow viewport
 
 The smoke test fails on app-level `console.error`, `console.warn`, or uncaught
@@ -47,12 +50,20 @@ does not validate production upstream telemetry, firmware, stream, or account
 manager integrations. Those remain covered by backend contract tests and live
 environment validation.
 
+Platform Dashboard browser code calls only Admin Console BFF JSON routes. The
+mocked Platform Dashboard fixture covers the configured Prometheus path and the
+backend fixture tests cover Prometheus unset, unavailable/timeout-like upstream
+failure, empty results, stale exporter data, one target down, missing series,
+and representative runtime/cross-service/business/infrastructure metric
+families. Grafana remains optional SRE tooling for deep time-series inspection;
+it is not the Platform Admin UI and is not embedded by the browser smoke.
+
 ## Final Signoff Notes
 
 - Admin repo WebUI milestone coverage is complete for the documented scope:
   Customer View four pages, public auth/signup/verification/quota states,
-  Platform View four pages, route guards, source-aware states, and read-only
-  customer workflows.
+  Platform Dashboard, Platform View drill-down pages, route guards,
+  source-aware states, and read-only customer workflows.
 - Remaining blockers are upstream production sources, not admin repo WebUI
   completion: authoritative telemetry, firmware rollout facts, and WebRTC
   session facts still require live-source validation outside this mocked smoke

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -30,9 +30,8 @@ production data work in `rtk_video_cloud` or `rtk_account_manager` is tracked as
 a dependency note only; do not open upstream issues as part of this batch.
 
 This roadmap tracks the completed first WebUI implementation sequence for
-Customer View, auth, and the initial Platform View pages. Platform Dashboard
-metrics and Brand Clouds are subsequent Platform View design extensions; their
-drafts live in
+Customer View, auth, Platform View pages, and Platform Dashboard. Brand Clouds
+remain a subsequent Platform View design extension; the relevant drafts live in
 [platform-view-dashboard-design.md](platform-view-dashboard-design.md) and
 [platform-brand-cloud-management-design.md](platform-brand-cloud-management-design.md).
 
@@ -475,8 +474,8 @@ Platform View separation.
 ## Scope
 
 - Polish Service Health, including Platform-only demo mode banner behavior.
-- Add Platform Dashboard as the Tier 1 landing page when the metrics BFF surface
-  is implemented; follow `platform-view-dashboard-design.md`.
+- Keep Platform Dashboard as the Tier 1 landing page through the implemented
+  metrics BFF surface; follow `platform-view-dashboard-design.md`.
 - Complete SSO Providers status/settings surface through Account Manager-backed
   data.
 - Complete Operations Log with Friendly Summary, raw type/state as Platform-only
@@ -497,7 +496,7 @@ Platform View separation.
 ## Dependencies
 
 - Milestone 1 route and role gates.
-- `/api/admin/service-health`, `/api/admin/sso/providers`,
+- `/api/admin/platform-dashboard`, `/api/admin/service-health`, `/api/admin/sso/providers`,
   `/api/admin/operations`, and `/api/admin/audit`.
 - Account Manager remains source of truth for SSO provider configuration and
   secrets.
@@ -505,6 +504,8 @@ Platform View separation.
 ## Acceptance Criteria
 
 - Customer users cannot see Platform View data.
+- Platform Dashboard remains the first Platform View route and shows Prometheus
+  source states instead of direct Prometheus or Grafana browser access.
 - SSO Providers never displays secrets or stores provider secrets in Admin
   Console SQLite.
 - SSO Providers does not present SAML as implemented; OIDC is first supported.


### PR DESCRIPTION
Closes #180

## Summary
- tighten the Platform Dashboard OpenAPI description for the BFF response and Prometheus boundary
- document browser QA coverage for configured Prometheus, fallback source states, mobile, route guard, and Grafana boundary
- update the web UI roadmap to reflect the implemented Platform Dashboard sequence

## Validation
- git diff --check
- go test ./...
- cd web && npm test
- cd web && npm run build
- cd web && npm run browser:smoke