### PR TITLE
Fix Billing portal owner fallback capabilities

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -460,6 +460,14 @@ const (
 	capabilityProvisioningCreate        = "provisioning.create"
 	capabilityBillingAccountRead        = "billing_account.read"
 	capabilityBillingLedgerRead         = "billing_ledger.read"
+	capabilityBillingSummaryRead        = "billing_summary.read"
+	capabilityBillingUsageRead          = "billing_usage.read"
+	capabilityInvoiceRead               = "invoice.read"
+	capabilityInvoiceDocumentRead       = "invoice_document.read"
+	capabilityBillingActivityRead       = "billing_activity.read"
+	capabilityBillingProfileRead        = "billing_profile.read"
+	capabilityBillingProfileManage      = "billing_profile.manage"
+	capabilityBillingStatementExport    = "billing_statement.export"
 	capabilityPaymentMethodRead         = "payment_method.read"
 	capabilityPaymentMethodManage       = "payment_method.manage"
 	capabilityPaymentIntentRead         = "payment_intent.read"
@@ -6256,6 +6264,14 @@ func fleetManagerCapabilities() []string {
 		capabilityProvisioningCreate,
 		capabilityBillingAccountRead,
 		capabilityBillingLedgerRead,
+		capabilityBillingSummaryRead,
+		capabilityBillingUsageRead,
+		capabilityInvoiceRead,
+		capabilityInvoiceDocumentRead,
+		capabilityBillingActivityRead,
+		capabilityBillingProfileRead,
+		capabilityBillingProfileManage,
+		capabilityBillingStatementExport,
 		capabilityPaymentMethodRead,
 		capabilityPaymentMethodManage,
 		capabilityPaymentIntentRead,

--- a/internal/app/billing_portal_test.go
+++ b/internal/app/billing_portal_test.go
@@ -106,3 +106,28 @@ func TestServerBuildsBillingClientFromConfiguration(t *testing.T) {
 		t.Fatal("configured Billing service did not create a client")
 	}
 }
+
+func TestBillingPortalCapabilitiesCoverOwnerCompatibilityFallback(t *testing.T) {
+	required := []string{
+		capabilityBillingSummaryRead,
+		capabilityBillingUsageRead,
+		capabilityInvoiceRead,
+		capabilityInvoiceDocumentRead,
+		capabilityBillingActivityRead,
+		capabilityBillingProfileRead,
+		capabilityBillingProfileManage,
+		capabilityBillingStatementExport,
+	}
+	ownerCapabilities := capabilitiesForOrganization(accountclient.Organization{Role: "owner"})
+	for _, capability := range required {
+		if !hasCapability(ownerCapabilities, capability) {
+			t.Fatalf("owner compatibility capabilities missing %q", capability)
+		}
+	}
+	viewerCapabilities := capabilitiesForOrganization(accountclient.Organization{Role: "viewer"})
+	for _, capability := range required {
+		if hasCapability(viewerCapabilities, capability) {
+			t.Fatalf("read-only compatibility capabilities unexpectedly include %q", capability)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- include the Billing portal read/manage capabilities in the non-read-only customer compatibility fallback
- preserve the restricted viewer fallback
- add a regression test covering both owner and viewer behavior

## Validation
- `GOWORK=off go test ./... -count=1`

## Staging evidence
The Billing live qualification passed, but real Cloud Admin desktop/mobile smoke exposed deterministic 403 responses for the newly added Billing portal routes when the Account Manager organization response had no explicit capability projection.