### PR TITLE
Support email verification links and live activation E2E

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Implemented in this first version:
 - explicit SQLite schema migrations tracked in `schema_migrations`
 - URL routes for `/console`, `/console/customers`, `/console/devices`,
   `/console/operations`, `/console/audit`, and `/admin`
+- public email verification routes `/verify` and the mail-contract-compatible
+  `/signup/verify` alias
 - native release packaging and GitHub Actions CI
 - shared frontend style contract in `docs/rtk_cloud_contracts_doc/FRONTEND_STYLE.md`
 - local Realtek logo asset copied from the Realtek Connect+ marketing site

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -367,6 +367,8 @@ func (s *Server) routes() {
 		"/reset-password",
 		"/signup",
 		"/signup/check-email",
+		"/signup/verify",
+		"/signup/verify/",
 		"/verify",
 		"/console",
 		"/console/overview",
@@ -887,7 +889,7 @@ func (s *Server) apiCustomerVerifyEmail(w http.ResponseWriter, r *http.Request) 
 	}
 	result, err := s.accountClient.VerifyEmail(r.Context(), body.Token)
 	if err != nil {
-		s.writeCustomerError(w, err)
+		s.writeAuthProxyError(w, err)
 		return
 	}
 	if result.Tokens.AccessToken != "" {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -142,6 +142,12 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 		case "/v1/auth/signup":
 			_, _ = w.Write([]byte(`{"user":{"id":"u-signup","email":"signup@example.com","name":"Signup User"},"organization":{"id":"org-1","name":"Acme Eval","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
 		case "/v1/auth/verify-email":
+			var body accountclient.AuthTokenRequest
+			_ = json.NewDecoder(r.Body).Decode(&body)
+			if body.Token == "consumed-token" {
+				http.Error(w, "Invalid or expired verification token", http.StatusBadRequest)
+				return
+			}
 			_, _ = w.Write([]byte(`{"user":{"id":"u-signup","email":"signup@example.com","name":"Signup User"},"tokens":{"access_token":"access-1","refresh_token":"refresh-1","expires_in":3600}}`))
 		case "/v1/auth/resend-verification":
 			w.WriteHeader(http.StatusAccepted)
@@ -167,7 +173,7 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
-	for _, path := range []string{"/login", "/signup", "/signup/check-email", "/verify"} {
+	for _, path := range []string{"/login", "/signup", "/signup/check-email", "/signup/verify", "/signup/verify/", "/verify"} {
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 		if rec.Code != http.StatusOK {
@@ -199,6 +205,12 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 		t.Fatalf("verify did not set a session cookie")
 	}
 	sessionCookie := verifyRec.Result().Cookies()[0]
+
+	replayRec := httptest.NewRecorder()
+	srv.ServeHTTP(replayRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"consumed-token"}`)))
+	if replayRec.Code != http.StatusBadRequest {
+		t.Fatalf("replayed verification status = %d, want 400; body=%s", replayRec.Code, replayRec.Body.String())
+	}
 
 	meRec := httptest.NewRecorder()
 	meReq := httptest.NewRequest(http.MethodGet, "/api/me", nil)

