### PR TITLE
Recognize staging-qualified UI evidence IDs

### DIFF
--- a/web/scripts/test-evidence-reporter.mjs
+++ b/web/scripts/test-evidence-reporter.mjs
@@ -2,7 +2,11 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 
-const TEST_ID = /\[(UI-[A-Z0-9]+-[A-Z0-9]+-\d{3})\]/;
+const TEST_ID = /\[(UI-(?:[A-Z0-9]+-)+\d{3})\]/;
+
+export function extractTestID(title) {
+  return String(title ?? '').match(TEST_ID)?.[1] || '';
+}
 
 function relative(runDir, value) {
   return value ? path.relative(runDir, value).split(path.sep).join('/') : '';
@@ -32,12 +36,11 @@ export default class EvidenceReporter {
   }
 
   onTestEnd(test, result) {
-    const match = test.title.match(TEST_ID);
-    if (!match) {
+    const testID = extractTestID(test.title);
+    if (!testID) {
       this.errors.push(`Playwright test is missing Test ID: ${test.title}`);
       return;
     }
-    const testID = match[1];
     const attempts = this.attempts.get(testID) || [];
     attempts.push({
       title: test.title,

--- a/web/src/evidence-reporter.test.mjs
+++ b/web/src/evidence-reporter.test.mjs
@@ -1,0 +1,10 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { extractTestID } from '../scripts/test-evidence-reporter.mjs';
+
+test('evidence reporter accepts standard and staging-qualified test IDs', () => {
+  assert.equal(extractTestID('[UI-CA-BILLING-001] billing overview'), 'UI-CA-BILLING-001');
+  assert.equal(extractTestID('[UI-CA-BILLING-STG-001] real staging overview'), 'UI-CA-BILLING-STG-001');
+  assert.equal(extractTestID('missing test ID'), '');
+});


### PR DESCRIPTION
## Summary
- accept Test IDs with additional qualified segments such as `UI-CA-BILLING-STG-001`
- keep existing standard ID support
- add a Node regression test for standard, staging-qualified, and invalid titles

## Validation
- `npm test` (78 passed)
- `npm run build`

## Staging evidence
All six real Billing UI tests passed on desktop/mobile, but the reporter rejected the qualified IDs and incorrectly failed the workflow.