### PR TITLE
Document completed admin work

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,14 @@ Implemented in this first version:
 - legacy local platform admin login/session endpoint backed by SQLite for controlled break-glass access
 - SSO/OIDC architecture documented for the next authentication milestone
 - Account Manager proxy mode for organizations, devices, provision, and deactivate
+- Platform Dashboard BFF and React landing page with curated Prometheus-backed
+  operational panels, source states, and no browser-side Prometheus or Grafana
+  access
 - Account Manager-backed brand-cloud admin BFF routes for future Platform View
   UI implementation
+- narrow application store interfaces for sessions, break-glass platform
+  admins, audit events, projection reads, and lifecycle operations; the current
+  implementation remains SQLite-backed and does not add Redis
 - explicit SQLite schema migrations tracked in `schema_migrations`
 - URL routes for `/console`, `/console/customers`, `/console/devices`,
   `/console/operations`, `/console/audit`, and `/admin`
@@ -62,6 +68,17 @@ identity broker and authorization source. See
 [`docs/sso-oidc-design.md`](docs/sso-oidc-design.md). Existing password login
 paths are legacy compatibility or controlled break-glass surfaces, not the
 long-term production target.
+
+Recent completion status:
+
+- Platform Dashboard implementation, QA documentation, OpenAPI coverage, and
+  browser smoke coverage are complete.
+- Admin Console local-store access is split behind narrow interfaces so future
+  session/projection cache work can be introduced without making Admin Console
+  the source of truth for upstream tenant or device facts.
+- The contracts documentation submodule URL and CI rewrite now support the
+  local `github.com-work` SSH alias while preserving token-authenticated CI
+  checkout.
 
 ## WebUI Background
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -106,7 +106,11 @@ Runtime components:
 
 - `cmd/server`: process entry point, configuration, server startup, graceful shutdown.
 - `internal/app`: application wiring, route registration, JSON API handlers, static frontend serving, health endpoint.
-- `internal/store`: SQLite schema, repository methods, seed data, and migrations.
+- `internal/app/store_ports.go`: narrow local-store interfaces for sessions,
+  break-glass platform admin verification, audit events, projection reads, and
+  lifecycle operations.
+- `internal/store`: SQLite schema, repository methods, seed data, migrations,
+  and the current implementation of the app-local store interfaces.
 - `internal/contracts`: Go vocabulary for readiness states, operation states, roles, and DTOs used by the UI.
 - `web`: React frontend source, built with Vite and served as static files by the Go backend.
 - `web/dist`: generated frontend build output, not manually edited.
@@ -115,6 +119,9 @@ Data ownership:
 
 - SQLite is authoritative only for console-local data: platform admins, sessions, audit, settings, preferences, and demo projections.
 - SQLite cache tables for upstream organizations, devices, operations, and readiness facts are non-authoritative mirrors that can be refreshed from Account Manager and Video Cloud.
+- Application handlers depend on narrow local-store interfaces where practical;
+  this is a boundary for future cache/session backends, not a change in source
+  of truth.
 - Account Manager remains authoritative for customer users, organizations, membership, and registry devices.
 - Account Manager is also the planned identity broker and authorization source
   for standards-based SSO; see

--- a/docs/backend-api-gap-audit.md
+++ b/docs/backend-api-gap-audit.md
@@ -154,11 +154,11 @@ validation.
 
 ### Admin Repo Follow-Up Work
 
-Status: tracked in [webui-implementation-roadmap.md](webui-implementation-roadmap.md).
+Status: completed for the first WebUI implementation batch tracked in
+[webui-implementation-roadmap.md](webui-implementation-roadmap.md).
 
 These items can be implemented in `rtk_cloud_admin` without making this repo the
-source of truth for upstream facts. Open developer issues from the roadmap
-milestones, not from ad hoc page lists:
+source of truth for upstream facts. The completed milestone sequence covered:
 
 1. WebUI foundation cleanup and route guards.
 2. Customer View source-aware page states.

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -22,6 +22,12 @@ The app is not a stateless frontend. Local SQLite holds sessions, platform
 admins, audit metadata, settings, and upstream cache projections. Treat the
 database file as production state and back it up accordingly.
 
+The Go application now accesses this local state through narrow app-level
+interfaces for sessions, break-glass platform admin verification, audit,
+projection reads, and lifecycle operations. SQLite remains the implementation
+for this deployment profile; no Redis-compatible session or projection cache is
+required or configured by this release.
+
 ## Linode Staging Profile
 
 The supported Linode staging shape is a dedicated Admin VM with public HTTPS
@@ -101,6 +107,9 @@ state.
   firmware facts
 - local SQLite remains authoritative for admin sessions, platform admins,
   audit metadata, and cached projections used by the dashboard
+- local projection interfaces are non-authoritative cache/read-model ports;
+  they must not be used to turn Admin Console into the canonical brand-cloud,
+  organization, device, or lifecycle-operation store
 
 In production, upstream failures must be visible. The dashboard should surface
 gateway errors instead of silently falling back when a configured upstream is

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -1,6 +1,6 @@
 # WebUI Implementation Roadmap
 
-Status: developer-ready issue roadmap.
+Status: completed first-batch implementation roadmap.
 
 Audience:
 
@@ -20,14 +20,15 @@ Related documents:
 
 ## Summary
 
-This roadmap is the source of truth for opening developer issues to finish the
-RTK Cloud Admin WebUI. Issues are split by implementation milestone rather than
-by isolated page so that shared route guards, source states, role behavior, and
-browser QA are implemented once and reused consistently.
+This roadmap records the completed first RTK Cloud Admin WebUI implementation
+batch and remains the reference for future follow-up issues. The original work
+was split by implementation milestone rather than by isolated page so that
+shared route guards, source states, role behavior, and browser QA were
+implemented once and reused consistently.
 
-All issues in this roadmap are for `hkt999rtk/rtk_cloud_admin`. Upstream
-production data work in `rtk_video_cloud` or `rtk_account_manager` is tracked as
-a dependency note only; do not open upstream issues as part of this batch.
+The completed admin-repo issues were for `hkt999rtk/rtk_cloud_admin`. Upstream
+production data work in `rtk_video_cloud` or `rtk_account_manager` remains a
+dependency note only and was not opened as part of this batch.
 
 This roadmap tracks the completed first WebUI implementation sequence for
 Customer View, auth, Platform View pages, and Platform Dashboard. Brand Clouds


### PR DESCRIPTION
## Summary
- document the completed Platform Dashboard, local-store port, and contracts-doc submodule work
- clarify source-of-truth boundaries and that SQLite remains the current local-store implementation without Redis
- update roadmap and backend gap audit status from issue-opening language to completed first-batch implementation

## Validation
- git diff --check