### PR TITLE
[codex] Document persistence cache boundaries

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -121,6 +121,15 @@ Data ownership:
   [`docs/sso-oidc-design.md`](sso-oidc-design.md).
 - Video Cloud remains authoritative for activation, transport, streaming, media, firmware, and device runtime facts.
 
+Future Redis-compatible session or projection cache support must start by
+extracting narrow ports from the current SQLite `internal/store.Store`. SQLite
+remains authoritative only for console-local data such as platform break-glass
+users, sessions, audit, settings, preferences, and demo data. Upstream
+organization, device, operation, readiness, firmware, telemetry, and stream
+facts remain non-authoritative projections or proxy results from Account Manager
+and Video Cloud. The cross-repository roadmap is maintained in
+`../../docs/persistence-cache-refactor-roadmap.md`.
+
 ## HTTP Interface
 
 The machine-readable BFF API contract is maintained in


### PR DESCRIPTION
## Summary

- Documents the Admin Console local-store boundary for future Redis-compatible session/projection cache support.
- Clarifies that SQLite remains authoritative only for console-local data while upstream facts remain non-authoritative projections or proxy results.
- Links the workspace roadmap and the developer issue.

## Validation

- Docs-only change.
- Verified diff is limited to `docs/SPEC.md`.

Related issue: #181
Workspace roadmap: https://github.com/hkt999rtk/rtk_cloud_workspace/blob/codex/persistence-cache-docs/docs/persistence-cache-refactor-roadmap.md
