### PR TITLE
Fix staging admin release bundle deploy

### DIFF
--- a/deploy/linode/backup-admin-db.sh
+++ b/deploy/linode/backup-admin-db.sh
@@ -29,7 +29,7 @@ local_archive="$backup_dir/rtk-cloud-admin-db-$stamp.tar.gz"
 [ -n "$admin_host" ] || { echo "ADMIN_LINODE_HOST or ADMIN_LINODE_PUBLIC_IPV4 is required" >&2; exit 1; }
 [ -s "$ssh_key" ] || { echo "SSH key not found: $ssh_key" >&2; exit 1; }
 mkdir -p "$backup_dir"
-ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null)
 remote="$ssh_user@$admin_host"
 
 ssh "${ssh_opts[@]}" "$remote" "tar -C '$data_dir' -czf '$remote_archive' rtk-cloud-admin.db rtk-cloud-admin.db-wal rtk-cloud-admin.db-shm 2>/dev/null || tar -C '$data_dir' -czf '$remote_archive' rtk-cloud-admin.db"

--- a/deploy/linode/deploy-admin-env-test.sh
+++ b/deploy/linode/deploy-admin-env-test.sh
@@ -39,7 +39,7 @@ esac
 FAKE_SCP
 chmod +x "$fake_bin/scp"
 
-release_bundle="$tmpdir/release/rtk_cloud_admin-test.tar.gz"
+release_bundle="$tmpdir/release/test.tar.gz"
 printf 'fake release\n' > "$release_bundle"
 ssh_key="$tmpdir/id_ed25519"
 printf 'fake key\n' > "$ssh_key"

--- a/deploy/linode/deploy-admin.sh
+++ b/deploy/linode/deploy-admin.sh
@@ -21,6 +21,7 @@ fi
 
 release_bundle="${ADMIN_LINODE_RELEASE_BUNDLE:-}"
 bundle_release=""
+release_hint="${ADMIN_LINODE_RELEASE:-}"
 if [ -n "$release_bundle" ]; then
   release_name="$(basename "$release_bundle")"
   release_parent="$(basename "$(dirname "$release_bundle")")"
@@ -31,13 +32,13 @@ if [ -n "$release_bundle" ]; then
       ;;
     *.tar.gz)
       bundle_release="${release_name%.tar.gz}"
-      if [ "$release_parent" != "rtk_cloud_admin-$bundle_release" ]; then
-        printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz or stored as rtk_cloud_admin-<version>/<version>.tar.gz\n' >&2
+      if [ "$release_parent" != "rtk_cloud_admin-$bundle_release" ] && { [ -z "$release_hint" ] || [ "$bundle_release" != "$release_hint" ]; }; then
+        printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz, stored as rtk_cloud_admin-<version>/<version>.tar.gz, or match ADMIN_LINODE_RELEASE as <version>.tar.gz\n' >&2
         exit 1
       fi
       ;;
     *)
-      printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz or stored as rtk_cloud_admin-<version>/<version>.tar.gz\n' >&2
+      printf 'error: ADMIN_LINODE_RELEASE_BUNDLE must be named rtk_cloud_admin-<version>.tar.gz, stored as rtk_cloud_admin-<version>/<version>.tar.gz, or match ADMIN_LINODE_RELEASE as <version>.tar.gz\n' >&2
       exit 1
       ;;
   esac
@@ -136,7 +137,7 @@ if [ -z "$release_bundle" ]; then
 fi
 [ -s "$release_bundle" ] || die "release bundle not found: $release_bundle"
 
-ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new)
+ssh_opts=(-i "$ssh_key" -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=/dev/null)
 remote="$ssh_user@$admin_host"
 
 tmp_env="$(mktemp)"


### PR DESCRIPTION
## Summary
- accept <version>.tar.gz release bundles when ADMIN_LINODE_RELEASE matches
- avoid stale SSH known_hosts prompts in deploy and backup scripts
- update contracts-doc submodule pointer

## Validation
- bash deploy/linode/deploy-admin-env-test.sh
