### PR TITLE
[codex] Publish LKE image from service repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ name: Release Bundle
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:
@@ -13,9 +15,11 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   package:
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     name: Package release
     runs-on: ubuntu-latest
     steps:
@@ -131,3 +135,82 @@ jobs:
           else
             gh release create "$GITHUB_REF_NAME" "${assets[@]}" --generate-notes --title "$GITHUB_REF_NAME"
           fi
+
+  publish-image:
+    name: Publish LKE image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Select image tags
+        id: image
+        shell: bash
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          image="ghcr.io/${GITHUB_REPOSITORY}/cloud-admin"
+          short_sha="${GITHUB_SHA::12}"
+          tags=("$image:sha-$short_sha")
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            tags+=("$image:$GITHUB_REF_NAME")
+          elif [[ -n "${INPUT_VERSION:-}" ]]; then
+            tags+=("$image:$INPUT_VERSION")
+          fi
+          {
+            printf 'image=%s\n' "$image"
+            printf 'short_sha=%s\n' "$short_sha"
+            printf 'tags<<EOF\n'
+            printf '%s\n' "${tags[@]}"
+            printf 'EOF\n'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build smoke image
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build -t "${{ steps.image.outputs.image }}:local-smoke" -f deploy/lke/Dockerfile .
+          docker run --rm --entrypoint /bin/sh "${{ steps.image.outputs.image }}:local-smoke" -c \
+            'test -x /app/rtk-cloud-admin && test -d /app/web/dist'
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: deploy/lke/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.image.outputs.tags }}
+
+      - name: Write image manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .artifacts/lke-image
+          cat > .artifacts/lke-image/image-manifest.json <<JSON
+          {
+            "schema": "rtk-service-image/v1",
+            "repository": "${GITHUB_REPOSITORY}",
+            "image": "${{ steps.image.outputs.image }}",
+            "source_commit": "${GITHUB_SHA}",
+            "primary_tag": "sha-${{ steps.image.outputs.short_sha }}"
+          }
+          JSON
+
+      - name: Upload image manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-manifest
+          path: .artifacts/lke-image/image-manifest.json
+          if-no-files-found: error

--- a/deploy/lke/Dockerfile
+++ b/deploy/lke/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22-bookworm AS web
+
+WORKDIR /src/web
+COPY web/package*.json ./
+RUN npm ci
+COPY web ./
+RUN npm run build
+
+FROM golang:1.26-bookworm AS builder
+
+WORKDIR /src
+COPY . .
+COPY --from=web /src/web/dist /src/web/dist
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath -o /out/rtk-cloud-admin ./cmd/server
+
+FROM debian:bookworm-slim
+
+WORKDIR /app
+RUN useradd -r -u 10001 app && chown app:app /app
+
+COPY --from=builder /out/rtk-cloud-admin /app/rtk-cloud-admin
+COPY --from=web /src/web/dist /app/web/dist
+
+USER app
+EXPOSE 8080
+ENTRYPOINT ["/app/rtk-cloud-admin"]


### PR DESCRIPTION
## Summary
- publish the LKE runtime image from `rtk_cloud_admin` to `ghcr.io/hkt999rtk/rtk_cloud_admin/cloud-admin`
- tag images with `sha-<12>` plus release tag/version metadata when available
- add a Dockerfile, local image smoke check, and `image-manifest.json` artifact

## Test Plan
- YAML workflows parsed with Ruby Psych
- `docker build -f deploy/lke/Dockerfile -t lke-cloud-admin-smoke .`
- smoke checked expected runtime binary and built web assets in the image