### PR TITLE
Use brand-scoped users for brand cloud membership

### DIFF
--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -88,7 +88,7 @@ Tier 2 customers.
 - Platform-side admin actions: customer session refresh and invalidation (existing in `internal/app/app.go`).
 - Brand-cloud backend actions when authenticated through Account Manager as
   `platform_admin`: create/list/read/update brand clouds and assign existing
-  Account Manager users to a brand cloud.
+  brand-scoped users to a brand cloud.
 - Tenant lifecycle actions (provisioning, deactivation, firmware campaign control on behalf of a tenant): not supported. Tenant-side write actions remain with Tier 2 Fleet Managers.
 
 **Current Admin Console capabilities:**

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 81.0% |
+| Go total coverage | 80.9% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |

--- a/docs/assets/webui-design/platform-brand-clouds-mock.html
+++ b/docs/assets/webui-design/platform-brand-clouds-mock.html
@@ -778,7 +778,7 @@
   <aside class="drawer create" aria-label="Create Brand Cloud">
     <div class="drawer-head">
       <h2>Create Brand Cloud</h2>
-      <p>Create a Tier 2 brand-cloud organization in Account Manager, then assign an existing Account Manager user as owner.</p>
+      <p>Create a Tier 2 brand-cloud organization in Account Manager, then assign an existing brand-scoped user as owner.</p>
     </div>
     <div class="drawer-body">
       <div class="stepper">
@@ -797,9 +797,9 @@
         </div>
       </section>
       <section class="form-card">
-        <h3>Initial Admin</h3>
+        <h3>Initial Brand Admin</h3>
         <div class="form-grid">
-          <div class="control"><label>Existing user email</label><input class="input" value="ops@acme.example"></div>
+          <div class="control"><label>Brand User id</label><input class="input" value="brand-user-001"></div>
           <div class="control"><label>Role</label><select><option>Owner</option></select></div>
         </div>
       </section>
@@ -846,7 +846,7 @@
       <section class="detail-card">
         <h3>Members</h3>
         <div class="member-row"><div><span class="primary-text">ops@example.com</span><span class="secondary-text">Owner</span></div><span class="badge active">Active</span></div>
-        <button class="link-button">Assign Existing User</button>
+        <button class="link-button">Assign Existing Brand User</button>
       </section>
       <section class="detail-card">
         <h3>SSO</h3>

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -2451,19 +2451,20 @@ components:
           additionalProperties: true
     BrandCloudMemberRequest:
       type: object
-      required: [user_id, role]
+      required: [brand_cloud_user_id, role]
       properties:
-        user_id:
+        brand_cloud_user_id:
           type: string
+          description: Brand-scoped user id. Platform Account Manager user ids are not accepted.
         role:
           type: string
     Member:
       type: object
-      required: [organization_id, user_id, role]
+      required: [brand_cloud_id, brand_cloud_user_id, role]
       properties:
-        organization_id:
+        brand_cloud_id:
           type: string
-        user_id:
+        brand_cloud_user_id:
           type: string
         email:
           type: string

--- a/docs/platform-brand-cloud-management-design.md
+++ b/docs/platform-brand-cloud-management-design.md
@@ -34,9 +34,9 @@ management in `rtk_cloud_admin`.
 organizations, membership, status, audit, entitlement, and user identity.
 `rtk_cloud_admin` owns the Platform Admin WebUI and BFF surface. The WebUI
 therefore provides a controlled operational workspace for Platform Admins to
-list, create, inspect, update, and assign existing Account Manager users to
-brand-cloud organizations without storing authoritative brand-cloud records in
-Admin Console SQLite.
+list, create, inspect, update, and assign brand-scoped users to brand-cloud
+organizations without storing authoritative brand-cloud records in Admin
+Console SQLite.
 
 The working product name in the UI is **Brand Clouds**. It represents
 `organization_kind=brand_cloud` records and should not be presented as a
