### PR TITLE
Fix Login and Sign-in auth page modes

### DIFF
--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -170,11 +170,18 @@ Main header:
 Login page:
 
 - Use the Realtek logo asset, followed by the `Connect+ Ops` product label.
-- The default login mode is email sign-in: one `Email` field and a primary
-  `Continue` action that calls `POST /api/auth/sign-in`.
-- Password login is a secondary fallback exposed as `Use password instead`.
-  It keeps the existing platform/customer password login behavior during the
-  migration period, but it is not the primary first-viewport action.
+- The auth page is a normal website-style entry page with two first-class
+  modes: `Login` and `Sign-in`. Do not model either mode as a fallback hidden
+  behind copy such as `Use password instead`.
+- `Login` is the default mode for an existing Admin Console user. It shows
+  `Email`, `Password`, a primary `Login` action, and a `Forgot password?`
+  link. Password login keeps the existing platform/customer login behavior.
+- `Sign-in` is the email activation-link mode. It shows one `Email` field and
+  a primary `Continue` action that calls `POST /api/auth/sign-in`. The UI copy
+  must make clear that this sends an activation/sign-in link instead of
+  logging in immediately.
+- The `Login` / `Sign-in` switcher must be visible in the first viewport, for
+  example as tabs or a segmented control directly above the form.
 - The email field label is `Email`; do not use `Work email`.
 - Do not show a top-right `Need help?` link on the login page.
 - Keep login copy short and operational. Avoid support, marketing, or
@@ -232,8 +239,8 @@ Capability and role behavior:
 
 Auth and access states:
 
-- Unauthenticated users see the standalone Admin Console login page with email
-  sign-in as the default and password login as a secondary fallback.
+- Unauthenticated users see the standalone Admin Console auth page. `Login`
+  and `Sign-in` are both first-class modes, with `Login` selected by default.
 - Signup entry points route to the self-service evaluation flow documented in
   `SPEC.md`; commercial brand-cloud user creation is separate and platform
   admin-owned.

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -973,8 +973,8 @@ function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onP
             <img src="/assets/realtek-logo.png" alt="Realtek" />
             <strong>Connect+ Ops</strong>
           </div>
-          <h1 id="login-title">Sign in to Admin Console</h1>
-          <p className="login-copy">Use your email to continue.</p>
+          <h1 id="login-title">Admin Console</h1>
+          <p className="login-copy">Login with your password or sign in with an email activation link.</p>
           {content}
           {error ? <div className="error">{error}</div> : null}
         </section>
@@ -984,19 +984,39 @@ function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onP
 }
 
 function LoginEntryForm({ onEmailSignIn, onPasswordLogin, disabled }) {
-  const [mode, setMode] = useState('email');
-  if (mode === 'password') {
-    return (
-      <div className="auth-stack">
-        <LoginPasswordForm onPasswordLogin={onPasswordLogin} disabled={disabled} />
-        <button type="button" className="link-button" onClick={() => setMode('email')}>Use email sign-in</button>
+  const [mode, setMode] = useState('login');
+  return (
+    <div className="auth-stack">
+      <div className="auth-mode-tabs" role="tablist" aria-label="Auth mode">
+        <button
+          type="button"
+          className={mode === 'login' ? 'active' : ''}
+          role="tab"
+          aria-selected={mode === 'login'}
+          onClick={() => setMode('login')}
+        >
+          Login
+        </button>
+        <button
+          type="button"
+          className={mode === 'signin' ? 'active' : ''}
+          role="tab"
+          aria-selected={mode === 'signin'}
+          onClick={() => setMode('signin')}
+        >
+          Sign-in
+        </button>
       </div>
-    );
-  }
-  return <LoginEmailForm onEmailSignIn={onEmailSignIn} onUsePassword={() => setMode('password')} disabled={disabled} />;
+      {mode === 'signin' ? (
+        <LoginEmailForm onEmailSignIn={onEmailSignIn} disabled={disabled} />
+      ) : (
+        <LoginPasswordForm onPasswordLogin={onPasswordLogin} disabled={disabled} />
+      )}
+    </div>
+  );
 }
 
-function LoginEmailForm({ onEmailSignIn, onUsePassword, disabled }) {
+function LoginEmailForm({ onEmailSignIn, disabled }) {
   const [email, setEmail] = useState('');
   const [busy, setBusy] = useState(false);
   const [localError, setLocalError] = useState('');
@@ -1014,12 +1034,12 @@ function LoginEmailForm({ onEmailSignIn, onUsePassword, disabled }) {
   }
   return (
     <form className="login-form" onSubmit={submit}>
+      <p className="auth-status">Send an activation link to continue without a password.</p>
       <label>
         Email
         <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="name@company.com" required />
       </label>
       <button type="submit" disabled={busy || disabled}>{busy ? 'Sending' : 'Continue'}</button>
-      <button type="button" className="secondary-button" onClick={onUsePassword}>Use password instead</button>
       {localError ? <p className="error">{localError}</p> : null}
     </form>
   );
@@ -1052,7 +1072,7 @@ function LoginPasswordForm({ onPasswordLogin, disabled }) {
         Password
         <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="Enter your password" required />
       </label>
-      <button type="submit" disabled={busy || disabled}>{busy ? 'Signing in' : 'Sign in'}</button>
+      <button type="submit" disabled={busy || disabled}>{busy ? 'Logging in' : 'Login'}</button>
       <a className="auth-link" href={`/forgot-password${email ? `?email=${encodeURIComponent(email)}` : ''}`}>Forgot password?</a>
       {localError ? <p className="error">{localError}</p> : null}
     </form>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1977,6 +1977,38 @@ p {
   gap: 12px;
 }
 
+.auth-mode-tabs {
+  background: #eef4f8;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  display: grid;
+  gap: 4px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  padding: 4px;
+}
+
+.auth-mode-tabs button {
+  background: transparent;
+  border: 0;
+  border-radius: 6px;
+  color: var(--muted);
+  cursor: pointer;
+  font-weight: 800;
+  min-height: 40px;
+  padding: 0 12px;
+}
+
+.auth-mode-tabs button.active {
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(37, 56, 76, 0.12);
+  color: var(--navy);
+}
+
+.auth-mode-tabs button:focus-visible {
+  outline: 3px solid rgba(0, 104, 183, 0.18);
+  outline-offset: 2px;
+}
+
 .login-form label {
   color: var(--navy);
   display: grid;


### PR DESCRIPTION
## Summary
- update the auth-page design spec so Login and Sign-in are first-class modes
- make Login the default mode with email/password and Forgot password
- add a visible Login / Sign-in segmented switch; Sign-in uses the email activation-link flow
- remove the old `Use password instead` fallback model from the first-viewport UI

## Verification
- npm test
- npm run build
- Playwright smoke against local Vite app using local Chrome with `/api/me` mocked
