### PR TITLE
Fix batch job lifecycle UI test

### DIFF
--- a/web/e2e/brand-fleet-jobs.spec.mjs
+++ b/web/e2e/brand-fleet-jobs.spec.mjs
@@ -2,22 +2,30 @@ import { test, expect } from '@playwright/test';
 import { login } from './fixtures/session.mjs';
 import { waitForJob } from './fixtures/brand-fleet.mjs';
 
-test('[UI-CA-JOBS-001] batch job uses server scope, idempotency and result lifecycle @brand-fleet', async ({ page }) => {
+test('[UI-CA-JOBS-001] batch job uses server scope, idempotency and result lifecycle @brand-fleet', async ({ page }, testInfo) => {
   await login(page, 'operations');
   await page.goto('/console/brand-e2e-01/jobs');
   await expect(page.getByRole('heading', { name: '批次工作' }).first()).toBeVisible();
-  const headers = { 'Content-Type': 'application/json', 'Idempotency-Key': 'e2e-batch-job-1' };
+  const attemptKey = `e2e-batch-job-${Date.now()}-${testInfo.retry}`;
+  const headers = { 'Content-Type': 'application/json', 'Idempotency-Key': attemptKey };
   const payload = { type: 'device_settings', name: 'E2E device settings', scope: { query: { region: ['na'] }, excluded_device_ids: [] } };
   const created = await page.request.post('/api/jobs', { headers, data: payload });
   expect(created.status()).toBe(202);
   const job = (await created.json()).job;
   expect(job.scope.scope_hash).toMatch(/^sha256:/);
   expect(job.scope.estimated_total).toBeGreaterThanOrEqual(0);
-  const pause = await page.request.post(`/api/jobs/${encodeURIComponent(job.id)}/pause`, { headers: { 'Idempotency-Key': 'e2e-batch-job-pause-1' } });
+  const pause = await page.request.post(`/api/jobs/${encodeURIComponent(job.id)}/pause`, { headers: { 'Idempotency-Key': `pause-${job.id}` } });
   expect(pause.status()).toBe(202);
+  expect((await pause.json()).job.state).toBe('paused');
   const replay = await page.request.post('/api/jobs', { headers, data: payload });
   expect(replay.status()).toBe(202);
   expect((await replay.json()).idempotent_replay).toBeTruthy();
+  const current = await page.request.get(`/api/jobs/${encodeURIComponent(job.id)}`);
+  expect(current.ok()).toBeTruthy();
+  if ((await current.json()).job.state === 'paused') {
+    const resume = await page.request.post(`/api/jobs/${encodeURIComponent(job.id)}/resume`, { headers: { 'Idempotency-Key': `resume-${job.id}` } });
+    expect(resume.status()).toBe(202);
+  }
   await waitForJob(page, job.id);
   const result = await page.request.get(`/api/jobs/${encodeURIComponent(job.id)}/result`);
   expect(result.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary
- isolate batch job idempotency keys per Playwright attempt
- verify the pause response, then resume when the asynchronous job is still paused
- tolerate the valid race where the worker reaches a terminal state before the follow-up read

## Validation
- `npm run build`
- `npx playwright test e2e/brand-fleet-jobs.spec.mjs --project=chromium --workers=1` (1 passed)
- `node --check web/e2e/brand-fleet-jobs.spec.mjs`
- `git diff --check`