@@ -217,17 +217,18 @@ Validation:
 - slug/code must be unique when provided
 - region must be one of the Account Manager-supported values
 
-### Step 2: Initial Admin
+### Step 2: Initial Brand Admin
 
 Fields:
 
-- Existing Account Manager user email or user id
+- Existing Brand User id, when the brand-scoped user already exists
 - Initial role, default `owner`
 - Optional note for audit/support context, only if Account Manager accepts it
 
-The UI must make it clear that this flow assigns an existing Account Manager
-user. Inviting or creating a new user is out of scope for the first pass unless
-Account Manager exposes a supported API.
+The UI must make it clear that this flow assigns an existing brand-scoped user.
+Platform Account Manager user ids are not valid for brand-cloud membership.
+Creating or reactivating a brand-scoped user uses the Brand User form and then
+assigns membership by `brand_cloud_user_id`.
 
 ### Step 3: Entitlement Snapshot
 
@@ -304,7 +305,7 @@ Created             2026-05-02
 
 Members
 Owner               ops@example.com
-[Assign Existing User]
+[Assign Existing Brand User]
 
 SSO
 Status              Ready
@@ -335,8 +336,8 @@ Recent Activity
   - status
   - created/updated timestamps when available
 - Members:
-  - assigned owner/admin users exposed by Account Manager
-  - `Assign Existing User` action when capability is present
+  - assigned owner/admin brand-scoped users exposed by Account Manager
+  - `Assign Existing Brand User` action when capability is present
 - SSO:
   - SSO status summary
   - link to SSO Providers filtered to this organization
@@ -362,13 +363,13 @@ Use a small drawer section or modal launched from the detail drawer.
 
 Fields:
 
-- Account Manager user email or user id
+- Brand User id
 - Role, default `owner` or `admin` depending on Account Manager contract
 
 Behavior:
 
 - validate required input locally
