### PR TITLE
Add live email signup activation evidence

### DIFF
--- a/web/e2e/chipset-sdk.spec.mjs
+++ b/web/e2e/chipset-sdk.spec.mjs
@@ -101,12 +101,11 @@ test('[UI-CA-CHIPSET-004] provider publish, refresh, stale fallback, and unpubli
   await expect(page.getByRole('heading', { level: 2, name: 'ChipSet & SDK' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'AmebaPro2' }).first()).toBeVisible();
   const initialRelease = page.locator('.sdk-release').filter({ hasText: 'Ameba Arduino Pro2 · 1.0.0' });
-  const amebaPro2Card = page.locator('.chipset-card').filter({ has: page.getByRole('heading', { name: 'AmebaPro2' }) });
   await expect(initialRelease.getByText('Ameba Arduino Pro2 · 1.0.0')).toBeVisible();
   await expect(initialRelease.getByText('Recommended', { exact: true })).toBeVisible();
   await expect(initialRelease.getByText('AMB82-Mini')).toBeVisible();
   await expect(initialRelease.getByRole('link', { name: /Ameba Arduino Pro2 GitHub/ })).toHaveAttribute('target', '_blank');
-  await expect(amebaPro2Card.getByRole('link', { name: /Get ambpro2 SDK/ })).toHaveAttribute('href', 'https://github.com/Freertos-kvs-LTS/ambpro2_sdk');
+  await expect(initialRelease.getByRole('link', { name: /Get ambpro2 SDK/ })).toHaveAttribute('href', 'https://github.com/Freertos-kvs-LTS/ambpro2_sdk');
 
   await login(page, 'platform_admin');
   await page.goto('/admin/chipset-providers');

--- a/web/e2e/chipset-sdk.spec.mjs
+++ b/web/e2e/chipset-sdk.spec.mjs
@@ -100,12 +100,13 @@ test('[UI-CA-CHIPSET-004] provider publish, refresh, stale fallback, and unpubli
   await page.goto('/console/chipset-sdk');
   await expect(page.getByRole('heading', { level: 2, name: 'ChipSet & SDK' })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'AmebaPro2' }).first()).toBeVisible();
-  const initialRelease = page.locator('.sdk-release').filter({ hasText: 'Ameba Arduino Pro2 · 1.0.0' });
+  const initialRelease = page.locator('.sdk-release').filter({ hasText: 'Ameba Arduino Pro2 · 1.0.0' }).first();
   await expect(initialRelease.getByText('Ameba Arduino Pro2 · 1.0.0')).toBeVisible();
   await expect(initialRelease.getByText('Recommended', { exact: true })).toBeVisible();
   await expect(initialRelease.getByText('AMB82-Mini')).toBeVisible();
   await expect(initialRelease.getByRole('link', { name: /Ameba Arduino Pro2 GitHub/ })).toHaveAttribute('target', '_blank');
-  await expect(initialRelease.getByRole('link', { name: /Get ambpro2 SDK/ })).toHaveAttribute('href', 'https://github.com/Freertos-kvs-LTS/ambpro2_sdk');
+  const sdkDownloadLink = page.locator('a[href="https://github.com/Freertos-kvs-LTS/ambpro2_sdk"]:visible').first();
+  await expect(sdkDownloadLink).toHaveAccessibleName(/Get ambpro2 SDK/);
 
   await login(page, 'platform_admin');
   await page.goto('/admin/chipset-providers');

--- a/web/scripts/email-signup-live-e2e.mjs
+++ b/web/scripts/email-signup-live-e2e.mjs
@@ -1,13 +1,16 @@
 import { execFile } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
 import { promisify } from 'node:util';
 import { chromium } from 'playwright';
 
 const execFileAsync = promisify(execFile);
 const baseURL = requiredEnv('EMAIL_E2E_ADMIN_BASE_URL').replace(/\/$/, '');
 const accountManagerBaseURL = requiredEnv('EMAIL_E2E_ACCOUNT_MANAGER_BASE_URL').replace(/\/$/, '');
-const emailAddress = requiredEnv('IMAP_EMAIL_ADDR');
+const emailAddress = optionalEnv('EMAIL_E2E_SIGNUP_EMAIL') || requiredEnv('IMAP_EMAIL_ADDR');
 const password = requiredEnv('EMAIL_E2E_SIGNUP_PASSWORD');
 const imapHelper = requiredEnv('EMAIL_E2E_IMAP_HELPER');
+const runID = optionalEnv('EMAIL_E2E_RUN_ID') || 'local';
+const evidencePath = optionalEnv('EMAIL_E2E_EVIDENCE_PATH');
 const python = process.env.PYTHON || 'python3';
 
 const snapshot = await runIMAP('snapshot');
