### PR TITLE
Remove NATS dashboard references

### DIFF
--- a/docs/platform-view-dashboard-design.md
+++ b/docs/platform-view-dashboard-design.md
@@ -92,7 +92,7 @@ Tenant & Device Footprint                         Operation Risk
 | Readiness distribution | top customer risks |    | open ops | failed ops | dead letters |
 
 Runtime Health                                    Infrastructure Health
-| request rate / 5xx / latency by service |       | CPU | memory | disk | nginx | postgres | redis | nats | emqx |
+| request rate / 5xx / latency by service |       | CPU | memory | disk | nginx | postgres | redis | emqx |
 
 Business Signals                                  Recent Platform Activity
 | quota requests | eval signups | blob use |       | audit + ops links |
@@ -133,14 +133,12 @@ Current configured targets:
 | Job | Target | Path | Dashboard use |
 | --- | --- | --- | --- |
 | `prometheus` | `10.42.1.30:9090` | `/metrics` | Prometheus self-health |
-| `nats` | `10.42.1.30:8222` | `/metrics` | message bus / JetStream health |
 | `nginx` role `edge` | `10.42.1.5:9113` | `/metrics` | public gateway health |
 | `nginx` role `admin` | `10.42.1.60:9113` | `/metrics` | Admin gateway health |
 | `postgres` role `infra` | `10.42.1.30:9187` | `/metrics` | database exporter health |
 | `redis` role `infra` | `10.42.1.30:9121` | `/metrics` | cache exporter health |
 | `emqx` role `mqtt` | `10.42.1.40:18083` | `/api/v5/prometheus/stats` | MQTT broker health |
 | `video_cloud_app` service `api` | `10.42.1.10:18080` | `/metrics/prometheus` | Video Cloud API runtime |
-| `video_cloud_app` service `crossservice` | `10.42.1.10:18180` | `/metrics/prometheus` | bus/worker runtime |
 | `video_cloud_app` service `turnregistry` | `10.42.1.10:18190` | `/metrics/prometheus` | TURN registry runtime |
 | `video_cloud_app` service `metricsexporter` | `10.42.1.10:19200` | `/metrics/prometheus` | aggregate device/blob metrics |
 | `video_cloud_app` service `logingester` | `10.42.1.10:19300` | `/metrics/prometheus` | device log ingestion |
@@ -217,7 +215,6 @@ aggregated health groups and drill-down rows.
 | nginx | `nginx_up`, `nginx_connections_*`, `nginx_http_requests_total` | Gateway status summary. |
 | PostgreSQL | `up{job="postgres"}` plus exporter-specific `pg_*` detail | Primary card is availability; deep DB charts remain Grafana/SRE. |
 | Redis | `up{job="redis"}` plus exporter-specific `redis_*` detail | Primary card is availability. |
-| NATS | `up{job="nats"}` plus NATS/JetStream families | Primary card is availability and backlog risk. |
 | EMQX | `up{job="emqx"}` plus broker/client/session families | Primary card is availability and broker pressure. |
 
 ## Drill-Down Behavior

--- a/internal/app/platform_dashboard.go
+++ b/internal/app/platform_dashboard.go
@@ -389,7 +389,7 @@ func platformDashboardScrapeGroup(labels map[string]string) string {
 		return "host"
 	case job == "postgres" || job == "redis":
 		return "data"
-	case job == "nats" || job == "emqx" || role == "mqtt":
+	case job == "emqx" || role == "mqtt":
 		return "broker"
 	case job == "nginx" || role == "edge" || role == "gateway":
 		return "gateway"

--- a/internal/app/platform_dashboard_test.go
+++ b/internal/app/platform_dashboard_test.go
@@ -154,9 +154,9 @@ func TestAdminPlatformDashboardAllTargetsUpFixture(t *testing.T) {
 	prometheus := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch query := r.URL.Query().Get("query"); {
 		case query == `sum by(job, service, role) (up)`:
-			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"2"]},{"metric":{"job":"node","role":"api"},"value":[1780369304,"1"]},{"metric":{"job":"postgres","role":"infra"},"value":[1780369304,"1"]},{"metric":{"job":"nats","role":"broker"},"value":[1780369304,"1"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"1"]}]}}`))
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"2"]},{"metric":{"job":"node","role":"api"},"value":[1780369304,"1"]},{"metric":{"job":"postgres","role":"infra"},"value":[1780369304,"1"]},{"metric":{"job":"emqx","role":"mqtt"},"value":[1780369304,"1"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"1"]}]}}`))
 		case query == `sum by(job, service, role) (up == 0)`:
-			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"0"]},{"metric":{"job":"node","role":"api"},"value":[1780369304,"0"]},{"metric":{"job":"postgres","role":"infra"},"value":[1780369304,"0"]},{"metric":{"job":"nats","role":"broker"},"value":[1780369304,"0"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"0"]}]}}`))
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"video_cloud_app","service":"api","role":"app"},"value":[1780369304,"0"]},{"metric":{"job":"node","role":"api"},"value":[1780369304,"0"]},{"metric":{"job":"postgres","role":"infra"},"value":[1780369304,"0"]},{"metric":{"job":"emqx","role":"mqtt"},"value":[1780369304,"0"]},{"metric":{"job":"nginx","role":"gateway"},"value":[1780369304,"0"]}]}}`))
 		default:
 			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[{"metric":{"job":"metricsexporter"},"value":[1780369304,"60"]}]}}`))
 		}


### PR DESCRIPTION
## Summary\n- remove NATS and crossservice scrape targets from platform dashboard design\n- stop classifying job=nats as an active broker target\n- update contracts mirror to the NATS-clean contract commit\n\n## Tests\n- GOWORK=off go test ./...