### PR TITLE
Implement management-first Platform View

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Initialize contracts submodule when token is available
         env:

--- a/README.md
+++ b/README.md
@@ -89,8 +89,11 @@ Go BFF:
   Customer-facing pages must not expose platform-only audit, customer browsing,
   raw upstream payloads, or cross-tenant facts.
 - **Platform View** is for Tier 1 Platform Admins. It covers Platform
-  Dashboard, Service Health, SSO Providers, Operations Log, Audit Log, and the
-  planned Brand Clouds management UI. Platform View data and navigation are
+  Dashboard, Grafana, Service Health, Brand Clouds, SSO Providers, Service
+  Logs, Operations Log, and Audit Log. Brand Clouds has an implemented baseline;
+  remaining design/API parity work is tracked in
+  [`docs/platform-admin-implementation-plan.md`](docs/platform-admin-implementation-plan.md).
+  Platform View data and navigation are
   role-gated away from Customer View.
 
 The design and implementation context is split across these documents:
@@ -106,7 +109,9 @@ The design and implementation context is split across these documents:
 - [`docs/platform-view-dashboard-design.md`](docs/platform-view-dashboard-design.md):
   Platform Dashboard metrics, Prometheus source mapping, and BFF boundary.
 - [`docs/platform-brand-cloud-management-design.md`](docs/platform-brand-cloud-management-design.md):
-  draft Platform View Brand Clouds GUI and workflow design.
+  Brand Clouds design, source ownership, and current implementation boundary.
+- [`docs/platform-admin-implementation-plan.md`](docs/platform-admin-implementation-plan.md):
+  design-to-code gap matrix and phased frontend/BFF/upstream implementation plan.
 - [`docs/webui-implementation-roadmap.md`](docs/webui-implementation-roadmap.md):
   developer-ready issue roadmap for implementing the WebUI milestones.
 - [`docs/customer-view-visual-qa-checklist.md`](docs/customer-view-visual-qa-checklist.md)

--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ npm test
 npm run build
 ```
 
+Browser E2E:
+
+```sh
+cd web
+npm run e2e:install
+npm run build
+npm run e2e:generate-fixture
+npm run e2e:smoke
+```
+
+See [`docs/cloud-admin-e2e.md`](docs/cloud-admin-e2e.md) for the local
+load-test-backed fixture harness, full Playwright suite, and staging flow.
+
 Testing policy:
 
 - API handler behavior changes need focused Go tests with `httptest`.

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -29,7 +29,7 @@
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
 | `rtk_cloud_admin/internal/accountclient` | 50.2% |
-| `rtk_cloud_admin/internal/app` | 64.0% |
+| `rtk_cloud_admin/internal/app` | 64.1% |
 | `rtk_cloud_admin/internal/config` | 85.7% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -6,6 +6,7 @@
 |---|---|
 | Go total coverage | 65.3% |
 | Go coverage gate | >= 65.0% |
+| Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
 

--- a/docs/backend-api-gap-audit.md
+++ b/docs/backend-api-gap-audit.md
@@ -1,6 +1,6 @@
 # Backend API Gap Audit
 
-Date: 2026-06-06
+Date: 2026-07-13
 
 Source documents:
 
@@ -15,6 +15,38 @@ design are called out separately.
 This document distinguishes Admin Console work from upstream blockers. Items
 listed as implemented in `rtk_cloud_admin` can still depend on production data
 from Account Manager or Video Cloud before server validation is complete.
+
+## 2026-07-13 Design-to-Implementation Reconciliation
+
+The current Platform View and Brand Clouds backend baseline exists and supports
+the current React pages. It does not yet support every field and workflow in
+the approved dashboard/Brand Clouds design assets. The detailed execution plan
+is [platform-admin-implementation-plan.md](platform-admin-implementation-plan.md).
+
+Current gaps that are backend or upstream-contract work, rather than merely
+visual work:
+
+- Brand Cloud list filtering is performed in Cloud Admin after a full upstream
+  list fetch; Account Manager needs bounded server-side pagination and filters.
+- Brand Cloud list/detail DTOs do not consistently expose SSO status, region,
+  created-at, brand code, entitlement usage, and freshness as one stable read
+  model.
+- Brand Cloud detail now performs fresh reads through the existing organization
+  and SSO routes; a composed overview endpoint is not required for the first
+  management release.
+- Service Logs, Operations, and Audit need bounded filter/pagination contracts;
+  full cross-service audit history still requires an authoritative upstream
+  source or ingestion contract.
+- Platform Dashboard now uses source-state/freshness data and existing
+  management-page links; environment/cluster context and deep resource detail
+  remain deferred display work.
+
+Priority adjustment: authoritative health, operation risk, Brand Cloud
+identity/status/owner/SSO, member assignment, enable/disable, safe source
+states, and local management audit records are implemented or first-release
+blockers. Region, brand code, created-at, historical quota/device analytics,
+rich Service Logs queries, deep resource detail, and full audit export remain
+design follow-ups, not urgent API work.
 
 ## Status Legend
 

--- a/docs/cloud-admin-e2e.md
+++ b/docs/cloud-admin-e2e.md
@@ -33,6 +33,20 @@ E2E_PROMETHEUS_MODE=unavailable \
   npx playwright test e2e/platform-dashboard.spec.mjs --grep unavailable
 ```
 
+The other deterministic source states and mutation failure path are available
+through the same harness:
+
+```sh
+E2E_PROMETHEUS_MODE=empty npx playwright test e2e/platform-dashboard.spec.mjs --grep "empty and stale"
+E2E_PROMETHEUS_MODE=stale npx playwright test e2e/platform-dashboard.spec.mjs --grep "empty and stale"
+E2E_PROMETHEUS_MODE=unconfigured npx playwright test e2e/platform-dashboard.spec.mjs --grep "empty and stale"
+E2E_FAIL_ACTION=member-assign npx playwright test e2e/brand-cloud.spec.mjs --grep "partial owner"
+E2E_SCENARIO_MODE=unavailable npx playwright test e2e/brand-cloud.spec.mjs --grep "upstream failures"
+```
+
+Each local run starts a fresh fixture-backed Go BFF and temporary database, so
+mutating tests do not reuse state from an earlier run.
+
 Playwright retains failure screenshots, videos, traces, and the HTML report
 under `.artifacts/playwright-results/` and `.artifacts/playwright-report/`.
 

--- a/docs/cloud-admin-e2e.md
+++ b/docs/cloud-admin-e2e.md
@@ -1,0 +1,47 @@
+# Cloud Admin End-to-End Tests
+
+Cloud Admin browser E2E uses Playwright Test. The local harness starts the
+actual Go Admin BFF and connects it to fixture upstreams; Browser tests do not
+mock `/api/admin/*` responses.
+
+## Local
+
+From `web/`:
+
+```sh
+npm ci
+npm run e2e:install
+npm run build
+npm run e2e:generate-fixture
+npm run e2e:smoke
+npm run e2e
+npm run e2e:report
+```
+
+The fixture generator reuses `loadtests/home-100k`'s `BrandPlan` validation,
+device/user distribution, and `run_id` correlation. Generated data is written
+under `.artifacts/e2e-fixtures/cloud-admin-e2e/` and is never production data.
+
+## Scenarios
+
+The default fixture covers Platform Dashboard, Operations, Service Logs,
+Brand Clouds, SSO state, user lifecycle, creation flow, and authorization.
+Prometheus failure behavior can be run separately:
+
+```sh
+E2E_PROMETHEUS_MODE=unavailable \
+  npx playwright test e2e/platform-dashboard.spec.mjs --grep unavailable
+```
+
+Playwright retains failure screenshots, videos, traces, and the HTML report
+under `.artifacts/playwright-results/` and `.artifacts/playwright-report/`.
+
+## Staging
+
+Staging tests use `E2E_BASE_URL`, `E2E_PLATFORM_SESSION_ID`, and
+`E2E_CUSTOMER_SESSION_ID`. Read-only tests are the default. Mutation tests
+require `E2E_ALLOW_MUTATIONS=true` and a disposable Brand Cloud.
+
+Large load profiles are not run by PR E2E. Use the existing `video-1k` profile
+before staging Browser validation when real metrics and operation activity are
+required.

