### PR TITLE
test: make staging operations heading exact

### DIFF
--- a/web/e2e/staging.spec.mjs
+++ b/web/e2e/staging.spec.mjs
@@ -5,6 +5,6 @@ test('[UI-CA-STAGING-001] staging platform admin can read operations @staging', 
   test.skip(!process.env.E2E_BASE_URL, 'staging base URL is required');
   await loginWithStagingSession(page);
   await page.goto('/admin/ops');
-  await expect(page.getByRole('heading', { name: /Operations/i })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Operations', exact: true })).toBeVisible();
   await expect(page.getByRole('button', { name: /Platform Dashboard/i })).toBeVisible();
 });


### PR DESCRIPTION
Avoids matching the Lifecycle operations subheading, removing retry-only staging smoke success.