### PR TITLE
test: isolate chipset flow retries

### DIFF
--- a/web/e2e/chipset-sdk.spec.mjs
+++ b/web/e2e/chipset-sdk.spec.mjs
@@ -57,8 +57,8 @@ test('[UI-CA-CHIPSET-003] provider and developer pages expose upstream unavailab
   await expect(page.getByRole('heading', { name: '資源暫時無法取得' })).toBeVisible();
 });
 
-test('[UI-CA-CHIPSET-004] provider publish, refresh, stale fallback, and unpublish flow @chipset-sdk @smoke', async ({ page }) => {
-  const providerName = 'Ameba IoT Qualification Candidate';
+test('[UI-CA-CHIPSET-004] provider publish, refresh, stale fallback, and unpublish flow @chipset-sdk @smoke', async ({ page }, testInfo) => {
+  const providerName = `Ameba IoT Qualification Candidate attempt-${testInfo.retry}`;
   const shellResponses = new Map([
     ['/api/admin/summary', {}], ['/api/admin/customers', []], ['/api/admin/devices', []],
     ['/api/admin/operations', []], ['/api/admin/service-health', []], ['/api/admin/audit', []],


### PR DESCRIPTION
## Summary
- suffix the chipset provider fixture with the Playwright retry index
- prevent retry attempts from matching state left by an earlier aborted attempt

## Evidence
The first attempt in workspace run 30111713163 was retried after a transient `page.goto` abort. The retry created a second provider with the same name, causing strict locator failure.

## Validation
- `node --check web/e2e/chipset-sdk.spec.mjs`
- Cloud Admin web unit tests: 71 PASS