--- a/docs/platform-admin-implementation-plan.md
+++ b/docs/platform-admin-implementation-plan.md
@@ -1,0 +1,248 @@
+# Platform Admin Design-to-Implementation Plan
+
+Date: 2026-07-13
+
+Status: implementation plan based on the current `rtk_cloud_admin` checkout
+
+Related documents:
+
+- [Platform View Dashboard Design](platform-view-dashboard-design.md)
+- [Platform Brand Cloud Management Design](platform-brand-cloud-management-design.md)
+- [Backend API Gap Audit](backend-api-gap-audit.md)
+- [Role Definitions](ROLES.md)
+- [OpenAPI contract](openapi.yaml)
+
+## Executive Summary
+
+The current checkout already has a working Platform View shell, a server-side
+Platform Dashboard BFF, Grafana proxying, Service Health, SSO Providers,
+Service Logs, Operations Log, Audit Log, and an Account Manager-backed Brand
+Clouds workflow. The backend is therefore sufficient for the current reduced
+UI, but it does not yet support the design assets as a complete product
+contract.
+
+The remaining gaps after the management-first implementation are:
+
+1. dashboard environment/cluster context remains intentionally deferred;
+2. Brand Clouds list data lacks SSO, created-at, and region-filter support and
+   is filtered after a full upstream list fetch;
+3. entitlement display and full SSO setup workflows remain intentionally
+   minimal;
+4. rich log search, operation detail, and full upstream audit remain deferred;
+5. Service Logs filters render as read-only inputs and do not become query
+   parameters;
+6. Audit and activity data remain local/BFF projections rather than a complete
+   upstream platform activity contract.
+
+The P0 dashboard source-state rendering, recent incident context, Brand Cloud
+fresh detail/SSO read, create stepper, partial-failure handling, and local
+management audit records are implemented in the current branch.
+
+## Priority Rule
+
+Backend work is urgent only when it is required for a Platform Admin to make a
+management decision or perform a management action. Display-only context,
+extra metrics, historical exploration, and deep diagnostics do not block the
+first usable release.
+
+- **P0 management:** health state, failed/open operations, service/workload
+  status, Brand Cloud identity/status/owner, SSO setup state, enable/disable,
+  member assignment, authorization, and source-state handling.
+- **P1 workflow support:** basic search/filter, bounded paging, setup retry,
+  partial-failure state, and links to existing detail pages.
+- **P2 optional observability:** environment/cluster selectors, extra business
+  metrics, historical trends, deep node/workload detail, rich log dimensions,
+  and full audit export/search.
+
+P2 items remain design extensions, but are not backend release blockers.
+
+## Current Implementation Evidence
+
+### Implemented baseline
+
+- `/api/admin/platform-dashboard` returns KPI, scrape, service metric,
+  workload, node, operation-risk, business, infrastructure, and source-state
+  sections.
+- `/api/admin/summary`, `/customers`, `/devices`, `/operations`,
+  `/service-health`, and `/audit` are platform-admin protected.
+- Grafana is embedded through the same-origin `/api/admin/grafana/*` proxy.
+- Brand Clouds has list, pagination, search, status/tier filtering, create,
+  update, member assignment, brand-user creation, user listing, approve,
+  enable, disable, and delete routes.
+- SSO provider list/read/upsert routes exist and secrets are not returned.
+- Platform route guards distinguish platform-admin sessions from customer
+  sessions and require an Account Manager-backed session for Brand Clouds.
+- The shell refreshes authenticated data every 20 seconds.
+
+### Design parity gaps
+
+| Area | Design expectation | Current implementation | Required action | Owner |
+|---|---|---|---|---|
+| Dashboard shell | Environment, cluster, health, freshness and drill-down links | Environment and cluster are hard-coded in React; freshness says `now`; panels have limited/no drill-down actions | Add a dashboard context/read-model contract and route links to Service Health, Operations, and detail views | Admin BFF + WebUI |
+| Dashboard metrics | Compact KPI and dense service/workload/node/risk tables | Main tables and panels are implemented and backed by `/api/admin/platform-dashboard` | Keep payload; add stable IDs, links, detail routes, and source freshness | Admin BFF + WebUI |
+| Platform navigation | Dashboard, Service Health, Brand Clouds, SSO, Operations, Audit | Also exposes Grafana and Service Logs; this is useful but not represented consistently in design docs | Make the extended navigation explicit in the approved design | Docs + WebUI |
+| Brand Clouds list | Search, status/tier/region filters; SSO, quota, created columns | Search/status/tier work; region filter, SSO, created columns are absent; BFF fetches all upstream records then filters locally | Enrich list DTO and add upstream/BFF pagination/filter contract | Account Manager + Admin BFF + WebUI |
+| Create Brand Cloud | Four-step drawer: Identity, Admin, Entitlement, Review | Single form; no brand code, fixed organization-kind display, entitlement snapshot, or review summary | Implement stepper and validation; extend create DTO only for fields owned by Account Manager | WebUI + Account Manager contract |
+| Brand Cloud detail | Fresh setup checklist, identity, members, SSO, quota, actions | Uses selected list row; SSO is hard-coded unavailable; no fresh detail join | Fetch detail and SSO status in parallel; return a composed detail DTO | Admin BFF + WebUI |
+| Brand users | Existing-user assignment and lifecycle actions | Routes and UI exist, including create/reactivate | Add capability-aware controls, audit correlation, and pagination if upstream grows | Account Manager + Admin BFF |
+| SSO | Provider status in Brand Cloud setup and dedicated SSO page | Dedicated list/upsert exists; Brand Cloud detail does not consume it; OIDC only | Add detail composition, verify/test status, and document SAML as out of scope | Admin BFF + Account Manager |
+| Service Logs | Search/filter by service, host, level, trace/request/operation/device/org/user | Inputs are read-only; fetch is effectively fixed to one service | Add query parameters, bounded pagination, redaction, and backend log-search contract | Logger/BFF + WebUI |
+| Operations | Scan-first queue with filters and detail links | List exists but is a basic read model; dashboard does not provide complete drill-down | Add bounded filters, cursor/page contract, operation detail, and source freshness | Admin BFF + upstream |
+| Audit | Cross-platform actor/action/target history | Local audit rows exist; full upstream audit mirroring/export is not implemented | Define authoritative audit source, cursor pagination, filters, and retention/export behavior | Account Manager/Video Cloud + Admin BFF |
+
+## Backend/API Assessment
+
+### APIs that can support the current frontend
+
+The following APIs are adequate for the current baseline and should not be
+replaced merely for UI refactoring:
+
+- `GET /api/admin/platform-dashboard`
+- `GET /api/admin/summary`
+- `GET /api/admin/service-health`
+- `GET /api/admin/operations`
+- `GET /api/admin/audit`
+- `GET /api/admin/grafana/status` and the same-origin Grafana proxy
+- `GET/POST /api/admin/brand-clouds`
+- `GET/PATCH /api/admin/brand-clouds/{brandCloudId}`
+- `POST /api/admin/brand-clouds/{brandCloudId}/members`
+- Brand-user list/create/lifecycle routes
+- `GET /api/admin/sso/providers` and
+  `GET/PUT /api/admin/orgs/{orgId}/sso-provider`
+
+### API work required for design parity
+
+#### 1. Platform dashboard management contract (P0/P1)
+
+The existing dashboard response is sufficient for the first management release.
+Only add stable service/workload/node/operation identifiers, meaningful source
+freshness, and route-safe references to the existing Service Health and
+Operations pages. Environment selectors, historical context, and new resource
+detail routes are P2 and should not block the release.
+
+If later required, suggested bounded detail routes are:
+
+```text
+GET /api/admin/platform-dashboard?environment=&cluster=
+GET /api/admin/services/{serviceId}
+GET /api/admin/workloads/{workloadId}
+GET /api/admin/nodes/{nodeId}
+GET /api/admin/operations/{operationId}
+```
+
+These routes must return sanitized summaries only. Raw Prometheus labels and
+arbitrary PromQL remain server-side concerns.
+
+#### 2. Brand Cloud management read models (P0/P1)
+
+For the first management release, keep the current endpoint and make the
+management fields authoritative. A future enriched endpoint may be:
+
+```text
+GET /api/admin/brand-clouds?q=&status=&tier=&region=&limit=&cursor=
+GET /api/admin/brand-clouds/{brandCloudId}/overview
+```
+
+Rows/detail must include brand name/id, tier, normalized status, owner/admin,
+SSO setup status, source status, and enough quota/setup information to avoid an
+unsafe action. Region, created-at, brand code, and historical usage are P2
+display fields. A fresh detail read is P0 when the list row may be stale.
+Cloud Admin must not create a second authoritative store.
+
+Account Manager support is urgent only for authoritative owner, status, member,
+SSO, and action results. Server-side pagination, region/brand code/created-at,
+and rich entitlement usage are follow-up work unless current tenant counts make
+the existing bounded list unsafe.
+
+#### 3. Create/update workflow contract
+
+Keep creation as one Account Manager operation where possible. The BFF response
+should include the created brand cloud, owner assignment result, entitlement
+snapshot, SSO setup state, request correlation id, and retryable versus
+non-retryable failure. Do not accept billing approval or arbitrary entitlement
+changes in Cloud Admin.
+
+#### 4. Logs, operations, and audit (P1/P2)
+
+Keep current read routes for the first management release. Define bounded query
+contracts only when the current lists cannot support safe triage:
+
+```text
+GET /api/admin/service-logs?service=&host=&level=&trace_id=&request_id=&operation_id=&device_id=&org_id=&user_id=&cursor=&limit=
+GET /api/admin/operations?state=&organization_id=&type=&cursor=&limit=
+GET /api/admin/audit?actor=&action=&target=&organization_id=&result=&cursor=&limit=
+```
+
+The BFF must redact secrets, enforce maximum page sizes, and return source
+freshness. Full audit history requires an authoritative upstream audit API or
+an explicitly documented ingestion pipeline.
+
+## Delivery Plan
+
+### Phase 0 — Contract and documentation lock
+
+- Approve this matrix as the source plan.
+- Update OpenAPI schemas and examples for current versus planned fields.
+- Confirm Account Manager ownership for brand code, region, quota, SSO, users,
+  memberships, and audit.
+- Decide whether dashboard detail routes are needed immediately or whether
+  existing pages can be used as drill-down targets.
+
+Exit criteria: no design field is marked implemented without a route, DTO,
+source owner, and test reference.
+
+### Phase 1 — Make the existing Platform Dashboard management-ready
+
+- Make source status and freshness meaningful.
+- Add links from risk/KPI panels to existing Service Health and Operations
+  pages.
+- Add responsive/visual QA against the dashboard mockup.
+
+Exit criteria: an operator can identify the unhealthy service/workload/node or
+operation and reach the existing management/investigation page.
+
+### Phase 2 — Complete Brand Clouds management read experience
+
+- Make identity, status, owner, SSO, and action results authoritative.
+- Keep basic search/status filtering usable.
+- Fetch fresh detail data rather than reusing the list row.
+- Join SSO status and the minimum quota/setup state needed for safe actions.
+
+Exit criteria: an operator can find a Brand Cloud, understand whether it is
+ready, identify its owner/setup blocker, and safely enable/disable or assign a
+member.
+
+### Phase 3 — Complete Brand Cloud create/update workflow
+
+- Implement the four-step drawer with validation and review.
+- Handle initial-admin partial failure with retry from detail.
+- Add capability-aware actions and audit correlation.
+- Add tests for active, setup-required, disabled, unavailable, and
+  partial-failure states.
+
+Exit criteria: create/update/member flows are safe for production Account
+Manager sessions and cannot silently fall back to demo data.
+
+### Phase 4 — Optional observability depth
+
+- Add Service Logs filters and bounded pagination.
+- Add rich operation detail and source-backed dead-letter history.
+- Add audit filters, export, and authoritative upstream activity integration.
+- Keep Grafana private and linked for deep investigation.
+
+Exit criteria: a Platform Admin can move from a red KPI to a sanitized,
+traceable detail page without reading SQLite or constructing PromQL manually.
+
+## Verification Plan
+
+- Backend: Go handler/client tests, upstream contract fixtures, OpenAPI
+  validation, authorization, redaction, and pagination tests.
+- Frontend: route/component/state tests plus loading, empty, unavailable, and
+  partial-failure browser tests.
+- Visual: render Platform Dashboard and Brand Clouds list/create/detail at the
+  approved 1440px reference width and at a narrow viewport.
+- Live acceptance: Account Manager-backed Platform Admin login, real Brand
+  Cloud list/create/member assignment, SSO status, Prometheus source states,
+  Grafana proxy health, and audit correlation.
+- Regression: customer sessions cannot access `/api/admin/*` or receive
+  cross-tenant data.

--- a/docs/platform-admin-implementation-plan.md
+++ b/docs/platform-admin-implementation-plan.md
@@ -246,3 +246,7 @@ traceable detail page without reading SQLite or constructing PromQL manually.
   Grafana proxy health, and audit correlation.
 - Regression: customer sessions cannot access `/api/admin/*` or receive
   cross-tenant data.
+
+The canonical `docs/TEST_REPORT.md` is refreshed from the CI report generator
+when backend coverage changes; it is kept in sync with the tracked test and
+coverage evidence for each implementation branch.

--- a/docs/platform-brand-cloud-management-design.md
+++ b/docs/platform-brand-cloud-management-design.md
@@ -1,6 +1,7 @@
 # Platform Brand Cloud Management Design
 
-Status: draft for product, UX, and developer review.
+Status: implemented baseline; design-parity and upstream-contract follow-up is
+tracked in `platform-admin-implementation-plan.md`.
 
 Date: 2026-06-01
 
@@ -42,11 +43,30 @@ The working product name in the UI is **Brand Clouds**. It represents
 `organization_kind=brand_cloud` records and should not be presented as a
 generic customer organization table.
 
+## Management-First Scope
+
+The minimum information required to manage a Brand Cloud is:
+
+- brand name and organization id;
+- tier and normalized status;
+- owner/admin assignment;
+- SSO setup state;
+- the setup blocker, if any;
+- actions to create, assign a member, enable, or disable the Brand Cloud.
+
+Region, brand code, created-at, historical device usage, and rich entitlement
+analytics are useful display fields but are not required to make the first
+management actions safe. They may remain optional until Account Manager
+provides authoritative fields without adding a new local source of truth.
+
 ## GUI Draft
 
-The GUI draft is a code-native static mock so table labels, form fields,
-drawer copy, and state language remain readable during review. It is not an
-implementation of the React application.
+The PNG/HTML assets are the approved visual reference. The React application
+now implements the list, create drawer, detail drawer, member assignment, and
+brand-user lifecycle baseline. The implementation now includes the
+management-first create stepper, fresh detail reads, SSO setup state, and
+partial-failure handling. Entitlement analytics, region/created-at display
+fields, and deep setup workflows remain follow-up items.
 
 ### Brand Clouds List
 
@@ -158,7 +178,8 @@ Manage licensed brand operators backed by Account Manager.
   - text search across brand name, organization id, and owner/admin email
   - status filter
   - tier filter
-  - region filter when Account Manager exposes region metadata
+  - region filter when Account Manager exposes region metadata; this is an
+    optional enhancement and not a first-release backend blocker
   - primary `Create Brand Cloud` button
 - Table columns:
   - Brand
@@ -167,8 +188,8 @@ Manage licensed brand operators backed by Account Manager.
   - Status
   - Owner/Admin
   - SSO
-  - Device Quota or Device Usage
-  - Created
+  - Device Quota or Device Usage when available
+  - Created when available
   - Actions
 
 ### Status Labels
@@ -230,7 +251,7 @@ Platform Account Manager user ids are not valid for brand-cloud membership.
 Creating or reactivating a brand-scoped user uses the Brand User form and then
 assigns membership by `brand_cloud_user_id`.
 
-### Step 3: Entitlement Snapshot
+### Step 3: Entitlement Snapshot (optional information)
 
 Fields:
 
@@ -240,7 +261,8 @@ Fields:
 - SSO setup later checkbox or informational state
 
 This step should not imply that billing or contract approval is handled in
