### PR TITLE
[admin] Proxy canonical SKU OTA operations

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.8% |
+| Go total coverage | 80.6% |
 | Go coverage gate | >= 80.0% |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
@@ -28,12 +28,12 @@
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 84.8% |
-| `rtk_cloud_admin/internal/app` | 81.0% |
+| `rtk_cloud_admin/internal/app` | 80.7% |
 | `rtk_cloud_admin/internal/config` | 85.7% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |
 | `rtk_cloud_admin/internal/store` | 81.1% |
-| `rtk_cloud_admin/internal/videoclient` | 86.6% |
+| `rtk_cloud_admin/internal/videoclient` | 86.2% |
 
 ## Artifact Policy
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/http"
@@ -278,6 +279,8 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/fleet/health-summary", s.apiFleetHealthSummary)
 	s.mux.HandleFunc("GET /api/fleet/stream-stats", s.apiFleetStreamStats)
 	s.mux.HandleFunc("GET /api/fleet/firmware-distribution", s.apiFleetFirmwareDistribution)
+	s.mux.HandleFunc("GET /api/ota/", s.apiSKUOTA)
+	s.mux.HandleFunc("POST /api/ota/", s.apiSKUOTA)
 	s.mux.HandleFunc("GET /api/operations", s.apiOperations)
 	s.mux.HandleFunc("GET /api/admin/operations", s.apiAdminOperations)
 	s.mux.HandleFunc("GET /api/service-health", s.apiServiceHealth)