-- submit to `POST /api/admin/brand-clouds/{id}/members`
+- submit `brand_cloud_user_id` to `POST /api/admin/brand-clouds/{id}/members`
 - show success inline in the Members panel
 - show duplicate member as a non-destructive warning
 - preserve Account Manager authorization and validation messages in user-safe

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -47,8 +47,8 @@ type BrandCloudRequest struct {
 }
 
 type BrandCloudMemberRequest struct {
-	UserID string `json:"user_id"`
-	Role   string `json:"role"`
+	BrandCloudUserID string `json:"brand_cloud_user_id"`
+	Role             string `json:"role"`
 }
 
 type BrandCloudUserRequest struct {
@@ -82,8 +82,6 @@ type Member struct {
 
 type BrandCloudUserResult struct {
 	Action           string         `json:"action"`
-	User             User           `json:"user"`
-	Member           Member         `json:"member"`
 	BrandCloudUser   BrandCloudUser `json:"brand_cloud_user"`
 	BrandCloudMember Member         `json:"brand_cloud_member"`
 }

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -169,7 +169,7 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 				t.Fatal(err)
 			}
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"organization_id": "brand-1", "user_id": "user-1", "role": "owner"}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"brand_cloud_id": "brand-1", "brand_cloud_user_id": "brand-user-1", "role": "owner"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users":
 			if r.URL.Query().Get("status") != "pending_verification" {
 				t.Fatalf("brand user status query = %q", r.URL.Query().Get("status"))
@@ -218,11 +218,11 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 	if updated.Status != "disabled" || patchBody["status"] != "disabled" {
 		t.Fatalf("updated brand cloud = %#v body=%#v", updated, patchBody)
 	}
-	member, err := client.AssignBrandCloudMember(t.Context(), "admin-access", "brand-1", BrandCloudMemberRequest{UserID: "user-1", Role: "owner"})
+	member, err := client.AssignBrandCloudMember(t.Context(), "admin-access", "brand-1", BrandCloudMemberRequest{BrandCloudUserID: "brand-user-1", Role: "owner"})
 	if err != nil {
 		t.Fatalf("AssignBrandCloudMember returned error: %v", err)
 	}
-	if member.UserID != "user-1" || memberBody["user_id"] != "user-1" {
+	if member.BrandCloudUserID != "brand-user-1" || memberBody["brand_cloud_user_id"] != "brand-user-1" {
 		t.Fatalf("member = %#v body=%#v", member, memberBody)
 	}
 	users, err := client.BrandCloudUsers(t.Context(), "admin-access", "brand-1", url.Values{"status": []string{"pending_verification"}})

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -2337,8 +2337,12 @@ func (s *Server) apiAdminBrandCloudMember(w http.ResponseWriter, r *http.Request
 		http.Error(w, "invalid brand cloud member request", http.StatusBadRequest)
 		return
 	}
-	body.UserID = strings.TrimSpace(body.UserID)
+	body.BrandCloudUserID = strings.TrimSpace(body.BrandCloudUserID)
 	body.Role = strings.TrimSpace(body.Role)
+	if body.BrandCloudUserID == "" {
+		http.Error(w, "brand_cloud_user_id is required", http.StatusBadRequest)
+		return
+	}
 	member, err := s.accountClient.AssignBrandCloudMember(r.Context(), session.AccessToken, brandCloudID, body)
 	if err != nil {
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3805,11 +3805,11 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
-			if body.UserID != "user-1" || body.Role != "owner" {
+			if body.BrandCloudUserID != "brand-user-1" || body.Role != "owner" {
 				t.Fatalf("member request = %#v", body)
 			}
 			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"organization_id": "brand-1", "user_id": "user-1", "role": "owner"}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"brand_cloud_id": "brand-1", "brand_cloud_user_id": "brand-user-1", "role": "owner"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users":
 			var body accountclient.BrandCloudUserRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
@@ -3821,8 +3821,6 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"action":             "created",
-				"user":               map[string]any{"id": "user-2", "email": "owner@example.com", "name": "Owner"},
-				"member":             map[string]any{"organization_id": "brand-1", "user_id": "user-2", "role": "owner"},
 				"brand_cloud_user":   map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com", "email_verified": true, "signup_pending_verification": false},
 				"brand_cloud_member": map[string]any{"brand_cloud_id": "brand-1", "brand_cloud_user_id": "brand-user-1", "email": "owner@example.com", "role": "owner"},
 			})
@@ -3913,7 +3911,7 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 	}
 
 	member := httptest.NewRecorder()