-Admin Console.
+Admin Console. If entitlement data is unavailable, creation can still proceed
+with the minimum tier/setup information owned by Account Manager.
 
 ### Step 4: Review And Create
 

--- a/docs/platform-view-dashboard-design.md
+++ b/docs/platform-view-dashboard-design.md
@@ -1,6 +1,7 @@
 # Platform View Dashboard Design
 
-Status: draft for product, UX, SRE, and developer review.
+Status: implemented baseline; design-parity follow-up is tracked in
+`platform-admin-implementation-plan.md`.
 
 Date: 2026-06-02
 
@@ -35,6 +36,23 @@ investigate next.
 `rtk_cloud_admin` owns the WebUI and BFF. Account Manager, Video Cloud, and
 Prometheus remain the sources of truth for their respective facts.
 
+## Management-First Scope
+
+The first Platform Dashboard viewport is optimized for decisions and actions,
+not for displaying every available metric. The required management information
+is:
+
+- overall platform/service/workload/node health;
+- open, failed, and dead-lettered operation risk;
+- enough tenant/device footprint to understand impact;
+- source freshness and unavailable/degraded state;
+- links to the existing Service Health, Operations, and Grafana surfaces.
+
+Environment selectors, extra business signals, historical charts, detailed
+resource drill-downs, and rich log/audit exploration are optional follow-up
+surfaces. Their absence must not block the management dashboard or require new
+backend APIs in the first release.
+
 ## Product Goals
 
 - Give Tier 1 Platform Admins a first-screen answer to whether the platform is
@@ -64,18 +82,23 @@ Prometheus remain the sources of truth for their respective facts.
 
 ## Navigation Placement
 
-Recommended Platform View nav order:
+Current Platform View nav order:
 
 1. Platform Dashboard
-2. Service Health
-3. Brand Clouds
-4. SSO Providers
-5. Operations Log
-6. Audit Log
+2. Grafana
+3. Service Health
+4. Brand Clouds
+5. SSO Providers
+6. Service Logs
+7. Operations Log
+8. Audit Log
 
 `Service Health` remains a dedicated drill-down page. `Platform Dashboard`
-summarizes service and metrics health at a higher level and links to deeper
-surfaces.
+summarizes service and metrics health at a higher level. The current React
+implementation has the management summary panels, source-state rendering,
+recent incident context, and links to existing management pages.
+Environment/cluster selectors and deep resource detail remain deferred; see
+`platform-admin-implementation-plan.md`.
 
 ## Page Layout
 
@@ -110,6 +133,10 @@ Business Signals                                  Recent Platform Activity
 The page should use the existing Realtek Ops Console visual system:
 compact KPI strip, dense tables, restrained status labels, and right-side
 drill-down links. Do not use marketing hero sections or decorative charts.
+The primary viewport must keep Service Health, K8s Workloads, Cluster Nodes,
+and Operation Risk visible. Cross-Service Risk, Business Signals,
+Infrastructure Health, and historical/deep diagnostic panels are secondary and
+may be hidden or deferred when their source/API is not available.
 
 Operation Risk and Platform Activity must be scan-first dashboard panels, not
 large card stacks. Operation Risk uses a compact three-metric strip for Open,

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -1,6 +1,7 @@
 # WebUI Implementation Roadmap
 
-Status: historical first-batch roadmap plus the current Brand Fleet follow-up.
+Status: historical first-batch roadmap plus current Platform Admin and Brand
+Fleet follow-up.
 
 > The original four-page Customer View roadmap below is retained for historical
 > implementation traceability. It is superseded for the brand sub-tenant by the
@@ -39,11 +40,10 @@ dependency note only and was not opened as part of this batch.
 
 This roadmap tracks the completed first WebUI implementation sequence for
 Customer View, auth, Platform View pages, and Platform Dashboard. Brand Fleet
-Management is the next product implementation sequence for brand sub-tenants.
-Brand Clouds
-remain a subsequent Platform View design extension; the relevant drafts live in
-[platform-view-dashboard-design.md](platform-view-dashboard-design.md) and
-[platform-brand-cloud-management-design.md](platform-brand-cloud-management-design.md).
+Management remains the next large product sequence for brand sub-tenants.
+Platform Dashboard and Brand Clouds already have an implemented baseline; their
+remaining design/API work is tracked in
+[platform-admin-implementation-plan.md](platform-admin-implementation-plan.md).
 
 ## Issue Body Template
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ import (
 	"rtk_cloud_admin/internal/accountclient"
 	"rtk_cloud_admin/internal/config"
 	"rtk_cloud_admin/internal/contracts"
+	"rtk_cloud_admin/internal/correlation"
 	"rtk_cloud_admin/internal/readinessfacts"
 	"rtk_cloud_admin/internal/store"
 	"rtk_cloud_admin/internal/videoclient"
@@ -3797,6 +3798,7 @@ func (s *Server) apiAdminBrandClouds(w http.ResponseWriter, r *http.Request) {
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)
 		return
 	}
+	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.create", brandCloud.ID, "", "accepted")
 	writeJSONStatus(w, http.StatusCreated, map[string]accountclient.BrandCloud{"brand_cloud": brandCloud})
 }
 
@@ -3832,6 +3834,7 @@ func (s *Server) apiAdminBrandCloud(w http.ResponseWriter, r *http.Request) {
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)
 		return
 	}
+	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.update", brandCloudID, "", "accepted")
 	writeJSON(w, map[string]accountclient.BrandCloud{"brand_cloud": brandCloud})
 }
 
@@ -3861,6 +3864,7 @@ func (s *Server) apiAdminBrandCloudMember(w http.ResponseWriter, r *http.Request
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)
 		return
 	}
+	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.member.assign", brandCloudID, "", "accepted")
 	writeJSONStatus(w, http.StatusCreated, map[string]accountclient.Member{"member": member})
 }
 
@@ -3890,6 +3894,7 @@ func (s *Server) apiAdminBrandCloudUser(w http.ResponseWriter, r *http.Request) 
 	if status != http.StatusCreated {
 		status = http.StatusOK
 	}
+	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.user.create_or_reactivate", brandCloudID, "", "accepted")
 	writeJSONStatus(w, status, result)
 }
 
@@ -3927,6 +3932,7 @@ func (s *Server) apiAdminBrandCloudUserAction(w http.ResponseWriter, r *http.Req
 			s.writeUpstreamReadErrorForSession(w, session.ID, err)
 			return
 		}
+		s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.user.delete", brandCloudID, brandCloudUserID, "accepted")
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
@@ -3950,6 +3956,7 @@ func (s *Server) apiAdminBrandCloudUserAction(w http.ResponseWriter, r *http.Req
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)
 		return
 	}
+	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.user."+action, brandCloudID, brandCloudUserID, "accepted")
 	writeJSON(w, map[string]accountclient.BrandCloudUser{"brand_cloud_user": user})
 }
 
@@ -4886,6 +4893,20 @@ func (s *Server) auditSSOSession(email, kind, orgID, result string) error {
 		Target:         fallback(kind, "sso_session"),
 		OrganizationID: orgID,
 		Result:         result,
+	})
+}
+
+func (s *Server) auditPlatformBrandCloudAction(r *http.Request, session store.Session, action, organizationID, target, result string) {
+	values := correlation.FromContext(r.Context())
+	_ = s.audit.CreateAuditEventWithMetadata(store.AuditEventInput{
+		Actor:               fallback(session.Email, session.Subject),
+		ActorKind:           fallback(session.Kind, "platform_admin"),
+		Action:              action,
+		Target:              fallback(target, organizationID),
+		OrganizationID:      organizationID,
+		Result:              result,
+		RequestID:           values.RequestID,
+		UpstreamOperationID: values.OperationID,
 	})
 }
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4040,6 +4040,28 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 	if deleteUser.Code != http.StatusNoContent {
 		t.Fatalf("brand cloud user delete status = %d, want 204; body=%s", deleteUser.Code, deleteUser.Body.String())
 	}
+	auditEvents, err := st.ListAuditEvents()
+	if err != nil {
+		t.Fatalf("ListAuditEvents after brand cloud actions: %v", err)
+	}
+	auditActions := map[string]bool{}
+	for _, event := range auditEvents {
+		auditActions[event.Action] = true
+	}
+	for _, action := range []string{
+		"platform.brand_cloud.create",
+		"platform.brand_cloud.update",
+		"platform.brand_cloud.member.assign",
+		"platform.brand_cloud.user.create_or_reactivate",
+		"platform.brand_cloud.user.disable",
+		"platform.brand_cloud.user.enable",
+		"platform.brand_cloud.user.approve",
+		"platform.brand_cloud.user.delete",
+	} {
+		if !auditActions[action] {
+			t.Errorf("audit action %q was not recorded", action)
+		}
+	}
 
 	blocked := httptest.NewRecorder()
 	blockedReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds", strings.NewReader(`{"name":"Blocked"}`))

--- a/scripts/generate_test_report.sh
+++ b/scripts/generate_test_report.sh
@@ -33,6 +33,7 @@ cat > "$output" <<EOF
 |---|---|
 | Go total coverage | ${total_coverage} |
 | Go coverage gate | >= ${coverage_min}% |
+| Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
 | Coverage profile | GitHub Actions artifact only |
 

--- a/web/e2e/access-control.spec.mjs
+++ b/web/e2e/access-control.spec.mjs
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+import { login } from './fixtures/session.mjs';
+
+test('anonymous cannot read platform admin API', async ({ request }) => {
+  const response = await request.get('/api/admin/platform-dashboard');
+  expect(response.status()).toBe(401);
+});
+
+test('customer cannot read platform admin API', async ({ page }) => {
+  await login(page, 'customer');
+  const response = await page.request.get('/api/admin/platform-dashboard');
+  expect(response.status()).toBe(403);
+});
+
+test('customer view is separated from platform navigation', async ({ page }) => {
+  await login(page, 'customer');
+  await page.goto('/console');
+  await expect(page.getByText('Brand Clouds', { exact: true })).toHaveCount(0);
+});

--- a/web/e2e/audit.spec.mjs
+++ b/web/e2e/audit.spec.mjs
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { enterPlatform, login } from './fixtures/session.mjs';
+
+test('platform admin can review local audit records after a Brand Cloud action', async ({ page }) => {
+  await login(page, 'platform_admin');
+  await enterPlatform(page);
+  await page.getByRole('button', { name: 'Brand Clouds', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Brand Clouds' }).first()).toBeVisible();
+  await page.getByRole('button', { name: 'Create Brand Cloud', exact: true }).click();
+  const dialog = page.getByRole('dialog', { name: 'Create Brand Cloud' });
+  await dialog.getByLabel('Brand display name').fill('E2E Audit Cloud');
+  await dialog.getByRole('button', { name: 'Continue' }).click();
+  await dialog.getByRole('button', { name: 'Continue' }).click();
+  await dialog.getByRole('button', { name: 'Create Brand Cloud', exact: true }).click();
+  await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();
+  await page.getByRole('button', { name: 'Close' }).click();
+  await page.goto('/admin/audit');
+  await expect(page.getByRole('heading', { name: 'Audit Log', exact: true })).toBeVisible();
+  await expect(page.getByText('Current write coverage', { exact: false })).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'platform.brand_cloud.create', exact: true }).first()).toBeVisible();
+  await expect(page.getByRole('cell', { name: 'platform.admin@example.com', exact: true }).first()).toBeVisible();
+});

--- a/web/e2e/brand-cloud.spec.mjs
+++ b/web/e2e/brand-cloud.spec.mjs
@@ -25,6 +25,33 @@ test.describe('Brand Clouds', () => {
     await expect(page.getByText('E2E Alpha Cloud', { exact: true })).toHaveCount(0);
   });
 
