### PR TITLE
Anchor live evidence to workspace commits

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -11,7 +11,7 @@ rtk_spec:
 ## [FEAT-CA-BFF-001] Tenant-aware Cloud Admin BFF and operational console boundary
 
 <!-- rtk-feature
-{"owner":"rtk_cloud_admin","risk":"critical","status":"active","change_paths":["repos/rtk_cloud_admin/**"],"commit_anchors":["cloud_admin"],"surfaces":[{"kind":"api-route","source":"repos/rtk_cloud_admin/docs/openapi.yaml","selector":"postApiAuthCustomerLogin"}]}
+{"owner":"rtk_cloud_admin","risk":"critical","status":"active","change_paths":["repos/rtk_cloud_admin/**","scripts/go/rtk-cloud/**"],"commit_anchors":["workspace","cloud_admin"],"surfaces":[{"kind":"api-route","source":"repos/rtk_cloud_admin/docs/openapi.yaml","selector":"postApiAuthCustomerLogin"}]}
 -->
 
 ## Summary

--- a/docs/platform-view-dashboard-design.md
+++ b/docs/platform-view-dashboard-design.md
@@ -11,7 +11,7 @@ rtk_spec:
 ## [FEAT-CA-PLATFORM-DASHBOARD-001] Platform operations dashboard
 
 <!-- rtk-feature
-{"owner":"rtk_cloud_admin","risk":"critical","status":"active","change_paths":["repos/rtk_cloud_admin/internal/app/**","repos/rtk_cloud_admin/web/**"],"commit_anchors":["cloud_admin"],"surfaces":[{"kind":"api-route","source":"repos/rtk_cloud_admin/docs/openapi.yaml","selector":"getApiAdminPlatformDashboard"},{"kind":"ui-route","source":"repos/rtk_cloud_admin/web/src/routes.mjs","selector":"platform-dashboard"}]}
+{"owner":"rtk_cloud_admin","risk":"critical","status":"active","change_paths":["repos/rtk_cloud_admin/internal/app/**","repos/rtk_cloud_admin/web/**","scripts/go/rtk-cloud/**"],"commit_anchors":["workspace","cloud_admin"],"surfaces":[{"kind":"api-route","source":"repos/rtk_cloud_admin/docs/openapi.yaml","selector":"getApiAdminPlatformDashboard"},{"kind":"ui-route","source":"repos/rtk_cloud_admin/web/src/routes.mjs","selector":"platform-dashboard"}]}
 -->
 
 Status: implemented baseline; design-parity follow-up is tracked in


### PR DESCRIPTION
## Summary
- add the workspace test harness to Cloud Admin BFF and platform dashboard change paths
- require both workspace and Cloud Admin commit anchors for live evidence v3

This keeps source spec metadata consistent with the live runner and the evidence contract.

## Validation
- workspace `test-spec-inventory check`
- workspace platform live evidence contract test