@@ -330,6 +333,7 @@ const (
 	capabilityCustomerDevicesProvision  = "customer.devices.provision"
 	capabilityCustomerDevicesDeactivate = "customer.devices.deactivate"
 	capabilityCustomerFirmwareRead      = "customer.firmware.read"
+	capabilityCustomerFirmwareManage    = "customer.firmware.manage"
 	capabilityCustomerStreamRead        = "customer.stream.read"
 	capabilityPlatformAuditRead         = "platform.audit.read"
 	capabilityPlatformSSOManage         = "platform.sso.manage"
@@ -1086,6 +1090,61 @@ func (s *Server) apiFleetFirmwareDistribution(w http.ResponseWriter, r *http.Req
 	}
 	status, message := s.customerFirmwareSourceStatus(devices)
 	writeJSON(w, unavailableFirmwareDistribution(orgID, status, message))
+}
+
+func (s *Server) apiSKUOTA(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.customerSession(r)
+	if !ok {
+		http.Error(w, "customer authentication required", http.StatusUnauthorized)
+		return
+	}
+	orgID := strings.TrimSpace(session.ActiveOrgID)
+	capabilities := fleetManagerCapabilities()
+	if s.accountClient.Enabled() {
+		org, _, err := s.activeCustomerOrg(r.Context(), session)
+		if err != nil {
+			s.writeCustomerErrorForSession(w, session.ID, err)
+			return
+		}
+		orgID = org.ID
+		capabilities = capabilitiesForOrganization(org)
+	}
+	required := capabilityCustomerFirmwareRead
+	if r.Method != http.MethodGet {
+		required = capabilityCustomerFirmwareManage
+	}
+	if !hasCapability(capabilities, required) {
+		http.Error(w, "missing required capability: "+required, http.StatusForbidden)
+		return
+	}
+	if !s.videoClient.Enabled() || strings.TrimSpace(s.cfg.VideoCloudAdminToken) == "" {
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]any{"status": "fail", "code": "OTA_UNAVAILABLE", "reason": "Video Cloud OTA source is unavailable."})
+		return
+	}
+	upstreamPath := "/v1/ota/" + strings.TrimPrefix(r.URL.Path, "/api/ota/")
+	body, err := io.ReadAll(io.LimitReader(r.Body, 2<<20))
+	if err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	response, err := s.videoClient.DoOTA(r.Context(), r.Method, upstreamPath, s.cfg.VideoCloudAdminToken, orgID, r.Header.Get("Idempotency-Key"), body)
+	result := "succeeded"
+	if err != nil {
+		result = "failed"
+		writeJSONStatus(w, http.StatusServiceUnavailable, map[string]any{"status": "fail", "code": "OTA_UPSTREAM_ERROR", "reason": "Video Cloud OTA request failed."})
+	} else {
+		contentType := response.Header.Get("Content-Type")
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		w.Header().Set("Content-Type", contentType)
+		w.WriteHeader(response.StatusCode)
+		_, _ = w.Write(response.Body)
+		if response.StatusCode < 200 || response.StatusCode >= 300 {
+			result = "rejected"
+		}
+	}
+	_ = s.audit.CreateAuditEventWithMetadata(store.AuditEventInput{Actor: session.Email, ActorKind: session.Kind, Action: "sku_ota." + strings.ToLower(r.Method), Target: upstreamPath, OrganizationID: orgID, Result: result})
 }
 
 func (s *Server) firmwareDistributionDevices(ctx context.Context, session store.Session, orgID string) ([]contracts.Device, error) {
@@ -3597,6 +3656,7 @@ func fleetManagerCapabilities() []string {
 		capabilityCustomerDevicesProvision,
 		capabilityCustomerDevicesDeactivate,
 		capabilityCustomerFirmwareRead,
+		capabilityCustomerFirmwareManage,
 		capabilityCustomerStreamRead,
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -2659,6 +2659,59 @@ func TestFleetFirmwareDistributionRequiresCustomerSession(t *testing.T) {
 	}
 }
 
+func TestSKUOTAProxyInjectsActiveOrganizationAndAudits(t *testing.T) {
+	t.Parallel()
+	videoUpstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/ota/skus/sku-1/releases" || r.Method != http.MethodPost {
+			t.Fatalf("upstream request=%s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer vc-secret" || r.Header.Get("X-Brand-Cloud-ID") != "org-acme" || r.Header.Get("Idempotency-Key") != "release-key" {
+			t.Fatalf("upstream headers=%#v", r.Header)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"release_id":"rel-1"}`))
+	}))
+	defer videoUpstream.Close()
+	st, err := store.Open(t.TempDir() + "/admin.db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer st.Close()
+	if err := st.Migrate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.SeedDemoData(); err != nil {
+		t.Fatal(err)
+	}
+	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := NewWithOptions(st, Options{Config: config.Config{VideoCloudBaseURL: videoUpstream.URL, VideoCloudAdminToken: "vc-secret"}, VideoClient: videoclient.New(videoUpstream.URL)})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/ota/skus/sku-1/releases", strings.NewReader(`{"version":"1"}`))
+	req.Header.Set("Idempotency-Key", "release-key")
+	req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: session.ID})
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated || !strings.Contains(rec.Body.String(), "rel-1") {
+		t.Fatalf("proxy status=%d body=%s", rec.Code, rec.Body.String())
+	}
+	events, err := st.ListAuditEvents()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, event := range events {
+		if event.Action == "sku_ota.post" && event.OrganizationID == "org-acme" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing SKU OTA audit event: %+v", events)
+	}
+}
+
 func TestFleetFirmwareDistributionDemoPayload(t *testing.T) {
 	t.Parallel()
 

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -24,6 +24,12 @@ type HTTPStatusError struct {
 	Body       string
 }
 
+type OTAResponse struct {
+	StatusCode int
+	Body       []byte
+	Header     http.Header
+}
+
 func (e HTTPStatusError) Error() string {
 	if strings.TrimSpace(e.Body) != "" {
 		return fmt.Sprintf("status %d: %s", e.StatusCode, strings.TrimSpace(e.Body))
@@ -237,6 +243,44 @@ func (c *Client) doJSON(ctx context.Context, method, path, adminToken string, in
 		return err
 	}
 	return nil
+}
+
+// DoOTA forwards one canonical operator OTA request while preserving the typed
+// upstream response. brandCloudID is resolved by the BFF from the active
+// Account Manager organization; it is never copied from the browser body.
+func (c *Client) DoOTA(ctx context.Context, method, path, adminToken, brandCloudID, idempotencyKey string, body []byte) (OTAResponse, error) {
+	if !c.Enabled() {
+		return OTAResponse{}, fmt.Errorf("video cloud base URL is not configured")
+	}
+	if !strings.HasPrefix(path, "/v1/ota/") {
+		return OTAResponse{}, fmt.Errorf("invalid OTA path")
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, bytes.NewReader(body))
+	if err != nil {
+		return OTAResponse{}, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if adminToken != "" {
+		req.Header.Set("Authorization", "Bearer "+adminToken)
+	}
+	req.Header.Set("X-Brand-Cloud-ID", strings.TrimSpace(brandCloudID))
+	if strings.TrimSpace(idempotencyKey) != "" {
+		req.Header.Set("Idempotency-Key", strings.TrimSpace(idempotencyKey))
+	}
+	correlation.ApplyHeaders(ctx, req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return OTAResponse{}, err
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return OTAResponse{}, err
+	}
+	return OTAResponse{StatusCode: resp.StatusCode, Body: raw, Header: resp.Header.Clone()}, nil
 }
 
 func (c *Client) Health(ctx context.Context) error {

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -394,6 +395,28 @@ func TestFirmwareDistributionQueries(t *testing.T) {
 	}
 	if len(campaigns) != 1 || campaigns[0].ID != "campaign-1" {
 		t.Fatalf("QueryFirmwareCampaigns = %+v, want campaign-1", campaigns)
+	}
+}
+
+func TestDoOTAInjectsTrustedBrandAndIdempotencyHeaders(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/ota/skus/sku-1/releases" || r.Method != http.MethodPost {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer admin-token" || r.Header.Get("X-Brand-Cloud-ID") != "brand-1" || r.Header.Get("Idempotency-Key") != "idem-key" {
+			t.Fatalf("headers = %#v", r.Header)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"release_id":"rel-1"}`))
+	}))
+	defer upstream.Close()
+	response, err := New(upstream.URL).DoOTA(t.Context(), http.MethodPost, "/v1/ota/skus/sku-1/releases", "admin-token", "brand-1", "idem-key", []byte(`{"version":"1"}`))
+	if err != nil || response.StatusCode != http.StatusCreated || !strings.Contains(string(response.Body), "rel-1") {
+		t.Fatalf("DoOTA = %#v, %v", response, err)
+	}
+	if _, err := New(upstream.URL).DoOTA(t.Context(), http.MethodPost, "/download_firmware", "admin-token", "brand-1", "idem", nil); err == nil {
+		t.Fatal("expected non-canonical path rejection")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add authenticated customer BFF proxy routes under `/api/ota/*`
- resolve brand scope from the active Account Manager organization and inject it server-side
- enforce read vs manage capabilities, preserve idempotency keys, and record audit events
- add Video Cloud OTA forwarding support and sync the merged contract

## Validation
- `GOWORK=off go test ./...`
- `GOWORK=off go vet ./...`
- `git diff --check`