+  test('list renders Account Manager upstream failures safely', async ({ page }) => {
+    const mode = process.env.E2E_SCENARIO_MODE;
+    test.skip(mode !== 'unavailable', 'run with E2E_SCENARIO_MODE=unavailable');
+    await expect(page.getByText(/Brand Clouds (?:unavailable|is temporarily unavailable)/i)).toBeVisible();
+    await expect(page.getByText(/raw_payload|access_token|password|authorization/i)).toHaveCount(0);
+  });
+
+  test('detail supports Brand Cloud and user lifecycle actions', async ({ page }) => {
+    const betaRow = page.getByRole('row').filter({ hasText: 'E2E Beta Cloud' });
+    await betaRow.getByRole('button', { name: 'View', exact: true }).click();
+    const dialog = page.getByRole('dialog', { name: 'Brand Cloud detail' });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Re-enable Brand Cloud' })).toBeVisible();
+    await expect(dialog.getByText('Pending Activation', { exact: true })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Approve' }).click();
+    await expect(dialog.getByText('Brand user approved.', { exact: true })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Re-enable Brand Cloud' }).click();
+    await expect(dialog.getByText('Brand Cloud enabled.', { exact: true })).toBeVisible();
+    await dialog.getByLabel('Brand User id').fill('brand-user-beta-owner');
+    await dialog.getByRole('button', { name: 'Assign Existing Brand User' }).click();
+    await expect(dialog.getByText('Member assigned.', { exact: true })).toBeVisible();
+    await dialog.getByLabel('Email').fill('new-admin@example.com');
+    await dialog.getByLabel('Temporary password').fill('e2e-temporary-password');
+    await dialog.getByRole('button', { name: 'Create Or Reactivate User' }).click();
+    await expect(dialog.getByText('Brand user created and assigned.', { exact: true })).toBeVisible();
+  });
+
   test('create stepper completes a Brand Cloud creation', async ({ page }) => {
     await page.getByRole('button', { name: 'Create Brand Cloud' }).click();
     const dialog = page.getByRole('dialog', { name: 'Create Brand Cloud' });
@@ -35,5 +62,20 @@ test.describe('Brand Clouds', () => {
     await dialog.getByRole('button', { name: 'Create Brand Cloud' }).click();
     await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'E2E Created From Browser' })).toBeVisible();
+  });
+
+  test('create stepper surfaces partial owner assignment failure', async ({ page }) => {
+    test.skip(process.env.E2E_FAIL_ACTION !== 'member-assign', 'run with E2E_FAIL_ACTION=member-assign');
+    await page.getByRole('button', { name: 'Create Brand Cloud' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Create Brand Cloud' });
+    await dialog.getByLabel('Brand display name').fill('E2E Partial Owner Cloud');
+    await dialog.getByRole('button', { name: 'Continue' }).click();
+    await dialog.getByLabel('Initial admin mode').selectOption('existing');
+    await dialog.getByRole('textbox', { name: 'Brand User id' }).fill('brand-user-alpha-owner');
+    await dialog.getByRole('button', { name: 'Continue' }).click();
+    await dialog.getByRole('button', { name: 'Create Brand Cloud', exact: true }).click();
+    await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();
+    await expect(page.getByText(/Brand Cloud created, but initial admin setup needs attention/i)).toBeVisible();
+    await expect(page.getByText(/temporarily unavailable|try again later/i)).toBeVisible();
   });
 });

--- a/web/e2e/brand-cloud.spec.mjs
+++ b/web/e2e/brand-cloud.spec.mjs
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+import { enterPlatform, login } from './fixtures/session.mjs';
+
+test.describe('Brand Clouds', () => {
+  test.beforeEach(async ({ page }) => {
+    await login(page, 'platform_admin');
+    await enterPlatform(page);
+    await page.getByRole('button', { name: 'Brand Clouds', exact: true }).click();
+    await expect(page.getByRole('heading', { name: 'Brand Clouds' }).first()).toBeVisible();
+  });
+
+  test('list filters and detail reload show Account Manager data @smoke', async ({ page }) => {
+    await expect(page.getByText('Brand Clouds', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('E2E Alpha Cloud', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'View', exact: true }).first().click();
+    await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();
+    await expect(page.getByText('SSO enabled', { exact: true })).toBeVisible();
+    await expect(page.getByText('Brand Users', { exact: true })).toBeVisible();
+    await expect(page.getByText('trace-e2e-001', { exact: true })).toHaveCount(0);
+  });
+
+  test('list status filter selects disabled Brand Clouds', async ({ page }) => {
+    await page.getByLabel('Filter Brand Clouds status').selectOption('disabled');
+    await expect(page.getByText('E2E Beta Cloud', { exact: true })).toBeVisible();
+    await expect(page.getByText('E2E Alpha Cloud', { exact: true })).toHaveCount(0);
+  });
+
+  test('create stepper completes a Brand Cloud creation', async ({ page }) => {
+    await page.getByRole('button', { name: 'Create Brand Cloud' }).click();
+    const dialog = page.getByRole('dialog', { name: 'Create Brand Cloud' });
+    await dialog.getByLabel('Brand display name').fill('E2E Created From Browser');
+    await dialog.getByRole('button', { name: 'Continue' }).click();
+    await dialog.getByRole('button', { name: 'Continue' }).click();
+    await expect(dialog.getByText('Review', { exact: true })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Create Brand Cloud' }).click();
+    await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'E2E Created From Browser' })).toBeVisible();
+  });
+});

--- a/web/e2e/fixtures/session.mjs
+++ b/web/e2e/fixtures/session.mjs
@@ -1,0 +1,25 @@
+import { expect } from '@playwright/test';
+
+export async function login(page, kind) {
+  const endpoint = kind === 'platform_admin' ? '/api/auth/platform/login' : '/api/auth/customer/login';
+  const response = await page.request.post(endpoint, { data: { email: kind === 'platform_admin' ? 'platform.admin@example.com' : 'customer@example.com', password: kind === 'platform_admin' ? 'e2e-platform-password' : 'e2e-customer-password' } });
+  expect(response.ok()).toBeTruthy();
+}
+
+export async function loginWithStagingSession(page, kind = 'platform') {
+  const value = kind === 'customer' ? process.env.E2E_CUSTOMER_SESSION_ID : process.env.E2E_PLATFORM_SESSION_ID;
+  expect(value, `E2E_${kind.toUpperCase()}_SESSION_ID is required`).toBeTruthy();
+  await page.context().addCookies([{ name: 'rtk_admin_session', value, url: process.env.E2E_BASE_URL }]);
+}
+
+export async function enterPlatform(page) {
+  await page.goto('/admin');
+  const switchButton = page.getByRole('button', { name: 'Switch to Platform View' });
+  try {
+    await switchButton.waitFor({ state: 'visible', timeout: 10_000 });
+    await switchButton.click();
+    await page.getByRole('heading', { name: 'Platform Dashboard' }).waitFor();
+  } catch {
+    await page.getByRole('heading', { name: 'Platform Dashboard' }).waitFor();
+  }
+}

--- a/web/e2e/operations.spec.mjs
+++ b/web/e2e/operations.spec.mjs
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { enterPlatform, login } from './fixtures/session.mjs';
+
+test('platform admin can open operations and service logs', async ({ page }) => {
+  await login(page, 'platform_admin');
+  await enterPlatform(page);
+  await page.getByRole('button', { name: 'Operations Log', exact: true }).click();
+  await expect(page.getByText('Lifecycle operations', { exact: true })).toBeVisible();
+  await page.getByRole('textbox', { name: 'Search operations' }).fill('E2E upstream rejected');
+  await expect(page.getByText('E2E upstream rejected request.', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: 'Service Logs', exact: true }).click();
+  await expect(page.getByRole('heading', { name: 'Service Logs', exact: true })).toBeVisible();
+  await expect(page.getByText('E2E operation failed while calling upstream.', { exact: true })).toBeVisible();
+  await expect(page.getByText('trace-e2e-001', { exact: true })).toBeVisible();
+});

--- a/web/e2e/platform-dashboard.spec.mjs
+++ b/web/e2e/platform-dashboard.spec.mjs
@@ -22,3 +22,11 @@ test('dashboard shows degraded state when Prometheus fixture is unavailable', as
   await expect(page.getByText(/Source: unavailable|Source: unconfigured/i)).toBeVisible();
   await expect(page.getByText('Healthy', { exact: true })).toHaveCount(0);
 });
+
+test('dashboard exposes empty and stale Prometheus source states', async ({ page }) => {
+  const mode = process.env.E2E_PROMETHEUS_MODE;
+  test.skip(!['empty', 'stale', 'unconfigured'].includes(mode), 'run with E2E_PROMETHEUS_MODE=empty, stale, or unconfigured');
+  await login(page, 'platform_admin');
+  await enterPlatform(page);
+  await expect(page.getByText(`Source: ${mode}`, { exact: true })).toBeVisible();
+});

--- a/web/e2e/platform-dashboard.spec.mjs
+++ b/web/e2e/platform-dashboard.spec.mjs
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+import { enterPlatform, login } from './fixtures/session.mjs';
+
+test('platform admin can triage platform dashboard @smoke', async ({ page }) => {
+  await login(page, 'platform_admin');
+  await enterPlatform(page);
+  await expect(page.getByText('Services Up', { exact: true })).toBeVisible();
+  await expect(page.getByText('Service Health', { exact: true }).first()).toBeVisible();
+  await expect(page.getByText('K8s Workloads', { exact: true })).toBeVisible();
+  await expect(page.getByText('Cluster Nodes', { exact: true })).toBeVisible();
+  await expect(page.getByText('Operation Risk', { exact: true })).toBeVisible();
+  await expect(page.getByText('Recent Incident Context', { exact: true })).toBeVisible();
+  await expect(page.getByText(/Source: configured/i)).toBeVisible();
+  await expect(page.getByText('E2E operation failed while calling upstream.', { exact: true })).toBeVisible();
+  await expect(page.getByRole('link', { name: /View all operations/ })).toHaveAttribute('href', '/admin/ops');
+});
+
+test('dashboard shows degraded state when Prometheus fixture is unavailable', async ({ page }) => {
+  test.skip(process.env.E2E_PROMETHEUS_MODE !== 'unavailable', 'run with E2E_PROMETHEUS_MODE=unavailable');
+  await login(page, 'platform_admin');
+  await enterPlatform(page);
+  await expect(page.getByText(/Source: unavailable|Source: unconfigured/i)).toBeVisible();
+  await expect(page.getByText('Healthy', { exact: true })).toHaveCount(0);
+});

--- a/web/e2e/service-logs.spec.mjs
+++ b/web/e2e/service-logs.spec.mjs
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+import { enterPlatform, login } from './fixtures/session.mjs';
+
+test('platform admin can inspect recent service-log incident context', async ({ page }) => {
+  await login(page, 'platform_admin');
+  await enterPlatform(page);
+  await page.goto('/admin/logs');
+  await expect(page.getByRole('heading', { name: 'Service Logs', exact: true })).toBeVisible();
+  await expect(page.getByText('E2E operation failed while calling upstream.', { exact: true })).toBeVisible();
+  await expect(page.getByText('trace-e2e-001', { exact: true })).toBeVisible();
+  await expect(page.getByText('request-e2e-001', { exact: true })).toBeVisible();
+  await expect(page.getByText(/raw_payload|access_token|password/i)).toHaveCount(0);
+});

--- a/web/e2e/staging.spec.mjs
+++ b/web/e2e/staging.spec.mjs
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+import { loginWithStagingSession } from './fixtures/session.mjs';
+
+test('staging platform admin can read operations @staging', async ({ page }) => {
+  test.skip(!process.env.E2E_BASE_URL, 'staging base URL is required');
+  await loginWithStagingSession(page);
+  await page.goto('/admin/ops');
+  await expect(page.getByRole('heading', { name: /Operations/i })).toBeVisible();
+  await expect(page.getByRole('link', { name: /Dashboard/i })).toBeVisible();
+});

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,6 +12,7 @@
         "vite": "^8.0.14"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "playwright": "^1.60.0"
       }
     },
@@ -80,6 +81,22 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -691,13 +708,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
-      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.60.0"
+        "playwright-core": "1.61.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -710,9 +727,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.60.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
-      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,13 @@
     "dev": "vite --host 127.0.0.1",
     "test": "node --test src/*.test.mjs",
     "browser:smoke": "node scripts/browser-smoke.mjs",
+    "e2e:generate-fixture": "node scripts/generate-e2e-fixture.mjs",
+    "e2e": "playwright test",
+    "e2e:smoke": "playwright test --grep @smoke",
+    "e2e:staging": "playwright test --project=staging",
+    "e2e:headed": "playwright test --headed",
+    "e2e:report": "playwright show-report",
+    "e2e:install": "playwright install chromium",
     "build": "vite build",
     "preview": "vite preview --host 127.0.0.1"
   },
