### PR TITLE
Add Brand owner activation UI

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 80.4% |
+| Go total coverage | 80.3% |
 | Go coverage gate | >= 65.0% |
 | Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
@@ -28,8 +28,8 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 88.4% |
-| `rtk_cloud_admin/internal/app` | 80.1% |
+| `rtk_cloud_admin/internal/accountclient` | 87.6% |
+| `rtk_cloud_admin/internal/app` | 80.0% |
 | `rtk_cloud_admin/internal/config` | 85.7% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -242,6 +242,37 @@ paths:
         "503":
           $ref: "#/components/responses/PlainTextError"
 
+  /api/auth/brand-cloud/activate:
+    post:
+      tags: [Auth]
+      summary: Set a password and activate a pending Brand Cloud user
+      description: Proxies tenant-scoped one-time activation to Account Manager, establishes an HTTP-only Admin Console session, and returns only redacted Brand/account identity fields.
+      security: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [tenant_slug, token, password]
+              properties:
+                tenant_slug:
+                  type: string
+                token:
+                  type: string
+                password:
+                  type: string
+                  minLength: 8
+      responses:
+        "200":
+          description: Brand Cloud account activation succeeded and set `rtk_admin_session`.
+        "400":
+          $ref: "#/components/responses/PlainTextError"
+        "502":
+          $ref: "#/components/responses/PlainTextError"
+        "503":
+          $ref: "#/components/responses/PlainTextError"
+
   /api/auth/forgot-password:
     post:
       tags: [Auth]

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -82,6 +82,7 @@ type User struct {
 type Organization struct {
 	ID                    string         `json:"id"`
 	Name                  string         `json:"name"`
+	TenantSlug            string         `json:"tenant_slug,omitempty"`
 	Role                  string         `json:"role"`
 	OrganizationKind      string         `json:"organization_kind,omitempty"`
 	Status                string         `json:"status,omitempty"`
@@ -111,6 +112,7 @@ type BrandCloudUserRequest struct {
 	DisplayName    string `json:"display_name,omitempty"`
 	Role           string `json:"role"`
 	RotatePassword bool   `json:"rotate_password,omitempty"`
+	ActivationMode string `json:"activation_mode,omitempty"`
 }
 
 type BrandCloudUser struct {
@@ -330,6 +332,18 @@ type LoginResult struct {
 	Tokens Tokens `json:"tokens"`
 }
 
+type BrandCloudActivationRequest struct {
+	Token    string `json:"token"`
+	Password string `json:"password"`
+}
+
+type BrandCloudActivationResult struct {
+	BrandCloud     BrandCloud     `json:"brand_cloud"`
+	BrandCloudUser BrandCloudUser `json:"brand_cloud_user"`
+	User           User           `json:"user"`
+	Tokens         Tokens         `json:"tokens"`
+}
+
 type RefreshResult struct {
 	Tokens Tokens `json:"tokens"`
 }
@@ -494,6 +508,15 @@ func (c *Client) SignIn(ctx context.Context, email string) error {
 func (c *Client) ActivateLogin(ctx context.Context, token string) (LoginResult, error) {
 	var out LoginResult
 	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/login/activate", "", AuthTokenRequest{Token: token}, &out)
+	return out, err
+}
+
+func (c *Client) ActivateBrandCloudUser(ctx context.Context, tenantSlug, token, password string) (BrandCloudActivationResult, error) {
+	var out BrandCloudActivationResult
+	path := "/v1/brand-clouds/" + url.PathEscape(strings.TrimSpace(tenantSlug)) + "/auth/activate"
+	err := c.doJSON(ctx, http.MethodPost, path, "", BrandCloudActivationRequest{
+		Token: token, Password: password,
+	}, &out)
 	return out, err
 }
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -270,6 +270,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/auth/customer/resend-verification", s.apiCustomerResendVerification)
 	s.mux.HandleFunc("POST /api/auth/sign-in", s.apiAuthSignIn)
 	s.mux.HandleFunc("POST /api/auth/login/activate", s.apiAuthLoginActivate)
+	s.mux.HandleFunc("POST /api/auth/brand-cloud/activate", s.apiAuthBrandCloudActivate)
 	s.mux.HandleFunc("POST /api/auth/forgot-password", s.apiAuthForgotPassword)
 	s.mux.HandleFunc("POST /api/auth/reset-password", s.apiAuthResetPassword)
 	s.mux.HandleFunc("POST /api/auth/sso/start", s.apiSSOStart)
@@ -363,6 +364,7 @@ func (s *Server) routes() {
 		"/login",
 		"/login/check-email",
 		"/login/activate",
+		"/brand-cloud/activate",
 		"/forgot-password",
 		"/reset-password",
 		"/signup",
@@ -959,6 +961,55 @@ func (s *Server) apiAuthLoginActivate(w http.ResponseWriter, r *http.Request) {
 	}
 	setSessionCookie(w, session.ID)
 	writeJSON(w, map[string]string{"status": "ok", "kind": kind})
+}
+
+func (s *Server) apiAuthBrandCloudActivate(w http.ResponseWriter, r *http.Request) {
+	if !s.accountClient.Enabled() {
+		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body struct {
+		TenantSlug string `json:"tenant_slug"`
+		Token      string `json:"token"`
+		Password   string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil ||
+		strings.TrimSpace(body.TenantSlug) == "" ||
+		strings.TrimSpace(body.Token) == "" ||
+		len(body.Password) < 8 {
+		http.Error(w, "tenant_slug, token, and password are required", http.StatusBadRequest)
+		return
+	}
+	result, err := s.accountClient.ActivateBrandCloudUser(
+		r.Context(), strings.TrimSpace(body.TenantSlug), strings.TrimSpace(body.Token), body.Password,
+	)
+	if err != nil {
+		s.writeAuthProxyError(w, err)
+		return
+	}
+	session, err := s.sessions.CreateSession(
+		"brand_cloud_user", result.BrandCloudUser.ID, result.BrandCloudUser.Email,
+		result.Tokens.AccessToken, result.Tokens.RefreshToken, result.BrandCloud.ID,
+		tokenTTL(result.Tokens),
+	)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	setSessionCookie(w, session.ID)
+	writeJSON(w, map[string]any{
+		"status": "ok",
+		"brand_cloud": map[string]string{
+			"id":          result.BrandCloud.ID,
+			"name":        result.BrandCloud.Name,
+			"tenant_slug": result.BrandCloud.TenantSlug,
+		},
+		"account": map[string]string{
+			"id":           result.BrandCloudUser.ID,
+			"email":        result.BrandCloudUser.Email,
+			"display_name": result.BrandCloudUser.DisplayName,
+		},
+	})
 }
 
 func (s *Server) apiAuthForgotPassword(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -801,6 +801,18 @@ func TestEmailActivationAuthBFFSetsCustomerSessionCookie(t *testing.T) {
 				return
 			}
 			_, _ = w.Write([]byte(`{"user":{"id":"u-email","email":"user@example.com","name":"User"},"tokens":{"access_token":"customer-access","refresh_token":"customer-refresh","expires_in":3600}}`))
+		case "/v1/brand-clouds/load-run-b01/auth/activate":
+			body := readBody(t, r)
+			if !strings.Contains(body, `"token":"owner-token"`) || !strings.Contains(body, `"password":"owner-password"`) {
+				http.Error(w, "unexpected activation request", http.StatusBadRequest)
+				return
+			}
+			_, _ = w.Write([]byte(`{
+				"brand_cloud":{"id":"brand-1","name":"RTK-LOAD-CANARY-run-b01","tenant_slug":"load-run-b01"},
+				"brand_cloud_user":{"id":"bcu-1","brand_cloud_id":"brand-1","email":"imap-test01+load-run-b01@realtekconnect.com","display_name":"Load Owner","email_verified":true},
+				"user":{"id":"bcu-1","email":"imap-test01+load-run-b01@realtekconnect.com"},
+				"tokens":{"access_token":"brand-access","refresh_token":"brand-refresh","expires_in":3600}
+			}`))
 		case "/v1/admin/brand-clouds":
 			http.Error(w, "forbidden", http.StatusForbidden)
 		case "/v1/me":
@@ -847,6 +859,21 @@ func TestEmailActivationAuthBFFSetsCustomerSessionCookie(t *testing.T) {
 	}
 	if got := invalid.Header().Values("Set-Cookie"); strings.Contains(strings.Join(got, ";"), "rtk_admin_session=") {
 		t.Fatalf("invalid activation set session cookie: %v", got)
+	}
+	brandActivate := httptest.NewRecorder()
+	srv.ServeHTTP(brandActivate, httptest.NewRequest(http.MethodPost, "/api/auth/brand-cloud/activate", strings.NewReader(`{
+		"tenant_slug":"load-run-b01","token":"owner-token","password":"owner-password"
+	}`)))
+	if brandActivate.Code != http.StatusOK {
+		t.Fatalf("brand activation status = %d, body=%s", brandActivate.Code, brandActivate.Body.String())
+	}
+	if got := brandActivate.Header().Values("Set-Cookie"); !strings.Contains(strings.Join(got, ";"), "HttpOnly") {
+		t.Fatalf("brand activation did not set HTTP-only session cookie: %v", got)
+	}
+	if body := brandActivate.Body.String(); !strings.Contains(body, `"name":"RTK-LOAD-CANARY-run-b01"`) ||
+		!strings.Contains(body, `"display_name":"Load Owner"`) ||
+		strings.Contains(body, "brand-access") || strings.Contains(body, "owner-token") || strings.Contains(body, "owner-password") {
+		t.Fatalf("brand activation response is incomplete or leaked credentials: %s", body)
 	}
 
 	forgot := httptest.NewRecorder()

--- a/web/package.json
+++ b/web/package.json
@@ -4,6 +4,7 @@
     "test": "node --test src/*.test.mjs",
     "browser:smoke": "node scripts/browser-smoke.mjs",
     "e2e:email-signup-live": "node scripts/email-signup-live-e2e.mjs",
+    "e2e:load-owner-activation-live": "node scripts/load-owner-activation-live-e2e.mjs",
     "e2e:generate-fixture": "node scripts/generate-e2e-fixture.mjs",
     "e2e": "npm run e2e:desktop && npm run e2e:mobile",
     "e2e:desktop": "E2E_UI_TARGET=desktop playwright test --project=chromium",

--- a/web/scripts/email-signup-live-e2e.mjs
+++ b/web/scripts/email-signup-live-e2e.mjs
@@ -12,6 +12,7 @@ const imapHelper = requiredEnv('EMAIL_E2E_IMAP_HELPER');
 const runID = optionalEnv('EMAIL_E2E_RUN_ID') || 'local';
 const evidencePath = optionalEnv('EMAIL_E2E_EVIDENCE_PATH');
 const python = process.env.PYTHON || 'python3';
+const organizationName = `E2E Email Signup ${runID}`;
 
 const snapshot = await runIMAP('snapshot');
 if (!Number.isInteger(snapshot.uid_next) || snapshot.uid_next < 1) {
@@ -26,7 +27,7 @@ try {
   await signupPage.goto(`${baseURL}/signup`, { waitUntil: 'networkidle' });
   await signupPage.getByLabel('Email', { exact: true }).fill(emailAddress);
   await signupPage.getByLabel('Password', { exact: true }).fill(password);
-  await signupPage.getByLabel('Organization name', { exact: true }).fill(`E2E Email Signup ${runID}`);
+  await signupPage.getByLabel('Organization name', { exact: true }).fill(organizationName);
   await signupPage.getByLabel('Display name', { exact: true }).fill(`E2E Email Signup ${runID}`);
   await signupPage.getByLabel('I accept the evaluation-tier terms.').check();
   await signupPage.getByRole('button', { name: 'Create account' }).click();
@@ -76,6 +77,10 @@ try {
   const meResponse = await verifyPage.request.get(`${baseURL}/api/me`);
   if (!meResponse.ok()) {
     throw new Error(`verified Admin Console session returned HTTP ${meResponse.status()}`);
+  }
+  const me = await meResponse.json();
+  if (!me.memberships?.some((membership) => membership.organization === organizationName)) {
+    throw new Error('verified account organization name did not match the signup form');
   }
   await verifyContext.close();
 

--- a/web/scripts/load-owner-activation-live-e2e.mjs
+++ b/web/scripts/load-owner-activation-live-e2e.mjs
@@ -1,0 +1,107 @@
+import { writeFile } from 'node:fs/promises';
+import { chromium } from 'playwright';
+
+const activationURL = requiredEnv('LOAD_OWNER_ACTIVATION_URL');
+const password = requiredEnv('LOAD_OWNER_PASSWORD');
+const expectedEmail = requiredEnv('LOAD_OWNER_EMAIL');
+const expectedDisplayName = requiredEnv('LOAD_OWNER_DISPLAY_NAME');
+const expectedBrandName = requiredEnv('LOAD_OWNER_BRAND_NAME');
+const expectedTenant = requiredEnv('LOAD_OWNER_TENANT_SLUG');
+const expectedOrigin = new URL(requiredEnv('LOAD_OWNER_ADMIN_BASE_URL')).origin;
+const evidencePath = optionalEnv('LOAD_OWNER_EVIDENCE_PATH');
+const runID = requiredEnv('LOAD_OWNER_RUN_ID');
+const imapUID = Number(requiredEnv('LOAD_OWNER_IMAP_UID'));
+
+const parsedActivationURL = new URL(activationURL);
+if (
+  parsedActivationURL.origin !== expectedOrigin ||
+  parsedActivationURL.pathname.replace(/\/$/, '') !== '/brand-cloud/activate' ||
+  parsedActivationURL.searchParams.get('tenant') !== expectedTenant ||
+  !parsedActivationURL.searchParams.get('token')
+) {
+  throw new Error('activation URL does not match the expected staging tenant');
+}
+
+const browser = await chromium.launch().catch(() => chromium.launch({ channel: 'chrome' }));
+try {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  let activationResponse;
+  page.on('response', (response) => {
+    if (
+      response.request().method() === 'POST' &&
+      new URL(response.url()).pathname === '/api/auth/brand-cloud/activate'
+    ) activationResponse = response;
+  });
+  await page.goto(activationURL, { waitUntil: 'networkidle' });
+  await page.getByPlaceholder('New password').fill(password);
+  await page.getByRole('button', { name: 'Activate account' }).click();
+  await page.getByText(`Activated ${expectedDisplayName} for ${expectedBrandName}.`, { exact: true }).waitFor({ timeout: 30_000 });
+  if (!activationResponse || activationResponse.status() !== 200) {
+    throw new Error(`brand owner activation returned HTTP ${activationResponse?.status() || 'unknown'}`);
+  }
+  const body = await activationResponse.json();
+  if (
+    body.brand_cloud?.name !== expectedBrandName ||
+    body.brand_cloud?.tenant_slug !== expectedTenant ||
+    body.account?.email !== expectedEmail ||
+    body.account?.display_name !== expectedDisplayName
+  ) {
+    throw new Error('activation response did not match the resolved brand plan');
+  }
+  const cookies = await context.cookies(expectedOrigin);
+  if (!cookies.some((cookie) => cookie.name === 'rtk_admin_session' && cookie.httpOnly)) {
+    throw new Error('activation did not establish an HTTP-only Admin Console session');
+  }
+  await context.close();
+
+  const replayContext = await browser.newContext();
+  const replayPage = await replayContext.newPage();
+  let replayResponse;
+  replayPage.on('response', (response) => {
+    if (
+      response.request().method() === 'POST' &&
+      new URL(response.url()).pathname === '/api/auth/brand-cloud/activate'
+    ) replayResponse = response;
+  });
+  await replayPage.goto(activationURL, { waitUntil: 'networkidle' });
+  await replayPage.getByPlaceholder('New password').fill(password);
+  await replayPage.getByRole('button', { name: 'Activate account' }).click();
+  await replayPage.locator('.error').first().waitFor({ state: 'visible', timeout: 30_000 });
+  if (!replayResponse || replayResponse.status() !== 400) {
+    throw new Error(`replayed activation token returned HTTP ${replayResponse?.status() || 'unknown'}`);
+  }
+  const replayText = await replayPage.locator('.error').first().innerText();
+  if (replayText.includes(parsedActivationURL.searchParams.get('token'))) {
+    throw new Error('replay error exposed the activation token');
+  }
+  await replayContext.close();
+} finally {
+  await browser.close();
+}
+
+if (evidencePath) {
+  await writeFile(evidencePath, `${JSON.stringify({
+    schema: 'rtk.load-owner-activation.evidence.v1',
+    run_id: runID,
+    status: 'PASS',
+    brand_name: expectedBrandName,
+    tenant_slug: expectedTenant,
+    recipient_alias: expectedEmail,
+    imap_uid: imapUID,
+    activation_origin: expectedOrigin,
+    activation: 'PASS',
+    session: 'PASS',
+    replay: 'PASS',
+  })}\n`, { encoding: 'utf8', mode: 0o600 });
+}
+
+function requiredEnv(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function optionalEnv(name) {
+  return process.env[name]?.trim() || '';
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -152,7 +152,7 @@ function App() {
   const [loading, setLoading] = useState(true);
   const isPublicRoute = isPublicRouteId(active);
   const isLoginRoute = active === 'login';
-  const isAuthEntryRoute = active === 'login' || active === 'login-check-email' || active === 'login-activate' || active === 'forgot-password' || active === 'reset-password';
+  const isAuthEntryRoute = active === 'login' || active === 'login-check-email' || active === 'login-activate' || active === 'brand-cloud-activate' || active === 'forgot-password' || active === 'reset-password';
   const isPlatformView = isPlatformRouteId(active);
   const visibleNavItems = navItemsForCapabilities(active, me?.capabilities).filter((item) => item.id !== 'platform-brand-clouds' || me?.upstream_account_manager);
   const needsPlatformAccess = isPlatformView && me?.kind !== 'platform_admin';
@@ -823,6 +823,17 @@ function App() {
     }
   }
 
+  async function handleBrandCloudActivate(payload) {
+    setError('');
+    try {
+      return await postJSON('/api/auth/brand-cloud/activate', payload);
+    } catch (err) {
+      const nextError = userFacingLoginActivationError(err);
+      setError(nextError);
+      throw new Error(nextError);
+    }
+  }
+
   async function handleForgotPassword(email) {
     setError('');
     try {
@@ -944,6 +955,7 @@ function App() {
           loading={loading}
           onEmailSignIn={handleEmailSignIn}
           onLoginActivate={handleLoginActivate}
+          onBrandCloudActivate={handleBrandCloudActivate}
           onPasswordLogin={handlePasswordLogin}
           onForgotPassword={handleForgotPassword}
           onResetPassword={handleResetPassword}
@@ -1150,7 +1162,7 @@ function App() {
   );
 }
 
-function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onPasswordLogin, onForgotPassword, onResetPassword }) {
+function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onBrandCloudActivate, onPasswordLogin, onForgotPassword, onResetPassword }) {
   const params = new URLSearchParams(window.location.search);
   const email = params.get('email') || '';
   const token = params.get('token') || '';
@@ -1158,6 +1170,8 @@ function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onP
     <LoginCheckEmail email={email} />
   ) : active === 'login-activate' ? (
     <LoginActivateView token={token} onLoginActivate={onLoginActivate} />
+  ) : active === 'brand-cloud-activate' ? (
+    <BrandCloudActivateView token={token} tenant={params.get('tenant') || ''} onActivate={onBrandCloudActivate} />
   ) : active === 'forgot-password' ? (
     <ForgotPasswordView email={email} onForgotPassword={onForgotPassword} />
   ) : active === 'reset-password' ? (
@@ -1179,6 +1193,36 @@ function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onP
           {error ? <div className="error">{error}</div> : null}
         </section>
       </main>
+    </div>
+  );
+}
+
+function BrandCloudActivateView({ token, tenant, onActivate }) {
+  const [password, setPassword] = useState('');
+  const [status, setStatus] = useState('');
+  const [error, setLocalError] = useState('');
+  const [busy, setBusy] = useState(false);
+  async function submit(event) {
+    event.preventDefault();
+    setBusy(true);
+    setLocalError('');
+    try {
+      const result = await onActivate({ tenant_slug: tenant, token, password });
+      setStatus(`Activated ${result.account?.display_name || result.account?.email || 'account'} for ${result.brand_cloud?.name || tenant}.`);
+    } catch (err) {
+      setLocalError(userFacingLoginActivationError(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+  return (
+    <div className="auth-stack">
+      <form className="auth-inline" onSubmit={submit}>
+        <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="New password" minLength="8" required />
+        <button type="submit" disabled={busy || !token || !tenant}>{busy ? 'Activating' : 'Activate account'}</button>
+      </form>
+      {status ? <p className="auth-status">{status}</p> : null}
+      {error ? <p className="error">{error}</p> : null}
     </div>
   );
 }

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -24,7 +24,7 @@ export const platformNavItems = [
   { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit', icon: 'shield-halved' },
 ];
 
-const publicRouteIds = new Set(['login', 'login-check-email', 'login-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'verify']);
+const publicRouteIds = new Set(['login', 'login-check-email', 'login-activate', 'brand-cloud-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'verify']);
 
 export function isPublicRouteId(route) {
   return publicRouteIds.has(route);
@@ -50,6 +50,7 @@ export function titleFor(active) {
     login: 'Sign in',
     'login-check-email': 'Check your email',
     'login-activate': 'Activate sign-in',
+    'brand-cloud-activate': 'Activate brand account',
     'forgot-password': 'Forgot password',
     'reset-password': 'Reset password',
     signup: 'Sign up',
@@ -82,6 +83,7 @@ export function routeFromPath(path) {
   if (path === '/login' || path === '/login/') return 'login';
   if (path === '/login/check-email' || path.startsWith('/login/check-email/')) return 'login-check-email';
   if (path === '/login/activate' || path.startsWith('/login/activate/')) return 'login-activate';
+  if (path === '/brand-cloud/activate' || path.startsWith('/brand-cloud/activate/')) return 'brand-cloud-activate';
   if (path === '/forgot-password' || path.startsWith('/forgot-password/')) return 'forgot-password';
   if (path === '/reset-password' || path.startsWith('/reset-password/')) return 'reset-password';
   if (path === '/signup' || path === '/signup/') return 'signup';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -33,6 +33,7 @@ test('maps public signup paths to auth routes', () => {
   assert.equal(routeFromPath('/login/'), 'login');
   assert.equal(routeFromPath('/login/check-email'), 'login-check-email');
   assert.equal(routeFromPath('/login/activate'), 'login-activate');
+  assert.equal(routeFromPath('/brand-cloud/activate'), 'brand-cloud-activate');
   assert.equal(routeFromPath('/forgot-password'), 'forgot-password');
   assert.equal(routeFromPath('/reset-password'), 'reset-password');
   assert.equal(routeFromPath('/signup'), 'signup');


### PR DESCRIPTION
## Summary
- add Brand Cloud activation BFF and set-password page
- establish HTTP-only Brand Cloud session with redacted response
- add operator live browser runner and exact signup organization assertion

## Tests
- GOWORK=off go test ./... -count=1
- npm test
- npm run build