### PR TITLE
Handle batch pause completion race

### DIFF
--- a/web/e2e/brand-fleet-jobs.spec.mjs
+++ b/web/e2e/brand-fleet-jobs.spec.mjs
@@ -16,7 +16,7 @@ test('[UI-CA-JOBS-001] batch job uses server scope, idempotency and result lifec
   expect(job.scope.estimated_total).toBeGreaterThanOrEqual(0);
   const pause = await page.request.post(`/api/jobs/${encodeURIComponent(job.id)}/pause`, { headers: { 'Idempotency-Key': `pause-${job.id}` } });
   expect(pause.status()).toBe(202);
-  expect((await pause.json()).job.state).toBe('paused');
+  expect((await pause.json()).job.id).toBe(job.id);
   const replay = await page.request.post('/api/jobs', { headers, data: payload });
   expect(replay.status()).toBe(202);
   expect((await replay.json()).idempotent_replay).toBeTruthy();


### PR DESCRIPTION
## Summary
- assert that the accepted pause response refers to the created job without requiring a stale intermediate state
- keep the conditional resume and terminal-result verification
- preserve strict pause/resume state testing in the dedicated slow lifecycle case

The job worker can update SQLite between `UPDATE state=paused` and the handler's follow-up `SELECT`, so an accepted pause response may already report `running` or a terminal state.

## Validation
- `npm run build`
- focused Playwright case passed three consecutive fresh-server runs
- `git diff --check`