@@ -14,6 +21,7 @@
     "vite": "^8.0.14"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "playwright": "^1.60.0"
   }
 }

--- a/web/playwright.config.mjs
+++ b/web/playwright.config.mjs
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html', { outputFolder: '../.artifacts/playwright-report', open: 'never' }], ['line']] : [['html', { outputFolder: '../.artifacts/playwright-report', open: 'never' }], ['list']],
+  outputDir: '../.artifacts/playwright-results',
+  use: { baseURL: process.env.E2E_BASE_URL || 'http://127.0.0.1:18082', trace: 'retain-on-failure', screenshot: 'only-on-failure', video: 'retain-on-failure', viewport: { width: 1440, height: 1000 } },
+  webServer: process.env.E2E_BASE_URL ? undefined : { command: 'node scripts/e2e-server.mjs', cwd: '.', url: 'http://127.0.0.1:18082/healthz', reuseExistingServer: !process.env.CI, timeout: 120_000 },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+    { name: 'mobile', grep: /@smoke/, use: { ...devices['Pixel 7'] } },
+    { name: 'staging', grep: /@staging/, use: { ...devices['Desktop Chrome'] } },
+  ],
+});

--- a/web/playwright.config.mjs
+++ b/web/playwright.config.mjs
@@ -9,7 +9,7 @@ export default defineConfig({
   reporter: process.env.CI ? [['html', { outputFolder: '../.artifacts/playwright-report', open: 'never' }], ['line']] : [['html', { outputFolder: '../.artifacts/playwright-report', open: 'never' }], ['list']],
   outputDir: '../.artifacts/playwright-results',
   use: { baseURL: process.env.E2E_BASE_URL || 'http://127.0.0.1:18082', trace: 'retain-on-failure', screenshot: 'only-on-failure', video: 'retain-on-failure', viewport: { width: 1440, height: 1000 } },
-  webServer: process.env.E2E_BASE_URL ? undefined : { command: 'node scripts/e2e-server.mjs', cwd: '.', url: 'http://127.0.0.1:18082/healthz', reuseExistingServer: !process.env.CI, timeout: 120_000 },
+  webServer: process.env.E2E_BASE_URL ? undefined : { command: 'node scripts/e2e-server.mjs', cwd: '.', url: 'http://127.0.0.1:18082/healthz', reuseExistingServer: false, timeout: 120_000 },
   projects: [
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
     { name: 'mobile', grep: /@smoke/, use: { ...devices['Pixel 7'] } },

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -431,6 +431,7 @@ async function installApiMocks(page, { sessionForPath } = {}) {
     if (pathName === '/api/fleet/firmware-distribution') return route.fulfill({ json: firmwareDistribution });
     if (pathName === '/api/admin/platform-dashboard') return route.fulfill({ json: platformDashboard });
     if (pathName === '/api/admin/service-health') return route.fulfill({ json: platformHealth });
+    if (pathName === '/api/admin/service-logs') return route.fulfill({ json: { status: 'ok', events: [{ event_id: 'log-1', ts: '2026-05-13T11:58:00Z', service: 'video-cloud', level: 'info', msg: 'Platform health sample available.', trace_id: 'trace-1', request_id: 'req-1' }] } });
     if (pathName === '/api/admin/operations') return route.fulfill({ json: platformOperations });
     if (pathName === '/api/admin/audit') return route.fulfill({ json: audit });
     if (pathName === '/api/admin/sso/providers') return route.fulfill({ json: { providers: [] } });
@@ -525,7 +526,7 @@ async function runDesktopSmoke(page) {
   await expectText(page, 'Service Health');
   await expectText(page, 'K8s Workloads');
   await expectText(page, 'Cluster Nodes');
-  await expectText(page, 'Tenant & Device Footprint');
+  await expectText(page, 'Operation Risk');
   await expectText(page, 'Infrastructure Health');
   await screenshot(page, 'desktop-platform-dashboard.png');
 
@@ -576,7 +577,7 @@ async function runMobileSmoke(browserContext) {
   await screenshot(page, 'mobile-devices.png');
 
   await gotoAndAssert(page, '/admin', 'Platform Dashboard');
-  await expectText(page, 'Tenant & Device Footprint');
+  await expectText(page, 'Operation Risk');
   await expectText(page, 'K8s Workloads');
   await screenshot(page, 'mobile-platform-dashboard.png');
 

--- a/web/scripts/e2e-fixture-server.mjs
+++ b/web/scripts/e2e-fixture-server.mjs
@@ -1,0 +1,125 @@
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const fixtureDir = process.env.E2E_FIXTURE_DIR;
+const port = Number(process.env.E2E_FIXTURE_PORT || 0);
+const mode = process.env.E2E_SCENARIO_MODE || 'normal';
+const prometheusMode = process.env.E2E_PROMETHEUS_MODE || mode;
+if (!fixtureDir) throw new Error('E2E_FIXTURE_DIR is required');
+
+const [brandClouds, users, members, devices, operations, logs, sessions, prometheus] = await Promise.all([
+  load('brand-clouds.json'), load('brand-cloud-users.json'), load('brand-cloud-members.json'), load('devices.json'),
+  load('operations.json'), load('service-logs.json'), load('sessions.json'), load('prometheus-series.json'),
+]);
+const state = { brandClouds, users, members, devices, operations, logs, sessions, prometheus };
+
+const server = createServer(async (req, res) => {
+  try {
+    if (mode === 'unavailable') return send(res, 503, { error: 'fixture unavailable' });
+    if (mode === 'unauthorized') return send(res, 401, { error: 'unauthorized' });
+    if (mode === 'forbidden') return send(res, 403, { error: 'forbidden' });
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (url.pathname === '/api/v1/query' || url.pathname === '/api/v1/query_range') return prometheusResponse(res);
+    if (url.pathname === '/v1/logs') return send(res, 200, { events: state.logs.map((event) => ({ event_id: `${event.operation_id}-${event.request_id}`, service: event.service, level: event.level, ts: event.timestamp, msg: event.message, trace_id: event.trace_id, request_id: event.request_id, operation_id: event.operation_id })) });
+    if (url.pathname === '/v1/auth/login' && req.method === 'POST') return login(req, res);
+    if (url.pathname === '/v1/admin/brand-clouds' && req.method === 'GET') return send(res, 200, { brand_clouds: state.brandClouds });
+    if (url.pathname === '/v1/admin/brand-clouds' && req.method === 'POST') return createBrandCloud(req, res);
+    if (url.pathname === '/v1/admin/devices' && req.method === 'GET') return send(res, 200, { devices: state.devices });
+    if (url.pathname === '/v1/admin/operations' && req.method === 'GET') return send(res, 200, { operations: state.operations || [] });
+    if (url.pathname === '/v1/admin/sso/providers/status' && req.method === 'GET') return send(res, 200, { providers: state.brandClouds.map((brand) => ssoFor(brand.id)) });
+    if (url.pathname === '/v1/health') return send(res, 200, { status: 'ok' });
+    if (url.pathname === '/v1/me') return send(res, 200, { user: { id: 'customer-user', email: 'customer@example.com', name: 'E2E Customer' }, organizations: state.brandClouds.map((brand) => ({ id: brand.id, name: brand.name, role: 'owner', tier: brand.tier })) });
+    const match = url.pathname.match(/^\/v1\/admin\/(brand-clouds|orgs)\/([^/]+)(.*)$/);
+    if (match) return handleResource(req, res, match[1], decodeURIComponent(match[2]), match[3]);
+    return send(res, 404, { error: 'not found' });
+  } catch (error) {
+    return send(res, 500, { error: error.message });
+  }
+});
+
+server.listen(port, '127.0.0.1', () => {
+  const address = server.address();
+  process.stdout.write(JSON.stringify({ port: address.port }) + '\n');
+});
+
+async function load(name) {
+  return JSON.parse(await readFile(path.join(fixtureDir, name), 'utf8'));
+}
+
+function login(req, res) {
+  return readBody(req).then((body) => {
+    const session = state.sessions.find((item) => item.email === body.email);
+    if (!session || session.password !== body.password) return send(res, 401, { error: 'invalid credentials' });
+    return send(res, 200, { user: { id: session.kind === 'platform_admin' ? 'platform-admin' : 'customer-user', email: session.email, name: session.email }, tokens: { access_token: `e2e-${session.kind}-token`, refresh_token: `e2e-${session.kind}-refresh`, expires_in: 3600 } });
+  });
+}
+
+async function createBrandCloud(req, res) {
+  const body = await readBody(req);
+  const id = `brand-e2e-created-${state.brandClouds.length + 1}`;
+  const brand = { id, name: body.name || 'E2E Created Cloud', role: 'platform_admin', organization_kind: 'brand_cloud', status: body.status || 'active', tier: 'evaluation', evaluation_device_quota: 10, metadata: { ...(body.metadata || {}), run_id: state.prometheus.run_id, setup_status: 'ready' } };
+  state.brandClouds.push(brand);
+  return send(res, 201, { brand_cloud: brand });
+}
+
+async function handleResource(req, res, root, id, suffix) {
+  if (root === 'orgs' && suffix === '/sso-provider') return send(res, 200, { provider: ssoFor(id) });
+  if (root !== 'brand-clouds') return send(res, 404, { error: 'not found' });
+  const brand = state.brandClouds.find((item) => item.id === id);
+  if (!brand) return send(res, 404, { error: 'brand cloud not found' });
+  if (suffix === '' && req.method === 'GET') return send(res, 200, { brand_cloud: brand });
+  if (suffix === '' && req.method === 'PATCH') {
+    Object.assign(brand, await readBody(req));
+    return send(res, 200, { brand_cloud: brand });
+  }
+  if (suffix === '/members' && req.method === 'POST') {
+    if (process.env.E2E_FAIL_ACTION === 'member-assign') return send(res, 502, { error: 'fixture member assignment failure' });
+    const body = await readBody(req);
+    const user = state.users.find((item) => item.id === body.brand_cloud_user_id);
+    const member = { organization_id: id, user_id: body.brand_cloud_user_id, brand_cloud_user_id: body.brand_cloud_user_id, email: user?.email || '', role: body.role || 'owner' };
+    state.members.push(member);
+    return send(res, 201, { member });
+  }
+  if (suffix === '/users' && req.method === 'GET') return send(res, 200, { brand_cloud_users: state.users.filter((user) => user.brand_cloud_id === id) });
+  if (suffix === '/users' && req.method === 'POST') {
+    const body = await readBody(req);
+    const user = { id: `bcu-created-${state.users.length + 1}`, brand_cloud_id: id, email: body.email, display_name: body.display_name || 'E2E Created User', email_verified: false, signup_pending_verification: true, created_at: new Date().toISOString(), updated_at: new Date().toISOString() };
+    state.users.push(user);
+    return send(res, 201, { action: 'created', brand_cloud_user: user, brand_cloud_member: { organization_id: id, brand_cloud_user_id: user.id, email: user.email, role: body.role || 'member' } });
+  }
+  const userAction = suffix.match(/^\/users\/([^/]+)(?:\/(disable|enable|approve))?$/);
+  if (userAction) {
+    const user = state.users.find((item) => item.id === decodeURIComponent(userAction[1]));
+    if (!user) return send(res, 404, { error: 'user not found' });
+    if (userAction[2] === 'disable') user.disabled_at = new Date().toISOString();
+    if (userAction[2] === 'enable') delete user.disabled_at;
+    if (userAction[2] === 'approve') user.signup_pending_verification = false;
+    if (req.method === 'DELETE') user.disabled_at = new Date().toISOString();
+    return send(res, 200, { brand_cloud_user: user });
+  }
+  return send(res, 404, { error: 'not found' });
+}
+
+function ssoFor(id) {
+  const configured = id === state.brandClouds[0]?.id;
+  return { organization_id: id, organization: state.brandClouds.find((brand) => brand.id === id)?.name || '', provider_id: configured ? 'sso-e2e-001' : '', issuer: configured ? 'https://idp.e2e.example' : '', client_id: configured ? 'e2e-client' : '', verified_domains: configured ? ['e2e.example'] : [], enabled: configured, configured, status: configured ? 'enabled' : 'not_configured', last_validated_at: configured ? new Date().toISOString() : '' };
+}
+
+function prometheusResponse(res) {
+  if (prometheusMode === 'unavailable') return send(res, 503, { error: 'prometheus unavailable' });
+  const value = prometheusMode === 'empty' ? [] : [{ metric: { job: 'e2e', service: 'cloud-admin', namespace: 'e2e', role: 'api' }, value: [String(Date.now() / 1000), prometheusMode === 'stale' ? '0' : '1'] }];
+  return send(res, 200, { status: 'success', data: { resultType: 'vector', result: value } });
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => { let data = ''; req.on('data', (chunk) => { data += chunk; }); req.on('end', () => { try { resolve(data ? JSON.parse(data) : {}); } catch (error) { reject(error); } }); req.on('error', reject); });
+}
+
+function send(res, status, body) {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+process.on('SIGTERM', () => server.close(() => process.exit(0)));

--- a/web/scripts/e2e-fixture-server.mjs
+++ b/web/scripts/e2e-fixture-server.mjs
@@ -14,23 +14,30 @@ const [brandClouds, users, members, devices, operations, logs, sessions, prometh
   load('operations.json'), load('service-logs.json'), load('sessions.json'), load('prometheus-series.json'),
 ]);
 const state = { brandClouds, users, members, devices, operations, logs, sessions, prometheus };
+let platformValidationAllowed = true;
 
 const server = createServer(async (req, res) => {
   try {
-    if (mode === 'unavailable') return send(res, 503, { error: 'fixture unavailable' });
-    if (mode === 'unauthorized') return send(res, 401, { error: 'unauthorized' });
-    if (mode === 'forbidden') return send(res, 403, { error: 'forbidden' });
     const url = new URL(req.url, `http://${req.headers.host}`);
     if (url.pathname === '/api/v1/query' || url.pathname === '/api/v1/query_range') return prometheusResponse(res);
     if (url.pathname === '/v1/logs') return send(res, 200, { events: state.logs.map((event) => ({ event_id: `${event.operation_id}-${event.request_id}`, service: event.service, level: event.level, ts: event.timestamp, msg: event.message, trace_id: event.trace_id, request_id: event.request_id, operation_id: event.operation_id })) });
     if (url.pathname === '/v1/auth/login' && req.method === 'POST') return login(req, res);
+    if (url.pathname === '/v1/me') return send(res, 200, { user: { id: 'customer-user', email: 'customer@example.com', name: 'E2E Customer' }, organizations: state.brandClouds.map((brand) => ({ id: brand.id, name: brand.name, role: 'owner', tier: brand.tier })) });
+    const authenticatedUpstreamRequest = Boolean(req.headers.authorization);
+    const platformValidationRequest = url.pathname === '/v1/admin/brand-clouds'
+      && req.method === 'GET'
+      && String(req.headers.authorization || '').includes('e2e-platform_admin-token');
+    if (platformValidationRequest && platformValidationAllowed) platformValidationAllowed = false;
+    const shouldFailAuthenticatedRequest = authenticatedUpstreamRequest && !(platformValidationRequest && !platformValidationAllowed);
+    if (shouldFailAuthenticatedRequest && mode === 'unavailable') return send(res, 503, { error: 'fixture unavailable' });
+    if (shouldFailAuthenticatedRequest && mode === 'unauthorized') return send(res, 401, { error: 'unauthorized' });
+    if (shouldFailAuthenticatedRequest && mode === 'forbidden') return send(res, 403, { error: 'forbidden' });
     if (url.pathname === '/v1/admin/brand-clouds' && req.method === 'GET') return send(res, 200, { brand_clouds: state.brandClouds });
     if (url.pathname === '/v1/admin/brand-clouds' && req.method === 'POST') return createBrandCloud(req, res);
     if (url.pathname === '/v1/admin/devices' && req.method === 'GET') return send(res, 200, { devices: state.devices });
     if (url.pathname === '/v1/admin/operations' && req.method === 'GET') return send(res, 200, { operations: state.operations || [] });
     if (url.pathname === '/v1/admin/sso/providers/status' && req.method === 'GET') return send(res, 200, { providers: state.brandClouds.map((brand) => ssoFor(brand.id)) });
     if (url.pathname === '/v1/health') return send(res, 200, { status: 'ok' });
-    if (url.pathname === '/v1/me') return send(res, 200, { user: { id: 'customer-user', email: 'customer@example.com', name: 'E2E Customer' }, organizations: state.brandClouds.map((brand) => ({ id: brand.id, name: brand.name, role: 'owner', tier: brand.tier })) });
     const match = url.pathname.match(/^\/v1\/admin\/(brand-clouds|orgs)\/([^/]+)(.*)$/);
     if (match) return handleResource(req, res, match[1], decodeURIComponent(match[2]), match[3]);
     return send(res, 404, { error: 'not found' });
@@ -109,7 +116,7 @@ function ssoFor(id) {
 
 function prometheusResponse(res) {
   if (prometheusMode === 'unavailable') return send(res, 503, { error: 'prometheus unavailable' });
-  const value = prometheusMode === 'empty' ? [] : [{ metric: { job: 'e2e', service: 'cloud-admin', namespace: 'e2e', role: 'api' }, value: [String(Date.now() / 1000), prometheusMode === 'stale' ? '0' : '1'] }];
+  const value = prometheusMode === 'empty' ? [] : [{ metric: { job: 'e2e', service: 'cloud-admin', namespace: 'e2e', role: 'api' }, value: [String(Date.now() / 1000), prometheusMode === 'stale' ? '999999' : '1'] }];
   return send(res, 200, { status: 'success', data: { resultType: 'vector', result: value } });
 }
 

--- a/web/scripts/e2e-server.mjs
+++ b/web/scripts/e2e-server.mjs
@@ -10,7 +10,8 @@ const fixtureDir = process.env.E2E_FIXTURE_DIR || path.join(repoRoot, '.artifact
 const databaseDir = await mkdtemp(path.join(os.tmpdir(), 'rtk-cloud-admin-e2e-'));
 const fixture = spawn(process.execPath, [path.join(webRoot, 'scripts', 'e2e-fixture-server.mjs')], { env: { ...process.env, E2E_FIXTURE_DIR: fixtureDir, E2E_FIXTURE_PORT: '0' }, stdio: ['ignore', 'pipe', 'inherit'] });
 const fixturePort = Number(await firstLine(fixture.stdout));
-const server = spawn('go', ['run', './cmd/server'], { cwd: repoRoot, env: { ...process.env, GOWORK: 'off', PORT: process.env.E2E_APP_PORT || '18082', DATABASE_PATH: path.join(databaseDir, 'e2e.db'), ACCOUNT_MANAGER_BASE_URL: `http://127.0.0.1:${fixturePort}`, VIDEO_CLOUD_PROMETHEUS_BASE_URL: `http://127.0.0.1:${fixturePort}`, CLOUD_LOGGER_ENDPOINT: `http://127.0.0.1:${fixturePort}`, CLOUD_LOGGER_INGEST_TOKEN: 'e2e-log-token', CUSTOMER_PASSWORD_LOGIN_ENABLED: 'true' }, stdio: 'inherit' });
+const prometheusBaseURL = process.env.E2E_PROMETHEUS_MODE === 'unconfigured' ? '' : `http://127.0.0.1:${fixturePort}`;
+const server = spawn('go', ['run', './cmd/server'], { cwd: repoRoot, env: { ...process.env, GOWORK: 'off', PORT: process.env.E2E_APP_PORT || '18082', DATABASE_PATH: path.join(databaseDir, 'e2e.db'), ACCOUNT_MANAGER_BASE_URL: `http://127.0.0.1:${fixturePort}`, VIDEO_CLOUD_PROMETHEUS_BASE_URL: prometheusBaseURL, CLOUD_LOGGER_ENDPOINT: `http://127.0.0.1:${fixturePort}`, CLOUD_LOGGER_INGEST_TOKEN: 'e2e-log-token', CUSTOMER_PASSWORD_LOGIN_ENABLED: 'true' }, stdio: 'inherit' });
 
 const cleanup = async () => {
   server.kill('SIGTERM');

--- a/web/scripts/e2e-server.mjs
+++ b/web/scripts/e2e-server.mjs
@@ -1,0 +1,31 @@
+import { spawn } from 'node:child_process';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+
+const webRoot = path.resolve(new URL('..', import.meta.url).pathname);
+const repoRoot = path.resolve(webRoot, '..');
+const fixtureDir = process.env.E2E_FIXTURE_DIR || path.join(repoRoot, '.artifacts', 'e2e-fixtures', 'cloud-admin-e2e');
+const databaseDir = await mkdtemp(path.join(os.tmpdir(), 'rtk-cloud-admin-e2e-'));
+const fixture = spawn(process.execPath, [path.join(webRoot, 'scripts', 'e2e-fixture-server.mjs')], { env: { ...process.env, E2E_FIXTURE_DIR: fixtureDir, E2E_FIXTURE_PORT: '0' }, stdio: ['ignore', 'pipe', 'inherit'] });
+const fixturePort = Number(await firstLine(fixture.stdout));
+const server = spawn('go', ['run', './cmd/server'], { cwd: repoRoot, env: { ...process.env, GOWORK: 'off', PORT: process.env.E2E_APP_PORT || '18082', DATABASE_PATH: path.join(databaseDir, 'e2e.db'), ACCOUNT_MANAGER_BASE_URL: `http://127.0.0.1:${fixturePort}`, VIDEO_CLOUD_PROMETHEUS_BASE_URL: `http://127.0.0.1:${fixturePort}`, CLOUD_LOGGER_ENDPOINT: `http://127.0.0.1:${fixturePort}`, CLOUD_LOGGER_INGEST_TOKEN: 'e2e-log-token', CUSTOMER_PASSWORD_LOGIN_ENABLED: 'true' }, stdio: 'inherit' });
+
+const cleanup = async () => {
+  server.kill('SIGTERM');
+  fixture.kill('SIGTERM');
+  await rm(databaseDir, { recursive: true, force: true });
+};
+process.on('SIGINT', async () => { await cleanup(); process.exit(130); });
+process.on('SIGTERM', async () => { await cleanup(); process.exit(143); });
+server.on('exit', async (code) => { await cleanup(); process.exit(code || 0); });
+
+async function firstLine(stream) {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const onData = (chunk) => { buffer += chunk.toString(); const index = buffer.indexOf('\n'); if (index >= 0) { stream.off('data', onData); try { resolve(buffer.slice(0, index)); } catch (error) { reject(error); } } };
+    stream.on('data', onData);
+    stream.on('error', reject);
+  }).then((line) => JSON.parse(line).port);
+}

--- a/web/scripts/generate-e2e-fixture.mjs
+++ b/web/scripts/generate-e2e-fixture.mjs
@@ -1,0 +1,17 @@
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { spawn } from 'node:child_process';
+
+const webRoot = path.resolve(new URL('..', import.meta.url).pathname);
+const repoRoot = path.resolve(webRoot, '..');
+const workspaceRoot = path.resolve(repoRoot, '../..');
+const loadtestRoot = path.join(workspaceRoot, 'loadtests', 'home-100k');
+const scenario = process.env.E2E_SCENARIO || path.join(loadtestRoot, 'scenarios', 'cloud-admin-e2e.json');
+const runID = process.env.E2E_RUN_ID || `cloud-admin-e2e-${new Date().toISOString().replace(/[-:.TZ]/g, '')}`;
+const outDir = process.env.E2E_FIXTURE_DIR || path.join(repoRoot, '.artifacts', 'e2e-fixtures', 'cloud-admin-e2e');
+await mkdir(outDir, { recursive: true });
+
+const args = ['run', './cmd/home-100k', 'generate-e2e-fixture', '--scenario', scenario, '--run-id', runID, '--out', outDir];
+const child = spawn('go', args, { cwd: loadtestRoot, env: { ...process.env, GOWORK: 'off' }, stdio: ['ignore', 'inherit', 'inherit'] });
+child.on('exit', (code, signal) => process.exit(code ?? (signal ? 1 : 0)));

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -258,7 +258,7 @@ function App() {
         }
         setOperations(nextOperations);
         setHealth(nextHealth);
-        if (useAdminApi && active === 'platform-logs') {
+        if (useAdminApi && ['platform-dashboard', 'platform-logs'].includes(active)) {
           const logs = await fetchJSON('/api/admin/service-logs?service=workspace-readiness').catch((err) => ({
             status: 'degraded',
             message: err.message || 'Central service logging is unavailable.',
@@ -627,6 +627,7 @@ function App() {
         }
       }
       await refreshBrandClouds();
+      if (memberError) setError(`Brand Cloud created, but initial admin setup needs attention: ${memberError}`);
       setSelectedBrandCloudId(result.brand_cloud.id);
       setBrandCloudDrawerMode('detail');
       return { brandCloud: result.brand_cloud, memberError };
@@ -1021,7 +1022,7 @@ function App() {
         {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'reports' ? <ReportsPage data={reports} skus={skus?.skus || []} loading={loading} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
         {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'groups' ? <GroupsPage data={groups} loading={loading} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
         {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'access' ? <AccessPage data={access} loading={loading} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
-        {!needsPlatformAccess && active === 'platform-dashboard' ? <PlatformDashboardLanding dashboard={platformDashboard} summary={summary} health={health} operations={operations} /> : null}
+        {!needsPlatformAccess && active === 'platform-dashboard' ? <PlatformDashboardLanding dashboard={platformDashboard} summary={summary} health={health} operations={operations} logs={serviceLogs} /> : null}
         {!needsPlatformAccess && active === 'platform-grafana' ? <PlatformGrafanaView status={platformGrafanaStatus} /> : null}
         {!needsPlatformAccess && active === 'platform-health' ? <PlatformHealth summary={summary} health={health} /> : null}
         {!needsPlatformAccess && active === 'platform-logs' ? <PlatformServiceLogs logs={serviceLogs} loading={loading} /> : null}
@@ -2470,7 +2471,37 @@ function PlatformAccessGate({ active, me }) {
   );
 }
 
-function PlatformDashboardLanding({ dashboard, summary, health, operations }) {
+function platformSourceLabel(status) {
+  const labels = {
+    configured: 'configured',
+    stale: 'stale',
+    empty: 'empty',
+    unavailable: 'unavailable',
+    unconfigured: 'unconfigured',
+  };
+  return labels[String(status || '').toLowerCase()] || 'unknown';
+}
+
+function dashboardSourceStatus(dashboard) {
+  return dashboard?.sources?.prometheus?.source_status || dashboard?.prometheus?.queries?.find((query) => query.source_status)?.source_status || 'unconfigured';
+}
+
+function platformCheckedAt(dashboard) {
+  return dashboard?.sources?.prometheus?.checked_at
+    || dashboard?.panel_sources?.service_metrics?.checked_at
+    || dashboard?.prometheus?.queries?.find((query) => query.checked_at)?.checked_at
+    || '';
+}
+
+function ssoStatusLabel(provider) {
+  if (!provider) return 'SSO unavailable';
+  if (provider.status === 'disabled' || provider.enabled === false && provider.configured) return 'SSO disabled';
+  if (provider.enabled) return 'SSO enabled';
+  if (provider.configured) return 'SSO configured';
+  return 'SSO not configured';
+}
+
+function PlatformDashboardLanding({ dashboard, summary, health, operations, logs }) {
   const source = dashboard?.sources?.prometheus || null;
   const serviceGroups = dashboard?.service_scrape_health || [];
   const serviceExporters = dashboard?.service_exporters || [];
@@ -2528,12 +2559,11 @@ function PlatformDashboardLanding({ dashboard, summary, health, operations }) {
   return (
     <section className="platform-dashboard">
       <div className="platform-dashboard-head">
-        <div className="platform-context-controls" aria-label="Platform dashboard context">
-          <span>Environment <strong>Production</strong></span>
-          <span>Cluster <strong>rtk-prod-eu1</strong></span>
-          <span className="platform-health-chip"><StatusDot value={targetsDown || workloadsDegraded ? 'warning' : 'ok'} />{targetsDown || workloadsDegraded ? 'Attention' : 'Healthy'}</span>
+        <div className="platform-context-controls" aria-label="Platform dashboard status">
+          <span className="platform-health-chip"><StatusDot value={targetsDown || workloadsDegraded || risk.failed_operations ? 'warning' : 'ok'} />{targetsDown || workloadsDegraded || risk.failed_operations ? 'Attention' : 'Healthy'}</span>
+          <span className="platform-source-state">Source: {platformSourceLabel(dashboardSourceStatus(dashboard))}</span>
         </div>
-        <span className="platform-updated"><Icon name="rotate" /> Last updated: now</span>
+        <span className="platform-updated"><Icon name="rotate" /> {platformCheckedAt(dashboard) ? `Checked ${formatRelativeTime(platformCheckedAt(dashboard))}` : 'Source freshness unavailable'}</span>
       </div>
 
       <section className="platform-kpi-strip">
@@ -2563,6 +2593,7 @@ function PlatformDashboardLanding({ dashboard, summary, health, operations }) {
         <ScrapeHealthPanel groups={serviceGroups} />
         <FootprintPanel rows={footprintRows} />
         <PlatformActivityPanel health={health} />
+        <PlatformIncidentContext logs={logs} />
         <PlatformMetricPanel title="Cross-Service Risk" rows={crossServiceRows} />
         <PlatformMetricPanel title="Business Signals" rows={businessRows} secondary />
         <PlatformMetricPanel title="Infrastructure Health" rows={infrastructureRows} />
@@ -2678,6 +2709,7 @@ function OperationRiskPanel({ risk, operations }) {
           <strong>{risk.dead_lettered_operations}</strong>
         </div>
       </div>
+      <div className="panel-action-row"><a className="inline-action" href="/admin/ops">View all operations <Icon name="arrow-right" /></a></div>
       <OperationList operations={operations} detailed />
     </article>
   );
@@ -2697,6 +2729,38 @@ function PlatformActivityPanel({ health }) {
   );
 }
 
+function PlatformIncidentContext({ logs }) {
+  const events = (logs?.events || []).filter((event) => ['error', 'fatal', 'warn', 'warning'].includes(String(event.level || '').toLowerCase())).slice(0, 5);
+  return (
+    <article className="panel platform-dashboard-panel platform-compact-panel platform-incident-panel">
+      <div className="panel-head">
+        <div>
+          <h2>Recent Incident Context</h2>
+          <p>Recent log events that help explain degraded platform state.</p>
+        </div>
+        <a className="inline-action" href="/admin/logs">View service logs <Icon name="arrow-up-right-from-square" /></a>
+      </div>
+      {logs?.message ? <p className="source-note">{logs.message}</p> : null}
+      {events.length ? (
+        <div className="incident-list">
+          {events.map((event) => (
+            <article className="incident-row" key={event.event_id || `${event.ts}-${event.msg}`}>
+              <StatusDot value="warning" />
+              <div>
+                <strong>{event.msg || 'Service event'}</strong>
+                <span>{[event.service, event.level, event.trace_id || event.request_id].filter(Boolean).join(' · ')}</span>
+              </div>
+              <time>{event.ts ? formatRelativeTime(event.ts) : '-'}</time>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="empty-state compact-empty">No recent warning or error log events.</p>
+      )}
+    </article>
+  );
+}
+
 function ServiceMetricsTable({ metrics, source }) {
   return (
     <article className="panel platform-dashboard-panel server-resource-panel">
@@ -2705,6 +2769,7 @@ function ServiceMetricsTable({ metrics, source }) {
           <h2>Service Health</h2>
           <p>Current k8s service target health and basic runtime metrics. Long-term trends live in Grafana.</p>
         </div>
+        <a className="inline-action" href="/admin/health">View service health <Icon name="arrow-right" /></a>
       </div>
       <div className="server-resource-table-wrap">
         <table className="server-resource-table service-metrics-table">
@@ -2751,6 +2816,7 @@ function WorkloadHealthTable({ workloads, source }) {
           <h2>K8s Workloads</h2>
           <p>Deployment replica, pod readiness, restart, and crashloop status.</p>
         </div>
+        <a className="inline-action" href="/admin/health">View workload health <Icon name="arrow-right" /></a>
       </div>
       <div className="server-resource-table-wrap">
         <table className="server-resource-table workload-health-table">
@@ -2799,6 +2865,7 @@ function ClusterNodeSummary({ nodes, source }) {
           <h2>Cluster Nodes</h2>
           <p>Current k8s node readiness and resource snapshot.</p>
         </div>
+        <a className="inline-action" href="/admin/health">View service health <Icon name="arrow-right" /></a>
       </div>
       <div className="server-resource-table-wrap">
         <table className="server-resource-table cluster-node-table">
@@ -3181,6 +3248,7 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
     displayName: '',
     role: 'owner',
   });
+  const [step, setStep] = useState(1);
   const [submitting, setSubmitting] = useState(false);
   const [message, setMessage] = useState('');
 
@@ -3193,6 +3261,18 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
     setMessage('');
     if (!form.name.trim()) {
       setMessage('Brand display name is required.');
+      return;
+    }
+    if (step < 3) {
+      if (step === 2 && form.initialMode === 'existing' && !form.userId.trim()) {
+        setMessage('Existing Brand User id is required.');
+        return;
+      }
+      if (step === 2 && form.initialMode === 'create' && (!form.email.trim() || !form.password.trim())) {
+        setMessage('Initial admin email and password are required.');
+        return;
+      }
+      setStep((current) => current + 1);
       return;
     }
     if (form.initialMode === 'existing' && !form.userId.trim()) {
@@ -3241,30 +3321,52 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
           </div>
           <button type="button" className="drawer-close" onClick={onClose} aria-label="Close Brand Cloud drawer">x</button>
         </div>
+        <div className="brand-cloud-stepper" aria-label="Create Brand Cloud steps">
+          {['Identity', 'Initial Admin', 'Review'].map((label, index) => <span className={step === index + 1 ? 'active' : step > index + 1 ? 'complete' : ''} key={label}>{index + 1}. {label}</span>)}
+        </div>
         <form className="drawer-form" onSubmit={submit}>
-          <label>Brand display name<input className="input" value={form.name} onChange={(event) => update('name', event.target.value)} /></label>
-          <div className="form-grid">
-            <label>Region<input className="input" value={form.region} onChange={(event) => update('region', event.target.value)} placeholder="Optional" /></label>
-            <label>Tier<select className="input" value={form.tier} onChange={(event) => update('tier', event.target.value)}><option>Evaluation</option><option>Commercial</option></select></label>
-          </div>
-          <label>Initial admin mode<select className="input" value={form.initialMode} onChange={(event) => update('initialMode', event.target.value)}>
-            <option value="none">Assign later</option>
-            <option value="existing">Assign existing Brand User id</option>
-            <option value="create">Create or reactivate brand user</option>
-          </select></label>
-          {form.initialMode === 'existing' ? <label>Brand User id<input className="input" value={form.userId} onChange={(event) => update('userId', event.target.value)} /></label> : null}
-          {form.initialMode === 'create' ? (
+          {step === 1 ? (
             <>
-              <label>Email<input className="input" type="email" value={form.email} onChange={(event) => update('email', event.target.value)} /></label>
-              <label>Temporary password<input className="input" type="password" value={form.password} onChange={(event) => update('password', event.target.value)} /></label>
-              <label>Display name<input className="input" value={form.displayName} onChange={(event) => update('displayName', event.target.value)} /></label>
+              <label>Brand display name<input className="input" value={form.name} onChange={(event) => update('name', event.target.value)} /></label>
+              <div className="form-grid">
+                <label>Region<input className="input" value={form.region} onChange={(event) => update('region', event.target.value)} placeholder="Optional" /></label>
+                <label>Tier<select className="input" value={form.tier} onChange={(event) => update('tier', event.target.value)}><option>Evaluation</option><option>Commercial</option></select></label>
+              </div>
+              <p className="source-note">Organization kind is fixed as <code>brand_cloud</code>.</p>
             </>
           ) : null}
-          {form.initialMode !== 'none' ? <label>Role<select className="input" value={form.role} onChange={(event) => update('role', event.target.value)}><option value="owner">Owner</option><option value="admin">Admin</option><option value="member">Member</option></select></label> : null}
+          {step === 2 ? (
+            <>
+              <label>Initial admin mode<select className="input" value={form.initialMode} onChange={(event) => update('initialMode', event.target.value)}>
+                <option value="none">Assign later</option>
+                <option value="existing">Assign existing Brand User id</option>
+                <option value="create">Create or reactivate brand user</option>
+              </select></label>
+              {form.initialMode === 'existing' ? <label>Brand User id<input className="input" value={form.userId} onChange={(event) => update('userId', event.target.value)} /></label> : null}
+              {form.initialMode === 'create' ? (
+                <>
+                  <label>Email<input className="input" type="email" value={form.email} onChange={(event) => update('email', event.target.value)} /></label>
+                  <label>Temporary password<input className="input" type="password" value={form.password} onChange={(event) => update('password', event.target.value)} /></label>
+                  <label>Display name<input className="input" value={form.displayName} onChange={(event) => update('displayName', event.target.value)} /></label>
+                </>
+              ) : null}
+              {form.initialMode !== 'none' ? <label>Role<select className="input" value={form.role} onChange={(event) => update('role', event.target.value)}><option value="owner">Owner</option><option value="admin">Admin</option><option value="member">Member</option></select></label> : null}
+            </>
+          ) : null}
+          {step === 3 ? (
+            <section className="drawer-summary create-review-summary">
+              <h3>Review</h3>
+              <div><span>Brand</span><strong>{form.name}</strong></div>
+              <div><span>Tier</span><strong>{form.tier}</strong></div>
+              <div><span>Initial admin</span><strong>{form.initialMode === 'none' ? 'Assign later' : form.initialMode === 'existing' ? form.userId : form.email}</strong></div>
+              <p className="source-note">Quota and SSO setup can be completed after creation.</p>
+            </section>
+          ) : null}
           {message ? <p className="form-message">{message}</p> : null}
           <div className="drawer-actions">
             <button type="button" className="ghost-button" onClick={onClose}>Cancel</button>
-            <button type="submit" className="primary-button" disabled={submitting}>{submitting ? 'Creating...' : 'Create Brand Cloud'}</button>
+            {step > 1 ? <button type="button" className="ghost-button" onClick={() => setStep((current) => current - 1)} disabled={submitting}>Back</button> : null}
+            <button type="submit" className="primary-button" disabled={submitting}>{submitting ? 'Creating...' : step < 3 ? 'Continue' : 'Create Brand Cloud'}</button>
           </div>
         </form>
       </aside>
@@ -3273,17 +3375,36 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
 }
 
 function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember, onCreateUser }) {
+  const [detailBrand, setDetailBrand] = useState(brand);
+  const [ssoProvider, setSSOProvider] = useState(null);
+  const [detailSource, setDetailSource] = useState({ status: 'loading', message: '' });
   const [member, setMember] = useState({ brand_cloud_user_id: '', role: 'owner' });
   const [user, setUser] = useState({ email: '', password: '', display_name: '', role: 'admin' });
   const [users, setUsers] = useState([]);
   const [userFilter, setUserFilter] = useState('all');
   const [usersSource, setUsersSource] = useState({ status: 'loading', message: '' });
   const [message, setMessage] = useState('');
-  const disabled = brandCloudStatusKey(brand) === 'disabled';
-  const owner = brandCloudOwner(brand);
+  const disabled = brandCloudStatusKey(detailBrand) === 'disabled';
+  const owner = brandCloudOwner(detailBrand);
   const pendingUsers = users.filter((row) => brandCloudUserStatus(row).key === 'pending_verification').length;
   const disabledUsers = users.filter((row) => brandCloudUserStatus(row).key === 'disabled').length;
   const activeUsers = users.filter((row) => brandCloudUserStatus(row).key === 'active').length;
+
+  async function loadDetail() {
+    setDetailSource({ status: 'loading', message: '' });
+    try {
+      const [detailResult, ssoResult] = await Promise.all([
+        fetchJSON(`/api/admin/brand-clouds/${encodeURIComponent(brand.id)}`),
+        fetchJSON(`/api/admin/orgs/${encodeURIComponent(brand.id)}/sso-provider`).catch(() => ({ provider: null })),
+      ]);
+      setDetailBrand(detailResult.brand_cloud || brand);
+      setSSOProvider(ssoResult.provider || null);
+      setDetailSource({ status: 'ready', message: '' });
+    } catch (err) {
+      setDetailBrand(brand);
+      setDetailSource({ status: 'unavailable', message: userFacingBrandCloudError(err) });
+    }
+  }
 
   async function loadUsers(nextFilter = userFilter) {
     setUsersSource({ status: 'loading', message: '' });
@@ -3301,6 +3422,7 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
   }
 
   useEffect(() => {
+    loadDetail();
     loadUsers('all');
   }, [brand.id]);
 
@@ -3312,7 +3434,8 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
   async function updateStatus(nextStatus) {
     setMessage('');
     try {
-      await onUpdateBrand(brand.id, { name: brand.name, status: nextStatus });
+      const updated = await onUpdateBrand(brand.id, { name: detailBrand.name, status: nextStatus });
+      setDetailBrand(updated || { ...detailBrand, status: nextStatus });
       setMessage(nextStatus === 'disabled' ? 'Brand Cloud disabled.' : 'Brand Cloud enabled.');
     } catch (err) {
       setMessage(err.message);
@@ -3385,29 +3508,30 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
       <aside className="drawer-panel brand-cloud-drawer" role="dialog" aria-modal="true" aria-label="Brand Cloud detail" onClick={(event) => event.stopPropagation()}>
         <div className="drawer-header">
           <div>
-            <h2>{brand.name || brand.id}</h2>
-            <p>{brand.id} / {brand.organization_kind || 'brand_cloud'}</p>
+            <h2>{detailBrand.name || detailBrand.id}</h2>
+            <p>{detailBrand.id} / {detailBrand.organization_kind || 'brand_cloud'}</p>
           </div>
           <button type="button" className="drawer-close" onClick={onClose} aria-label="Close Brand Cloud drawer">x</button>
         </div>
-        <section className={`brand-cloud-detail-hero brand-cloud-detail-${brandCloudStatusKey(brand)}`}>
+        {detailSource.status === 'unavailable' ? <p className="form-message">{detailSource.message}</p> : null}
+        <section className={`brand-cloud-detail-hero brand-cloud-detail-${brandCloudStatusKey(detailBrand)}`}>
           <div className="brand-cloud-status-block">
             <StatusBadge value={brandCloudStatusKey(brand)} label={brandCloudStatusLabel(brand)} />
-            <strong>{brand.name || brand.metadata?.brandname || brand.id}</strong>
-            <small>{brand.id}</small>
+            <strong>{detailBrand.name || detailBrand.metadata?.brandname || detailBrand.id}</strong>
+            <small>{detailBrand.id}</small>
           </div>
           <div className="brand-cloud-fact-grid">
-            <div><Icon name="location-dot" /><span>Region</span><strong>{brandCloudRegion(brand)}</strong></div>
-            <div><Icon name="layer-group" /><span>Tier</span><strong>{brandCloudTier(brand)}</strong></div>
+            <div><Icon name="location-dot" /><span>Region</span><strong>{brandCloudRegion(detailBrand)}</strong></div>
+            <div><Icon name="layer-group" /><span>Tier</span><strong>{brandCloudTier(detailBrand)}</strong></div>
             <div><Icon name="user-shield" /><span>Owner/Admin</span><strong>{owner || 'Unassigned'}</strong></div>
-            <div><Icon name="video" /><span>Devices</span><strong>{brandCloudQuotaLabel(brand)}</strong></div>
+            <div><Icon name="video" /><span>Devices</span><strong>{brandCloudQuotaLabel(detailBrand)}</strong></div>
           </div>
         </section>
         <section className="setup-list brand-cloud-setup-list" aria-label="Brand Cloud setup state">
           <span className="ok"><Icon name="circle-check" />Created</span>
           <span className={owner ? 'ok' : 'warn'}><Icon name={owner ? 'user-check' : 'user-clock'} />{owner ? 'Owner assigned' : 'Owner pending'}</span>
-          <span className="neutral"><Icon name="key" />SSO unavailable</span>
-          <span className="neutral"><Icon name="database" />{brand.updated_at ? `Updated ${formatRelativeTime(brand.updated_at)}` : 'No update time'}</span>
+          <span className={ssoProvider?.configured || ssoProvider?.enabled ? 'ok' : 'warn'}><Icon name="key" />{ssoStatusLabel(ssoProvider)}</span>
+          <span className="neutral"><Icon name="database" />{detailBrand.updated_at ? `Updated ${formatRelativeTime(detailBrand.updated_at)}` : 'No update time'}</span>
         </section>
         <section className="drawer-summary brand-cloud-summary">
           <article>
@@ -3435,7 +3559,7 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
           <button type="button" className="ghost-button" onClick={() => updateStatus(disabled ? 'active' : 'disabled')}>
             <Icon name={disabled ? 'rotate-right' : 'ban'} />{disabled ? 'Re-enable Brand Cloud' : 'Disable Brand Cloud'}
           </button>
-          <a className="inline-action action-link" href={`/admin/sso?org=${encodeURIComponent(brand.id)}`}>
+            <a className="inline-action action-link" href={`/admin/sso?org=${encodeURIComponent(detailBrand.id)}`}>
             <Icon name="key" />Open SSO Providers
           </a>
         </div>

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -442,7 +442,7 @@ function App() {
           setStreamStats(null);
           setRecentAlerts([]);
         }
-        if (alive) setError(err.message);
+        if (alive) setError(active === 'platform-brand-clouds' ? userFacingBrandCloudError(err) : err.message);
       } finally {
         if (alive) setLoading(false);
       }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -970,6 +970,99 @@ p {
   margin: 3px 0 0;
 }
 
+.platform-dashboard-panel .panel-head .inline-action {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
+.platform-source-state {
+  color: #667085;
+  font-size: 12px;
+}
+
+.platform-incident-panel {
+  grid-column: span 2;
+}
+
+.incident-list {
+  display: grid;
+}
+
+.incident-row {
+  align-items: center;
+  border-bottom: 1px solid #e6e8ec;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  padding: 10px 14px;
+}
+
+.incident-row strong,
+.incident-row span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.incident-row strong {
+  color: #1d2939;
+  font-size: 12px;
+}
+
+.incident-row span,
+.incident-row time {
+  color: #667085;
+  font-size: 11px;
+}
+
+.panel-action-row {
+  display: flex;
+  justify-content: flex-end;
+  padding: 8px 14px 0;
+}
+
+.brand-cloud-stepper {
+  border-bottom: 1px solid var(--line);
+  display: grid;
+  gap: 8px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 14px 20px 0;
+}
+
+.brand-cloud-stepper span {
+  border-bottom: 3px solid #d0d5dd;
+  color: #667085;
+  font-size: 11px;
+  font-weight: 700;
+  padding: 0 0 8px;
+}
+
+.brand-cloud-stepper span.active {
+  border-color: #0674c2;
+  color: #0674c2;
+}
+
+.brand-cloud-stepper span.complete {
+  border-color: #16a34a;
+  color: #15803d;
+}
+
+.create-review-summary {
+  display: grid;
+  gap: 10px;
+}
+
+.create-review-summary h3 {
+  margin: 0;
+}
+
+.create-review-summary div {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+}
+
 .server-resource-table-wrap {
   overflow-x: auto;
 }


### PR DESCRIPTION
## What changed

- Implemented the management-first Platform Dashboard using existing Prometheus-backed BFF data.
- Added source-state/freshness rendering, recent incident log context, and Service Health/Operations/Logs links.
- Removed dashboard environment/cluster/last-updated literals from the UI.
- Added fresh Brand Cloud detail reads for organization, SSO, and users.
- Replaced Brand Cloud creation with Identity, Initial Admin, and Review steps.
- Added partial setup failure handling and safe user-facing errors.
- Added local audit records with request/operation correlation for Brand Cloud management actions.
- Updated design, API-gap, roadmap, and README documentation.

## Validation

- `GOWORK=off go test ./...`
- `npm test` (67 tests)
- `npm run build`
- `npm run browser:smoke`
- `git diff --check`
