### PR TITLE
Clarify admin local health wait log

### DIFF
--- a/deploy/linode/deploy-admin-env-test.sh
+++ b/deploy/linode/deploy-admin-env-test.sh
@@ -67,5 +67,7 @@ grep -q '127.0.0.1:8081/stub_status' "$capture/remote-install.sh"
 grep -q -- '-web.listen-address=$nginx_exporter_listen_addr' "$capture/remote-install.sh"
 grep -q '10.42.1.60:9113' "$capture/remote-install-args.txt"
 grep -q 'systemctl enable --now prometheus-nginx-exporter' "$capture/remote-install.sh"
+grep -q '\[admin-deploy\] waiting for rtk-cloud-admin local health on 127.0.0.1:8080' "$capture/remote-install.sh"
+grep -q 'curl -fsS http://127.0.0.1:8080/healthz 2>/dev/null' "$capture/remote-install.sh"
 
 printf 'deploy-admin env test passed\n'

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -330,9 +330,13 @@ systemctl enable --now rtk-cloud-admin
 systemctl restart rtk-cloud-admin
 
 for _ in $(seq 1 30); do
-  if curl -fsS http://127.0.0.1:8080/healthz | grep -qx ok; then
+  if curl -fsS http://127.0.0.1:8080/healthz 2>/dev/null | grep -qx ok; then
     ready=1
     break
+  fi
+  if [ "${health_wait_logged:-0}" != "1" ]; then
+    printf '[admin-deploy] waiting for rtk-cloud-admin local health on 127.0.0.1:8080\n' >&2
+    health_wait_logged=1
   fi
   sleep 1
 done


### PR DESCRIPTION
## Summary
- silence transient `curl` stderr while waiting for the local Admin app health endpoint after restart
- emit one explicit non-fatal wait message instead of showing a raw `curl: (7)` connection failure
- keep the final failure behavior unchanged: dump `rtk-cloud-admin` journal and exit non-zero if health never becomes ready

## Context
During staging deploy, Admin can briefly log:

```text
curl: (7) Failed to connect to 127.0.0.1 port 8080
```

This happens while the deploy script is waiting for the freshly restarted Admin service. The deploy can still pass immediately afterward, but the raw curl error looks like a terminal failure.

## Test Plan
- `bash deploy/linode/deploy-admin-env-test.sh`
- `git diff --check -- deploy/linode/deploy-admin.sh deploy/linode/deploy-admin-env-test.sh`