--- a/web/e2e/chipset-sdk.spec.mjs
+++ b/web/e2e/chipset-sdk.spec.mjs
@@ -101,7 +101,8 @@ test('[UI-CA-CHIPSET-004] provider publish, refresh, stale fallback, and unpubli
   await expect(page.getByRole('heading', { level: 2, name: 'ChipSet & SDK' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'AmebaPro2' }).first()).toBeVisible();
   await expect(page.getByText('Ameba Arduino Pro2 · 1.0.0')).toBeVisible();
-  await expect(page.getByText('Recommended', { exact: true })).toBeVisible();
+  const initialRelease = page.locator('.sdk-release').filter({ hasText: 'Ameba Arduino Pro2 · 1.0.0' });
+  await expect(initialRelease.getByText('Recommended', { exact: true })).toBeVisible();
   await expect(page.getByText('AMB82-Mini')).toBeVisible();
   await expect(page.getByRole('link', { name: /Ameba Arduino Pro2 GitHub/ })).toHaveAttribute('target', '_blank');
   await expect(page.getByRole('link', { name: /Get ambpro2 SDK/ })).toHaveAttribute('href', 'https://github.com/Freertos-kvs-LTS/ambpro2_sdk');

--- a/web/package.json
+++ b/web/package.json
@@ -3,6 +3,7 @@
     "dev": "vite --host 127.0.0.1",
     "test": "node --test src/*.test.mjs",
     "browser:smoke": "node scripts/browser-smoke.mjs",
+    "e2e:email-signup-live": "node scripts/email-signup-live-e2e.mjs",
     "e2e:generate-fixture": "node scripts/generate-e2e-fixture.mjs",
     "e2e": "npm run e2e:desktop && npm run e2e:mobile",
     "e2e:desktop": "E2E_UI_TARGET=desktop playwright test --project=chromium",

--- a/web/scripts/email-signup-live-e2e.mjs
+++ b/web/scripts/email-signup-live-e2e.mjs
@@ -1,0 +1,150 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { chromium } from 'playwright';
+
+const execFileAsync = promisify(execFile);
+const baseURL = requiredEnv('EMAIL_E2E_ADMIN_BASE_URL').replace(/\/$/, '');
+const accountManagerBaseURL = requiredEnv('EMAIL_E2E_ACCOUNT_MANAGER_BASE_URL').replace(/\/$/, '');
+const emailAddress = requiredEnv('IMAP_EMAIL_ADDR');
+const password = requiredEnv('EMAIL_E2E_SIGNUP_PASSWORD');
+const imapHelper = requiredEnv('EMAIL_E2E_IMAP_HELPER');
+const python = process.env.PYTHON || 'python3';
+
+const snapshot = await runIMAP('snapshot');
+if (!Number.isInteger(snapshot.uid_next) || snapshot.uid_next < 1) {
+  throw new Error('IMAP snapshot did not return a valid UIDNEXT');
+}
+
+const browser = await chromium.launch().catch(() => chromium.launch({ channel: 'chrome' }));
+let delivered;
+try {
+  const signupContext = await browser.newContext();
+  const signupPage = await signupContext.newPage();
+  await signupPage.goto(`${baseURL}/signup`, { waitUntil: 'networkidle' });
+  await signupPage.getByLabel('Email', { exact: true }).fill(emailAddress);
+  await signupPage.getByLabel('Password', { exact: true }).fill(password);
+  await signupPage.getByLabel('Organization name', { exact: true }).fill('Local Email E2E');
+  await signupPage.getByLabel('Display name', { exact: true }).fill('Local Email E2E');
+  await signupPage.getByLabel('I accept the evaluation-tier terms.').check();
+  await signupPage.getByRole('button', { name: 'Create account' }).click();
+  await signupPage.waitForURL(/\/signup\/check-email(?:\?|$)/, { timeout: 30_000 });
+  await signupPage.getByText('We sent a verification link', { exact: false }).waitFor();
+  await signupContext.close();
+
+  delivered = await runIMAP(
+    'wait',
+    '--uid-start',
+    String(snapshot.uid_next),
+    '--timeout',
+    process.env.EMAIL_E2E_IMAP_TIMEOUT || '180',
+  );
+  validateDelivery(delivered);
+
+  const verifyContext = await browser.newContext();
+  const verifyPage = await verifyContext.newPage();
+  await verifyPage.goto(delivered.url, { waitUntil: 'networkidle' });
+  await verifyPage.waitForURL(/\/console\/overview(?:\?|$)/, { timeout: 30_000 });
+  const sessionCookies = await verifyContext.cookies(baseURL);
+  if (!sessionCookies.some((cookie) => cookie.name === 'rtk_admin_session' && cookie.httpOnly)) {
+    throw new Error('verification did not establish an HTTP-only Admin Console session');
+  }
+  const meResponse = await verifyPage.request.get(`${baseURL}/api/me`);
+  if (!meResponse.ok()) {
+    throw new Error(`verified Admin Console session returned HTTP ${meResponse.status()}`);
+  }
+  await verifyContext.close();
+
+  const loginResponse = await fetch(`${accountManagerBaseURL}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: emailAddress, password }),
+  });
+  if (!loginResponse.ok) {
+    throw new Error(`verified account login returned HTTP ${loginResponse.status}`);
+  }
+  const loginBody = await loginResponse.json();
+  if (!loginBody.user?.email_verified || loginBody.user?.signup_pending_verification) {
+    throw new Error('verified account state is inconsistent');
+  }
+  if (!loginBody.tokens?.access_token || !loginBody.tokens?.refresh_token) {
+    throw new Error('verified account login did not issue tokens');
+  }
+
+  const passwordContext = await browser.newContext();
+  const passwordPage = await passwordContext.newPage();
+  await passwordPage.goto(`${baseURL}/login`, { waitUntil: 'networkidle' });
+  await passwordPage.getByLabel('Email', { exact: true }).fill(emailAddress);
+  await passwordPage.getByLabel('Password', { exact: true }).fill(password);
+  await passwordPage.getByRole('button', { name: 'Login', exact: true }).click();
+  await passwordPage.waitForURL(/\/console\/overview(?:\?|$)/, { timeout: 30_000 });
+  await passwordContext.close();
+
+  const replayContext = await browser.newContext();
+  const replayPage = await replayContext.newPage();
+  const replayResponsePromise = replayPage.waitForResponse((response) => (
+    response.request().method() === 'POST' &&
+    new URL(response.url()).pathname === '/api/auth/customer/verify-email'
+  ));
+  await replayPage.goto(delivered.url, { waitUntil: 'networkidle' });
+  const replayResponse = await replayResponsePromise;
+  if (replayResponse.status() !== 400) {
+    throw new Error(`replayed verification token returned HTTP ${replayResponse.status()}`);
+  }
+  const replayError = replayPage.locator('.error').first();
+  await replayError.waitFor({ state: 'visible', timeout: 30_000 });
+  const replayErrorText = await replayError.innerText();
+  if (!/invalid|expired/i.test(replayErrorText) || replayErrorText.includes(new URL(delivered.url).searchParams.get('token'))) {
+    throw new Error('replayed verification error was missing or exposed the token');
+  }
+  await replayContext.close();
+} finally {
+  await browser.close();
+}
+
+console.log(`Local SMTP + IMAP signup E2E passed (IMAP UID ${delivered.uid}).`);
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function runIMAP(...args) {
+  try {
+    const { stdout } = await execFileAsync(python, [imapHelper, ...args], {
+      env: process.env,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024,
+      timeout: 210_000,
+    });
+    return JSON.parse(stdout);
+  } catch (error) {
+    const detail = String(error?.stderr || '')
+      .replace(/[\r\n]+/g, ' ')
+      .trim()
+      .slice(0, 300);
+    throw new Error(`IMAP ${args[0]} step failed${detail ? `: ${detail}` : ''}`);
+  }
+}
+
+function validateDelivery(result) {
+  if (
+    !result?.url ||
+    !Number.isInteger(result.uid) ||
+    !result.message_id_present ||
+    !result.multipart_alternative ||
+    !result.text_part_present ||
+    !result.html_part_present
+  ) {
+    throw new Error('received verification email did not satisfy MIME requirements');
+  }
+  const parsed = new URL(result.url);
+  const expected = new URL(baseURL);
+  if (
+    parsed.origin !== expected.origin ||
+    parsed.pathname.replace(/\/$/, '') !== '/signup/verify' ||
+    !parsed.searchParams.get('token')
+  ) {
+    throw new Error('verification email URL did not match the local Admin Console');
+  }
+}

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -86,6 +86,7 @@ export function routeFromPath(path) {
   if (path === '/reset-password' || path.startsWith('/reset-password/')) return 'reset-password';
   if (path === '/signup' || path === '/signup/') return 'signup';
   if (path === '/signup/check-email' || path.startsWith('/signup/check-email/')) return 'signup-check-email';
+  if (path === '/signup/verify' || path.startsWith('/signup/verify/')) return 'verify';
   if (path === '/verify' || path.startsWith('/verify/')) return 'verify';
   if (path === '/admin' || path === '/admin/') return 'platform-dashboard';
   if (path === '/admin/grafana' || path.startsWith('/admin/grafana/')) return 'platform-grafana';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -38,6 +38,8 @@ test('maps public signup paths to auth routes', () => {
   assert.equal(routeFromPath('/signup'), 'signup');
   assert.equal(routeFromPath('/signup/check-email'), 'signup-check-email');
   assert.equal(routeFromPath('/signup/check-email/inbox'), 'signup-check-email');
+  assert.equal(routeFromPath('/signup/verify'), 'verify');
+  assert.equal(routeFromPath('/signup/verify/'), 'verify');
   assert.equal(routeFromPath('/verify'), 'verify');
   assert.equal(routeFromPath('/verify/token-1'), 'verify');
 });


### PR DESCRIPTION
## Summary

- support the existing `/signup/verify` email-link contract as an alias of the verification view
- preserve upstream auth 400 responses so consumed verification links render a safe invalid/expired state instead of a 502
- add the Playwright portion of the opt-in local SMTP + IMAP signup activation E2E

## Why

Account Manager verification messages already link to `/signup/verify`, while the Admin Console only recognized `/verify`. In addition, the generic customer error mapper converted token replay failures into gateway errors.

## Impact

Users can open verification links directly, receive an authenticated session after successful activation, and see the correct safe error when a one-time link is reused.

The live E2E script is not included in normal CI and only runs when invoked by the Account Manager local harness.

## Validation

- `go test ./... -count=1`
- 71 Node route/helper tests
- frontend production build
- real local SMTP + IMAP + Playwright account activation E2E
- verification token replay returns HTTP 400 and renders a redacted error
- `go vet ./...`
- `git diff --check`