-	memberReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds/brand-1/members", strings.NewReader(`{"user_id":" user-1 ","role":" owner "}`))
+	memberReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds/brand-1/members", strings.NewReader(`{"brand_cloud_user_id":" brand-user-1 ","role":" owner "}`))
 	memberReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
 	srv.ServeHTTP(member, memberReq)
 	if member.Code != http.StatusCreated {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -493,7 +493,7 @@ function App() {
     try {
       const result = await postJSON('/api/admin/brand-clouds', payload.brandCloud);
       let memberError = '';
-      if (payload.initialMember?.user_id) {
+      if (payload.initialMember?.brand_cloud_user_id) {
         try {
           await postJSON(`/api/admin/brand-clouds/${encodeURIComponent(result.brand_cloud.id)}/members`, payload.initialMember);
         } catch (err) {
@@ -2834,7 +2834,7 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
       return;
     }
     if (form.initialMode === 'existing' && !form.userId.trim()) {
-      setMessage('Existing Account Manager user id is required.');
+      setMessage('Existing Brand User id is required.');
       return;
     }
     if (form.initialMode === 'create' && (!form.email.trim() || !form.password.trim())) {
@@ -2851,7 +2851,7 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
             tier: form.tier,
           },
         },
-        initialMember: form.initialMode === 'existing' ? { user_id: form.userId.trim(), role: form.role } : null,
+        initialMember: form.initialMode === 'existing' ? { brand_cloud_user_id: form.userId.trim(), role: form.role } : null,
         initialUser: form.initialMode === 'create' ? {
           email: form.email.trim(),
           password: form.password,
@@ -2887,10 +2887,10 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
           </div>
           <label>Initial admin mode<select className="input" value={form.initialMode} onChange={(event) => update('initialMode', event.target.value)}>
             <option value="none">Assign later</option>
-            <option value="existing">Assign existing user id</option>
+            <option value="existing">Assign existing Brand User id</option>
             <option value="create">Create or reactivate brand user</option>
           </select></label>
-          {form.initialMode === 'existing' ? <label>Account Manager user id<input className="input" value={form.userId} onChange={(event) => update('userId', event.target.value)} /></label> : null}
+          {form.initialMode === 'existing' ? <label>Brand User id<input className="input" value={form.userId} onChange={(event) => update('userId', event.target.value)} /></label> : null}
           {form.initialMode === 'create' ? (
             <>
               <label>Email<input className="input" type="email" value={form.email} onChange={(event) => update('email', event.target.value)} /></label>
@@ -2911,7 +2911,7 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
 }
 
 function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember, onCreateUser }) {
-  const [member, setMember] = useState({ user_id: '', role: 'owner' });
+  const [member, setMember] = useState({ brand_cloud_user_id: '', role: 'owner' });
   const [user, setUser] = useState({ email: '', password: '', display_name: '', role: 'admin' });
   const [users, setUsers] = useState([]);
   const [userFilter, setUserFilter] = useState('all');
@@ -2960,14 +2960,14 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
   async function submitMember(event) {
     event.preventDefault();
     setMessage('');
-    if (!member.user_id.trim()) {
-      setMessage('Account Manager user id is required.');
+    if (!member.brand_cloud_user_id.trim()) {
+      setMessage('Brand User id is required.');
       return;
     }
     try {
-      await onAssignMember(brand.id, { user_id: member.user_id.trim(), role: member.role });
+      await onAssignMember(brand.id, { brand_cloud_user_id: member.brand_cloud_user_id.trim(), role: member.role });
       setMessage('Member assigned.');
-      setMember({ user_id: '', role: 'owner' });
+      setMember({ brand_cloud_user_id: '', role: 'owner' });
     } catch (err) {
       setMessage(err.message);
     }
@@ -3137,10 +3137,10 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
         </section>
         <section className="brand-cloud-form-grid">
           <form className="drawer-form compact" onSubmit={submitMember}>
-            <h3><Icon name="user-plus" />Assign Existing User</h3>
-            <label>User id<input className="input" value={member.user_id} onChange={(event) => setMember((current) => ({ ...current, user_id: event.target.value }))} /></label>
+            <h3><Icon name="user-plus" />Assign Existing Brand User</h3>
+            <label>Brand User id<input className="input" value={member.brand_cloud_user_id} onChange={(event) => setMember((current) => ({ ...current, brand_cloud_user_id: event.target.value }))} /></label>
             <label>Role<select className="input" value={member.role} onChange={(event) => setMember((current) => ({ ...current, role: event.target.value }))}><option value="owner">Owner</option><option value="admin">Admin</option><option value="member">Member</option></select></label>
-            <button type="submit" className="primary-button"><Icon name="user-check" />Assign Existing User</button>
+            <button type="submit" className="primary-button"><Icon name="user-check" />Assign Existing Brand User</button>
           </form>
           <form className="drawer-form compact" onSubmit={submitUser}>
             <h3><Icon name="envelope-circle-check" />Create Or Reactivate Brand User</h3>


### PR DESCRIPTION
## Summary
- Change Platform Brand Clouds member assignment to send brand_cloud_user_id instead of platform user_id.
- Update BFF validation, account client contract, UI copy, OpenAPI, design docs, and static mock.
- Keep Brand User creation/reactivation as the path for creating brand-scoped identities.

## Test Plan
- GOWORK=off GOCACHE=/private/tmp/rtk-brand-admin-gocache go test ./...
- npm test
- npm run build
