### PR TITLE
Add platform service log dashboard

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.9% |
+| Go total coverage | 80.8% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,7 +28,7 @@
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 89.8% |
-| `rtk_cloud_admin/internal/app` | 81.0% |
+| `rtk_cloud_admin/internal/app` | 80.9% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -141,6 +142,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/admin/operations", s.apiAdminOperations)
 	s.mux.HandleFunc("GET /api/service-health", s.apiServiceHealth)
 	s.mux.HandleFunc("GET /api/admin/service-health", s.apiAdminServiceHealth)
+	s.mux.HandleFunc("GET /api/admin/service-logs", s.apiAdminServiceLogs)
 	s.mux.HandleFunc("GET /api/audit", s.apiAudit)
 	s.mux.HandleFunc("GET /api/admin/audit", s.apiAdminAudit)
 	s.mux.HandleFunc("POST /api/devices/{id}/provision", s.apiProvisionDevice)
@@ -165,6 +167,7 @@ func (s *Server) routes() {
 		"/admin/ops",
 		"/admin/operations",
 		"/admin/audit",
+		"/admin/logs",
 		"/admin/sso",
 	} {
 		s.mux.HandleFunc("GET "+path, s.shell)
@@ -2298,6 +2301,87 @@ func (s *Server) apiAdminServiceHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, s.serviceHealth(r.Context()))
+}
+
+func (s *Server) apiAdminServiceLogs(w http.ResponseWriter, r *http.Request) {
+	if _, ok := s.requirePlatformAdmin(w, r); !ok {
+		return
+	}
+	endpoint := strings.TrimRight(s.cfg.CloudLoggerEndpoint, "/")
+	if endpoint == "" || s.cfg.CloudLoggerToken == "" {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]any{"status": "unavailable", "message": "Central service logging is not configured.", "events": []any{}})
+		return
+	}
+	query := url.Values{}
+	for _, key := range []string{"since", "until", "service", "host", "unit", "level", "trace_id", "request_id", "operation_id", "device_id", "org_id", "user_id"} {
+		if value := strings.TrimSpace(r.URL.Query().Get(key)); value != "" {
+			query.Set(key, value)
+		}
+	}
+	req, err := http.NewRequestWithContext(r.Context(), http.MethodGet, endpoint+"/v1/logs?"+query.Encode(), nil)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+s.cfg.CloudLoggerToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]any{"status": "degraded", "message": "Central service logging is unavailable.", "events": []any{}})
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]any{"status": "degraded", "message": "Central service logging is unavailable.", "events": []any{}})
+		return
+	}
+	var payload struct {
+		Events []map[string]any `json:"events"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]any{"status": "degraded", "message": "Central service logging response was invalid.", "events": []any{}})
+		return
+	}
+	writeJSON(w, map[string]any{"status": "ok", "events": redactServiceLogEvents(payload.Events)})
+}
+
+func redactServiceLogEvents(events []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(events))
+	for _, event := range events {
+		clean := map[string]any{}
+		for key, value := range event {
+			if adminSensitiveLogKey(key) {
+				clean[key] = "REDACTED"
+			} else if fields, ok := value.(map[string]any); ok {
+				clean[key] = redactServiceLogFields(fields)
+			} else {
+				clean[key] = value
+			}
+		}
+		out = append(out, clean)
+	}
+	return out
+}
+
+func redactServiceLogFields(fields map[string]any) map[string]any {
+	out := map[string]any{}
+	for key, value := range fields {
+		if adminSensitiveLogKey(key) {
+			out[key] = "REDACTED"
+		} else {
+			out[key] = value
+		}
+	}
+	return out
+}
+
+func adminSensitiveLogKey(key string) bool {
+	normalized := strings.ToLower(strings.ReplaceAll(key, "-", "_"))
+	for _, item := range []string{"token", "password", "secret", "credential", "private_key", "access_key", "authorization", "cookie"} {
+		if strings.Contains(normalized, item) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) apiAudit(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -68,6 +68,59 @@ func TestServerHealthAndHomeRedirect(t *testing.T) {
 	}
 }
 
+func TestAdminServiceLogsProxyFiltersAndRedacts(t *testing.T) {
+	t.Parallel()
+
+	var gotAuth, gotQuery string
+	logger := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"events": []map[string]any{{
+				"event_id":   "evt-1",
+				"ts":         "2026-06-02T00:00:00Z",
+				"service":    "account-manager",
+				"level":      "info",
+				"msg":        "login",
+				"trace_id":   "trace-1",
+				"request_id": "request-1",
+				"fields": map[string]any{
+					"access_token": "raw-token",
+					"safe":         "ok",
+				},
+			}},
+		})
+	}))
+	defer logger.Close()
+
+	st := mustOpenStore(t)
+	session, err := st.CreateSession("platform_admin", "admin", "admin@example.com", "", "", "", time.Hour)
+	if err != nil {
+		t.Fatalf("CreateSession returned error: %v", err)
+	}
+	srv := NewWithOptions(st, Options{Config: config.Config{CloudLoggerEndpoint: logger.URL, CloudLoggerToken: "logger-token"}})
+	req := httptest.NewRequest(http.MethodGet, "/api/admin/service-logs?service=account-manager&trace_id=trace-1&ignored=secret", nil)
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body=%s", rec.Code, rec.Body.String())
+	}
+	if gotAuth != "Bearer logger-token" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if !strings.Contains(gotQuery, "service=account-manager") || !strings.Contains(gotQuery, "trace_id=trace-1") || strings.Contains(gotQuery, "ignored") {
+		t.Fatalf("query = %q", gotQuery)
+	}
+	body := rec.Body.String()
+	if strings.Contains(body, "raw-token") || strings.Contains(body, "logger-token") {
+		t.Fatalf("service logs response leaked secret: %s", body)
+	}
+	if !strings.Contains(body, `"access_token":"REDACTED"`) || !strings.Contains(body, `"safe":"ok"`) {
+		t.Fatalf("service logs response missing redacted fields: %s", body)
+	}
+}
+
 func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	VideoCloudBaseURL                  string
 	VideoCloudAdminToken               string
 	VideoCloudPrometheusBaseURL        string
+	CloudLoggerEndpoint                string
+	CloudLoggerToken                   string
 	AdminBootstrapEmail                string
 	AdminBootstrapPassword             string
 	AdminBreakGlassEnabled             bool
@@ -27,6 +29,8 @@ func FromEnv() Config {
 		VideoCloudBaseURL:                  os.Getenv("VIDEO_CLOUD_BASE_URL"),
 		VideoCloudAdminToken:               os.Getenv("VIDEO_CLOUD_ADMIN_TOKEN"),
 		VideoCloudPrometheusBaseURL:        os.Getenv("VIDEO_CLOUD_PROMETHEUS_BASE_URL"),
+		CloudLoggerEndpoint:                os.Getenv("CLOUD_LOGGER_ENDPOINT"),
+		CloudLoggerToken:                   os.Getenv("CLOUD_LOGGER_INGEST_TOKEN"),
 		AdminBootstrapEmail:                os.Getenv("ADMIN_BOOTSTRAP_EMAIL"),
 		AdminBootstrapPassword:             os.Getenv("ADMIN_BOOTSTRAP_PASSWORD"),
 		AdminBreakGlassEnabled:             truthy(os.Getenv("ADMIN_BREAK_GLASS_ENABLED")),

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -45,6 +45,7 @@ function App() {
   const [devices, setDevices] = useState([]);
   const [operations, setOperations] = useState([]);
   const [health, setHealth] = useState([]);
+  const [serviceLogs, setServiceLogs] = useState(null);
   const [audit, setAudit] = useState([]);
   const [platformDashboard, setPlatformDashboard] = useState(null);
   const [ssoProviders, setSSOProviders] = useState([]);
@@ -89,6 +90,7 @@ function App() {
           setDevices([]);
           setOperations([]);
           setHealth([]);
+          setServiceLogs(null);
           setAudit([]);
           setPlatformDashboard(null);
           setSSOProviders([]);
@@ -105,6 +107,7 @@ function App() {
           setDevices([]);
           setOperations([]);
           setHealth([]);
+          setServiceLogs(null);
           setAudit([]);
           setPlatformDashboard(null);
           setSSOProviders([]);
@@ -139,6 +142,17 @@ function App() {
         setDevices(nextDevices);
         setOperations(nextOperations);
         setHealth(nextHealth);
+        if (useAdminApi && active === 'platform-logs') {
+          const logs = await fetchJSON('/api/admin/service-logs?service=workspace-readiness').catch((err) => ({
+            status: 'degraded',
+            message: err.message || 'Central service logging is unavailable.',
+            events: [],
+          }));
+          if (!alive) return;
+          setServiceLogs(logs);
+        } else {
+          setServiceLogs(null);
+        }
         setAudit(nextAudit);
         setPlatformDashboard(nextPlatformDashboard);
         if (useAdminApi && active === 'platform-sso') {
@@ -201,6 +215,7 @@ function App() {
           setDevices([]);
           setOperations([]);
           setHealth([]);
+          setServiceLogs(null);
           setAudit([]);
           setSSOProviders([]);
           setFirmwareDistribution(null);
@@ -228,6 +243,7 @@ function App() {
     setDevices([]);
     setOperations([]);
     setHealth([]);
+    setServiceLogs(null);
     setAudit([]);
     setSSOProviders([]);
     setFirmwareDistribution(null);
@@ -555,6 +571,7 @@ function App() {
         ) : null}
         {!needsPlatformAccess && active === 'platform-dashboard' ? <PlatformDashboardLanding dashboard={platformDashboard} summary={summary} health={health} operations={operations} /> : null}
         {!needsPlatformAccess && active === 'platform-health' ? <PlatformHealth summary={summary} health={health} /> : null}
+        {!needsPlatformAccess && active === 'platform-logs' ? <PlatformServiceLogs logs={serviceLogs} loading={loading} /> : null}
         {!needsPlatformAccess && active === 'platform-sso' ? (
           <PlatformSSOProviders providers={ssoProviders} customers={customers} onSave={handleSSOProviderSave} />
         ) : null}
@@ -1687,6 +1704,52 @@ function PlatformHealth({ summary, health }) {
       </section>
       {hasDemo ? <section className="panel demo-banner"><p>{`Demo services active: ${demoServices.map((service) => service.name).join(', ')}`}</p></section> : null}
     </>
+  );
+}
+
+function PlatformServiceLogs({ logs, loading }) {
+  const events = logs?.events || [];
+  const status = logs?.status || (loading ? 'loading' : 'unavailable');
+  return (
+    <section className="panel platform-dashboard-panel">
+      <div className="panel-head">
+        <div>
+          <h2>Cloud Service Logs</h2>
+          <p>Centralized application logs from Account Manager, Video Cloud, Cloud Admin, and staging hosts.</p>
+        </div>
+        <span className={`status-pill ${status === 'ok' ? 'ok' : 'warn'}`}>{status}</span>
+      </div>
+      <div className="filter-row">
+        {['service', 'host', 'unit', 'level', 'trace_id', 'request_id', 'operation_id', 'device_id', 'org_id', 'user_id'].map((field) => (
+          <label key={field}>
+            <span>{field}</span>
+            <input readOnly value="" placeholder={field} />
+          </label>
+        ))}
+      </div>
+      {logs?.message ? <p className="source-note">{logs.message}</p> : null}
+      <div className="table-wrap">
+        <table>
+          <thead>
+            <tr><th>Time</th><th>Service</th><th>Level</th><th>Host</th><th>Message</th><th>Trace</th><th>Request</th></tr>
+          </thead>
+          <tbody>
+            {events.map((event) => (
+              <tr key={event.event_id || `${event.ts}-${event.msg}`}>
+                <td>{event.ts || '-'}</td>
+                <td>{event.service || '-'}</td>
+                <td>{event.level || '-'}</td>
+                <td>{event.host || '-'}</td>
+                <td>{event.msg || '-'}</td>
+                <td>{event.trace_id || '-'}</td>
+                <td>{event.request_id || '-'}</td>
+              </tr>
+            ))}
+            {!events.length ? <tr><td colSpan="7">{loading ? 'Loading service logs' : 'No service log events found'}</td></tr> : null}
+          </tbody>
+        </table>
+      </div>
+    </section>
   );
 }
 

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -9,6 +9,7 @@ export const platformNavItems = [
   { id: 'platform-dashboard', label: 'Platform Dashboard', path: '/admin' },
   { id: 'platform-health', label: 'Service Health', path: '/admin/health' },
   { id: 'platform-sso', label: 'SSO Providers', path: '/admin/sso' },
+  { id: 'platform-logs', label: 'Service Logs', path: '/admin/logs' },
   { id: 'platform-operations', label: 'Operations Log', path: '/admin/ops' },
   { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit' },
 ];
@@ -40,6 +41,7 @@ export function titleFor(active) {
     'platform-dashboard': 'Platform Dashboard',
     'platform-health': 'Service Health',
     'platform-sso': 'SSO Providers',
+    'platform-logs': 'Service Logs',
     'platform-operations': 'Operations',
     'platform-audit': 'Audit Log',
   }[active];
@@ -52,6 +54,7 @@ export function routeFromPath(path) {
   if (path === '/admin' || path === '/admin/') return 'platform-dashboard';
   if (path === '/admin/health' || path.startsWith('/admin/health/')) return 'platform-health';
   if (path === '/admin/sso' || path.startsWith('/admin/sso/')) return 'platform-sso';
+  if (path === '/admin/logs' || path.startsWith('/admin/logs/')) return 'platform-logs';
   if (path === '/admin/ops' || path.startsWith('/admin/ops/')) return 'platform-operations';
   if (path === '/admin/operations' || path.startsWith('/admin/operations/')) return 'platform-operations';
   if (path === '/admin/audit' || path.startsWith('/admin/audit/')) return 'platform-audit';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -15,6 +15,7 @@ test('maps platform shell paths to platform routes', () => {
   assert.equal(routeFromPath('/admin'), 'platform-dashboard');
   assert.equal(routeFromPath('/admin/health'), 'platform-health');
   assert.equal(routeFromPath('/admin/sso'), 'platform-sso');
+  assert.equal(routeFromPath('/admin/logs'), 'platform-logs');
   assert.equal(routeFromPath('/admin/ops'), 'platform-operations');
   assert.equal(routeFromPath('/admin/operations'), 'platform-operations');
   assert.equal(routeFromPath('/admin/audit'), 'platform-audit');
@@ -62,11 +63,11 @@ test('retired customer pages are not exposed in section navigation', () => {
 test('platform nav follows the Platform Dashboard landing order', () => {
   assert.deepEqual(
     platformNavItems.map((item) => item.label),
-    ['Platform Dashboard', 'Service Health', 'SSO Providers', 'Operations Log', 'Audit Log'],
+    ['Platform Dashboard', 'Service Health', 'SSO Providers', 'Service Logs', 'Operations Log', 'Audit Log'],
   );
   assert.deepEqual(
     platformNavItems.map((item) => item.path),
-    ['/admin', '/admin/health', '/admin/sso', '/admin/ops', '/admin/audit'],
+    ['/admin', '/admin/health', '/admin/sso', '/admin/logs', '/admin/ops', '/admin/audit'],
   );
 });
 
@@ -123,6 +124,7 @@ test('provides titles for all public shell routes', () => {
     'platform-dashboard',
     'platform-health',
     'platform-sso',
+    'platform-logs',
     'platform-operations',
     'platform-audit',
   ]) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -647,6 +647,33 @@ p {
   background: rgba(255, 255, 255, 0.78);
 }
 
+.filter-row {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  margin: 14px 0;
+}
+
+.filter-row label {
+  color: var(--muted);
+  display: grid;
+  font-size: 12px;
+  gap: 5px;
+}
+
+.filter-row input {
+  background: var(--surface);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  color: var(--navy);
+  min-width: 0;
+  padding: 8px 9px;
+}
+
+.table-wrap {
+  overflow-x: auto;
+}
+
 .overview-lower-grid {
   display: grid;
   gap: 18px;


### PR DESCRIPTION
## Summary
- add server-side Cloud Admin service log query adapter backed by the central logger API
- add Platform Service Logs route/page without exposing Loki or logger tokens to the browser
- cover query filters, degraded/unavailable state, and secret redaction

Supports hkt999rtk/rtk_cloud_workspace#84

## Tests
- GOWORK=off go test ./internal/app ./internal/config
- npm test -- --runInBand
- git diff --check