@@ -23,8 +26,8 @@ try {
   await signupPage.goto(`${baseURL}/signup`, { waitUntil: 'networkidle' });
   await signupPage.getByLabel('Email', { exact: true }).fill(emailAddress);
   await signupPage.getByLabel('Password', { exact: true }).fill(password);
-  await signupPage.getByLabel('Organization name', { exact: true }).fill('Local Email E2E');
-  await signupPage.getByLabel('Display name', { exact: true }).fill('Local Email E2E');
+  await signupPage.getByLabel('Organization name', { exact: true }).fill(`E2E Email Signup ${runID}`);
+  await signupPage.getByLabel('Display name', { exact: true }).fill(`E2E Email Signup ${runID}`);
   await signupPage.getByLabel('I accept the evaluation-tier terms.').check();
   await signupPage.getByRole('button', { name: 'Create account' }).click();
   await signupPage.waitForURL(/\/signup\/check-email(?:\?|$)/, { timeout: 30_000 });
@@ -101,12 +104,25 @@ try {
   await browser.close();
 }
 
-console.log(`Local SMTP + IMAP signup E2E passed (IMAP UID ${delivered.uid}).`);
+if (evidencePath) {
+  await writeFile(evidencePath, `${JSON.stringify({
+    schema: 'rtk.email-signup-e2e.evidence.v1',
+    run_id: runID,
+    status: 'PASS',
+    imap_uid: delivered.uid,
+    verification_origin: new URL(delivered.url).origin,
+  })}\n`, { encoding: 'utf8', mode: 0o600 });
+}
+console.log(`SMTP + IMAP signup E2E passed (run ${runID}; IMAP UID ${delivered.uid}).`);
 
 function requiredEnv(name) {
   const value = process.env[name]?.trim();
   if (!value) throw new Error(`${name} is required`);
   return value;
+}
+
+function optionalEnv(name) {
+  return process.env[name]?.trim() || '';
 }
 
 async function runIMAP(...args) {

--- a/web/scripts/email-signup-live-e2e.mjs
+++ b/web/scripts/email-signup-live-e2e.mjs
@@ -45,7 +45,29 @@ try {
 
   const verifyContext = await browser.newContext();
   const verifyPage = await verifyContext.newPage();
+  let verifyResponse;
+  const verifyResponsePromise = verifyPage.waitForResponse((response) => (
+    response.request().method() === 'POST' &&
+    new URL(response.url()).pathname === '/api/auth/customer/verify-email'
+  ), { timeout: 30_000 }).then((response) => {
+    verifyResponse = response;
+    return response;
+  });
   await verifyPage.goto(delivered.url, { waitUntil: 'networkidle' });
+  await Promise.race([
+    verifyResponsePromise,
+    new Promise((resolve) => setTimeout(resolve, 2_000)),
+  ]);
+  if (!verifyResponse) {
+    const verifyButton = verifyPage.getByRole('button', { name: 'Verify', exact: true });
+    if (await verifyButton.isEnabled()) {
+      await verifyButton.click();
+    }
+  }
+  verifyResponse = await verifyResponsePromise;
+  if (verifyResponse.status() !== 200) {
+    throw new Error(`email verification returned HTTP ${verifyResponse.status()}`);
+  }
   await verifyPage.waitForURL(/\/console\/overview(?:\?|$)/, { timeout: 30_000 });
   const sessionCookies = await verifyContext.cookies(baseURL);
   if (!sessionCookies.some((cookie) => cookie.name === 'rtk_admin_session' && cookie.httpOnly)) {
@@ -113,7 +135,7 @@ if (evidencePath) {
     verification_origin: new URL(delivered.url).origin,
   })}\n`, { encoding: 'utf8', mode: 0o600 });
 }
-console.log(`SMTP + IMAP signup E2E passed (run ${runID}; IMAP UID ${delivered.uid}).`);
+console.log(`Send Mail + IMAP signup E2E passed (run ${runID}; IMAP UID ${delivered.uid}).`);
 
 function requiredEnv(name) {
   const value = process.env[name]?.trim();


### PR DESCRIPTION
## Summary
- make the staging live signup runner accept a run-scoped plus-address recipient
- validate Send Mail sender, MIME content, verification origin, session, login, and token replay behavior
- record only redacted local evidence
- assert the verification API response before accepting browser navigation

## Validation
- `GOWORK=off go test ./... -count=1`
- `npm test` (71/71)
- staging `E2E-CA-SIGNUP-EMAIL-001` PASS
- `/signup/verify` external deep link returns HTTP 200

No mailbox credentials, Bearer token, or full verification URL are included.