### PR TITLE
feat: add Developer PKI test bundle tool

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 79.2% |
+| Go total coverage | 78.2% |
 | Go coverage gate | >= 65.0% |
 | Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
@@ -28,10 +28,10 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 87.6% |
-| `rtk_cloud_admin/internal/app` | 80.0% |
+| `rtk_cloud_admin/internal/accountclient` | 85.9% |
+| `rtk_cloud_admin/internal/app` | 78.8% |
 | `rtk_cloud_admin/internal/billingclient` | 24.4% |
-| `rtk_cloud_admin/internal/config` | 85.7% |
+| `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |
 | `rtk_cloud_admin/internal/store` | 80.2% |

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -299,6 +299,15 @@ type ProductionRun struct {
 	IssuedQuantity      int    `json:"issued_quantity"`
 }
 
+type ProductionRunIssueResponse struct {
+	ProductionRun ProductionRun `json:"production_run"`
+	FactoryJWT    string        `json:"factory_jwt"`
+	TokenType     string        `json:"token_type"`
+	ExpiresAt     string        `json:"expires_at"`
+}
+
+type CertificateBundle map[string]any
+
 type DeviceUpdateRequest struct {
 	Name     string         `json:"name"`
 	Category string         `json:"category"`
@@ -702,6 +711,25 @@ func (c *Client) DeveloperBrandCloud(ctx context.Context, accessToken, brandClou
 		return BrandCloud{}, Member{}, err
 	}
 	return body.BrandCloud, body.Membership, nil
+}
+
+func (c *Client) IssueDeveloperPKITestAppCertificate(ctx context.Context, accessToken, brandCloudID, idempotencyKey, targetType, targetID, csrPEM string) (CertificateBundle, error) {
+	var body struct {
+		CertificateBundle CertificateBundle `json:"certificate_bundle"`
+	}
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/pki/test-app-certificates"
+	err := c.doJSONWithIdempotency(ctx, http.MethodPost, path, accessToken, idempotencyKey, map[string]string{"target_type": targetType, "target_id": targetID, "csr_pem": csrPEM}, &body)
+	return body.CertificateBundle, err
+}
+
+func (c *Client) CreateDeveloperPKITestProductionRun(ctx context.Context, accessToken, brandCloudID, profileID, idempotencyKey string, validFrom, validUntil time.Time) (ProductionRunIssueResponse, error) {
+	var body ProductionRunIssueResponse
+	path := "/v1/orgs/" + url.PathEscape(brandCloudID) + "/device-item-profiles/" + url.PathEscape(profileID) + "/production-runs"
+	err := c.doJSONWithIdempotency(ctx, http.MethodPost, path, accessToken, idempotencyKey, map[string]any{
+		"factory_id": "developer-console", "batch_id": "pki-test-" + idempotencyKey,
+		"allowed_quantity": 1, "valid_from": validFrom.UTC(), "valid_until": validUntil.UTC(),
+	}, &body)
+	return body, err
 }
 
 func (c *Client) DeveloperBrandCloudMembers(ctx context.Context, accessToken, brandCloudID string, query url.Values) ([]Member, Pagination, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -271,6 +271,8 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/developer/brand-clouds/{brandCloudID}/owner-transfer/{transferID}", s.apiDeveloperOwnerTransfer)
 	s.mux.HandleFunc("POST /api/developer/brand-clouds/{brandCloudID}/owner-transfer/{transferID}/cancel", s.apiDeveloperOwnerTransfer)
 	s.mux.HandleFunc("POST /api/developer/brand-cloud-owner-transfers/accept", s.apiDeveloperOwnerTransferAccept)
+	s.mux.HandleFunc("POST /api/developer/pki/test-bundles/app", s.apiDeveloperPKITestAppBundle)
+	s.mux.HandleFunc("POST /api/developer/pki/test-bundles/device", s.apiDeveloperPKITestDeviceBundle)
 	s.mux.HandleFunc("POST /api/auth/customer/signup", s.apiCustomerSignup)
 	s.mux.HandleFunc("POST /api/auth/customer/login", s.apiCustomerLogin)
 	s.mux.HandleFunc("POST /api/auth/customer/verify-email", s.apiCustomerVerifyEmail)

--- a/internal/app/developer_pki.go
+++ b/internal/app/developer_pki.go
@@ -1,0 +1,145 @@
+package app
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const certificateBundleMIME = "application/vnd.realtek.rtk-certificate-bundle+json"
+
+type developerPKIAppRequest struct {
+	BrandCloudID string `json:"brand_cloud_id"`
+	TargetType   string `json:"target_type"`
+	TargetID     string `json:"target_id"`
+	CSRPEM       string `json:"csr_pem"`
+}
+
+type developerPKIDeviceRequest struct {
+	BrandCloudID string `json:"brand_cloud_id"`
+	ProfileID    string `json:"device_item_profile_id"`
+	DeviceID     string `json:"device_id"`
+	SerialNumber string `json:"serial_number"`
+	CSRPEM       string `json:"csr_pem"`
+}
+
+func (s *Server) developerPKIAllowed(w http.ResponseWriter, r *http.Request) (string, bool) {
+	if !s.cfg.DeveloperPKITestToolsEnabled || strings.EqualFold(s.cfg.Environment, "production") || strings.EqualFold(s.cfg.Environment, "prod") {
+		http.Error(w, "PKI test tools are unavailable", http.StatusNotFound)
+		return "", false
+	}
+	key, ok := requireIdempotencyKey(w, r)
+	return key, ok
+}
+
+func (s *Server) apiDeveloperPKITestAppBundle(w http.ResponseWriter, r *http.Request) {
+	key, ok := s.developerPKIAllowed(w, r)
+	if !ok {
+		return
+	}
+	session, ok := s.customerSession(r)
+	if !ok {
+		http.Error(w, "developer authentication required", http.StatusUnauthorized)
+		return
+	}
+	var body developerPKIAppRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 256<<10)).Decode(&body); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if session.ActiveOrgID != body.BrandCloudID {
+		http.Error(w, "active Brand Cloud mismatch", http.StatusForbidden)
+		return
+	}
+	bundle, err := s.accountClient.IssueDeveloperPKITestAppCertificate(r.Context(), session.AccessToken, body.BrandCloudID, key, body.TargetType, body.TargetID, body.CSRPEM)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	writeCertificateBundleJSON(w, bundle)
+}
+
+func (s *Server) apiDeveloperPKITestDeviceBundle(w http.ResponseWriter, r *http.Request) {
+	key, ok := s.developerPKIAllowed(w, r)
+	if !ok {
+		return
+	}
+	session, ok := s.customerSession(r)
+	if !ok {
+		http.Error(w, "developer authentication required", http.StatusUnauthorized)
+		return
+	}
+	if strings.TrimSpace(s.cfg.FactoryEnrollBaseURL) == "" {
+		http.Error(w, "factory enrollment is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body developerPKIDeviceRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 256<<10)).Decode(&body); err != nil {
+		http.Error(w, "invalid request", http.StatusBadRequest)
+		return
+	}
+	if session.ActiveOrgID != body.BrandCloudID || body.ProfileID == "" || body.DeviceID == "" || body.SerialNumber == "" || body.CSRPEM == "" {
+		http.Error(w, "invalid or cross-Brand-Cloud request", http.StatusForbidden)
+		return
+	}
+	keyDigest := sha256.Sum256([]byte(key))
+	testID := hex.EncodeToString(keyDigest[:16])
+	now := time.Now().UTC()
+	profile, err := s.accountClient.DeviceItemProfile(r.Context(), session.AccessToken, body.BrandCloudID, body.ProfileID)
+	if err != nil || profile.Status != "active" {
+		http.Error(w, "active device item profile is required", http.StatusBadRequest)
+		return
+	}
+	run, err := s.accountClient.CreateDeveloperPKITestProductionRun(r.Context(), session.AccessToken, body.BrandCloudID, body.ProfileID, testID, now.Add(-time.Minute), now.Add(30*time.Minute))
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"request_id": "developer-pki-device-" + testID, "devid": body.DeviceID, "serial_number": body.SerialNumber,
+		"csr_pem": body.CSRPEM, "factory_id": "developer-console", "batch_id": "pki-test-" + testID,
+		"production_run_id": run.ProductionRun.ID, "service_options": profile.ServiceOptions, "ttl_days": 30,
+	})
+	base, err := url.Parse(strings.TrimRight(s.cfg.FactoryEnrollBaseURL, "/"))
+	if err != nil {
+		http.Error(w, "factory enrollment is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	base.Path = strings.TrimRight(base.Path, "/") + "/v1/factory/enroll"
+	request, _ := http.NewRequestWithContext(r.Context(), http.MethodPost, base.String(), bytes.NewReader(payload))
+	request.Header.Set("Authorization", "Bearer "+run.FactoryJWT)
+	request.Header.Set("Content-Type", "application/json")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		http.Error(w, "factory enrollment unavailable", http.StatusBadGateway)
+		return
+	}
+	defer response.Body.Close()
+	result, _ := io.ReadAll(io.LimitReader(response.Body, 1<<20))
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		http.Error(w, "factory enrollment rejected request", http.StatusBadGateway)
+		return
+	}
+	var envelope struct {
+		CertificateBundle map[string]any `json:"certificate_bundle"`
+	}
+	if json.Unmarshal(result, &envelope) != nil || envelope.CertificateBundle == nil {
+		http.Error(w, "factory enrollment returned no certificate bundle", http.StatusBadGateway)
+		return
+	}
+	writeCertificateBundleJSON(w, envelope.CertificateBundle)
+}
+
+func writeCertificateBundleJSON(w http.ResponseWriter, bundle any) {
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Content-Type", certificateBundleMIME)
+	if err := json.NewEncoder(w).Encode(bundle); err != nil {
+		http.Error(w, "failed to encode certificate bundle", http.StatusInternalServerError)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,9 @@ type Config struct {
 	BillingServiceBaseURL        string
 	BillingServiceToken          string
 	VideoCloudBaseURL            string
+	FactoryEnrollBaseURL         string
+	Environment                  string
+	DeveloperPKITestToolsEnabled bool
 	VideoCloudAdminToken         string
 	VideoCloudPrometheusBaseURL  string
 	GrafanaBaseURL               string
@@ -31,6 +34,9 @@ func FromEnv() Config {
 		BillingServiceBaseURL:        os.Getenv("BILLING_SERVICE_BASE_URL"),
 		BillingServiceToken:          os.Getenv("BILLING_SERVICE_TOKEN"),
 		VideoCloudBaseURL:            os.Getenv("VIDEO_CLOUD_BASE_URL"),
+		FactoryEnrollBaseURL:         os.Getenv("FACTORY_ENROLL_BASE_URL"),
+		Environment:                  strings.ToLower(getenv("CLOUD_ADMIN_ENV", "local")),
+		DeveloperPKITestToolsEnabled: truthy(os.Getenv("DEVELOPER_PKI_TEST_TOOLS_ENABLED")),
 		VideoCloudAdminToken:         os.Getenv("VIDEO_CLOUD_ADMIN_TOKEN"),
 		VideoCloudPrometheusBaseURL:  os.Getenv("VIDEO_CLOUD_PROMETHEUS_BASE_URL"),
 		GrafanaBaseURL:               os.Getenv("CLOUD_ADMIN_GRAFANA_BASE_URL"),

--- a/web/src/certificateBundle.mjs
+++ b/web/src/certificateBundle.mjs
@@ -1,0 +1,40 @@
+const bytes = (...parts) => new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0)).map((_, index) => {
+  let offset = index;
+  for (const part of parts) { if (offset < part.length) return part[offset]; offset -= part.length; }
+  return 0;
+});
+const length = (value) => value < 128 ? new Uint8Array([value]) : (() => { const out = []; for (; value; value >>>= 8) out.unshift(value & 255); return new Uint8Array([0x80 | out.length, ...out]); })();
+const der = (tag, body) => bytes(new Uint8Array([tag]), length(body.length), body);
+const oid = (value) => der(0x06, new Uint8Array(value));
+const sequence = (...values) => der(0x30, bytes(...values));
+const base64 = (data) => btoa(String.fromCharCode(...new Uint8Array(data)));
+const pem = (type, data) => `-----BEGIN ${type}-----\n${base64(data).match(/.{1,64}/g).join('\n')}\n-----END ${type}-----\n`;
+
+function ecdsaSignatureDER(raw) {
+  const integer = (value) => { let body = new Uint8Array(value); while (body.length > 1 && body[0] === 0) body = body.slice(1); if (body[0] & 0x80) body = bytes(new Uint8Array([0]), body); return der(0x02, body); };
+  return sequence(integer(raw.slice(0, raw.length / 2)), integer(raw.slice(raw.length / 2)));
+}
+
+export async function createP256CSR(commonName) {
+  if (!commonName || commonName.length > 128) throw new Error('invalid certificate common name');
+  const pair = await crypto.subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+  const [spki, pkcs8] = await Promise.all([crypto.subtle.exportKey('spki', pair.publicKey), crypto.subtle.exportKey('pkcs8', pair.privateKey)]);
+  const subject = sequence(der(0x31, sequence(oid([0x55, 0x04, 0x03]), der(0x0c, new TextEncoder().encode(commonName)))));
+  const requestInfo = sequence(der(0x02, new Uint8Array([0])), subject, new Uint8Array(spki), der(0xa0, new Uint8Array()));
+  const rawSignature = new Uint8Array(await crypto.subtle.sign({ name: 'ECDSA', hash: 'SHA-256' }, pair.privateKey, requestInfo));
+  const signature = rawSignature[0] === 0x30 ? rawSignature : ecdsaSignatureDER(rawSignature);
+  const csr = sequence(requestInfo, sequence(oid([0x2a, 0x86, 0x48, 0xce, 0x3d, 0x04, 0x03, 0x02])), der(0x03, bytes(new Uint8Array([0]), signature)));
+  return { csrPEM: pem('CERTIFICATE REQUEST', csr), privateKeyPEM: pem('PRIVATE KEY', pkcs8) };
+}
+
+export function downloadExportableBundle(certificateOnlyBundle, privateKeyPEM) {
+  const bundle = structuredClone(certificateOnlyBundle);
+  bundle.profile = 'test_exportable';
+  bundle.key.material = { type: 'embedded_pkcs8_pem', private_key_pem: privateKeyPEM };
+  const fingerprint8 = bundle.certificate.fingerprint_sha256.slice(0, 8);
+  const safeID = bundle.identity.id.replace(/[^A-Za-z0-9._-]/g, '_');
+  const filename = `rtk-${bundle.environment}-${bundle.usage}-${safeID}-${fingerprint8}.certificate-bundle.json`;
+  const url = URL.createObjectURL(new Blob([`${JSON.stringify(bundle, null, 2)}\n`], { type: 'application/vnd.realtek.rtk-certificate-bundle+json' }));
+  const anchor = document.createElement('a'); anchor.href = url; anchor.download = filename; anchor.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}

--- a/web/src/certificateBundle.test.mjs
+++ b/web/src/certificateBundle.test.mjs
@@ -1,0 +1,11 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createP256CSR } from './certificateBundle.mjs';
+
+test('browser PKI helper creates P-256 PKCS#8 and sends only a CSR-shaped value', async () => {
+  const generated = await createP256CSR('app-brand-cloud-user:user-001');
+  assert.match(generated.csrPEM, /^-----BEGIN CERTIFICATE REQUEST-----\n/);
+  assert.match(generated.privateKeyPEM, /^-----BEGIN PRIVATE KEY-----\n/);
+  assert.equal(generated.csrPEM.includes('PRIVATE KEY'), false);
+  assert.equal(generated.privateKeyPEM.endsWith('\n'), true);
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { createP256CSR, downloadExportableBundle } from './certificateBundle.mjs';
 import {
   billingSubpaths,
   customerNavItems,
@@ -1167,7 +1168,7 @@ function App() {
         {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'reports' ? <ReportsPage data={reports} skus={skus?.skus || []} loading={loading} canCreate={canUseCapability({ capabilities: me?.capabilities || [] }, 'reports.create')} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
         {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'provisioning' ? <ProvisioningPage canCreate={canUseCapability({ capabilities: me?.capabilities || [] }, 'provisioning.create')} /> : null}
         {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'groups' ? <GroupsPage data={groups} loading={loading} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
-        {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'access' ? <AccessPage data={access} loading={loading} activeCloudId={me?.active_org_id} canManage={canUseCapability({ capabilities: me?.capabilities || [] }, 'team.manage')} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
+        {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'access' ? <AccessPage data={access} loading={loading} activeCloudId={me?.active_org_id} canManage={canUseCapability({ capabilities: me?.capabilities || [] }, 'team.manage')} canIssuePKITest={canUseCapability({ capabilities: me?.capabilities || [] }, 'pki.test.issue')} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
         {!needsPlatformAccess && !customerViewPending && !customerViewBlocked && active === 'billing' ? <BillingPage data={billing} loading={loading} capabilities={me?.capabilities || []} onRefresh={() => setRefreshTick((tick) => tick + 1)} /> : null}
         {!needsPlatformAccess && active === 'platform-dashboard' ? <PlatformDashboardLanding dashboard={platformDashboard} summary={summary} health={health} operations={operations} logs={serviceLogs} /> : null}
         {!needsPlatformAccess && active === 'platform-grafana' ? <PlatformGrafanaView status={platformGrafanaStatus} /> : null}
@@ -2170,7 +2171,7 @@ function GroupsPage({ data, loading, onRefresh }) {
   </section>;
 }
 
-function AccessPage({ data, loading, activeCloudId, canManage, onRefresh }) {
+function AccessPage({ data, loading, activeCloudId, canManage, canIssuePKITest, onRefresh }) {
   const members = data?.members || [];
   const assignments = data?.role_assignments || [];
   const roles = data?.roles || [];
@@ -2192,6 +2193,7 @@ function AccessPage({ data, loading, activeCloudId, canManage, onRefresh }) {
     <div className="page-intro"><div><p className="eyebrow">Fleet Governance</p><h2>團隊與權限</h2><p>角色決定可以做什麼，範圍決定可以管理哪些 SKU、區域、群組或設備。</p></div>{canManage && activeCloudId ? <button type="button" className="primary" onClick={() => setMessage('請使用下方表單邀請成員。')}>＋ 邀請成員</button> : null}</div>
     {canManage && activeCloudId ? <section className="panel"><form className="inline-form" onSubmit={async (event) => { event.preventDefault(); const response = await fetch(`/api/developer/brand-clouds/${encodeURIComponent(activeCloudId)}/members/invitations`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `member-invite-${email}-${role}` }, body: JSON.stringify({ email, role }) }); setMessage(response.ok ? '成員已加入 Brand Cloud。' : '成員目前無法加入。'); if (response.ok) { setEmail(''); onRefresh(); } }}><input required type="email" placeholder="成員 Email" value={email} onChange={(event) => setEmail(event.target.value)} /><select value={role} onChange={(event) => setRole(event.target.value)}><option value="member">Member</option><option value="admin">Admin</option></select><button type="submit" className="primary">送出邀請</button></form></section> : null}
     {message ? <div className="notice">{message}</div> : null}
+    {canIssuePKITest && activeCloudId ? <PKITestBundleTool activeCloudId={activeCloudId} /> : null}
     <section className="panel"><div className="panel-head"><div><h3>Accept owner transfer</h3><p>貼上 owner transfer email 中的 token，完成 ownership 轉移。</p></div></div><form className="inline-form" onSubmit={async (event) => { event.preventDefault(); const response = await fetch('/api/developer/brand-cloud-owner-transfers/accept', { method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `owner-transfer-accept-${transferToken}` }, body: JSON.stringify({ token: transferToken }) }); setMessage(response.ok ? 'Owner transfer 已接受。' : 'Owner transfer token 無效或已過期。'); if (response.ok) { setTransferToken(''); onRefresh(); } }}><input required placeholder="Owner transfer token" value={transferToken} onChange={(event) => setTransferToken(event.target.value)} /><button type="submit" className="primary">接受轉移</button></form></section>
     {canManage && activeCloudId ? <section className="panel"><div className="panel-head"><div><h3>Owner transfer</h3><p>轉移需由目標 developer 使用 email token 接受；pending transfer 可取消。</p></div></div><form className="inline-form" onSubmit={async (event) => { event.preventDefault(); const response = await fetch(`/api/developer/brand-clouds/${encodeURIComponent(activeCloudId)}/owner-transfer`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `owner-transfer-${transferEmail}` }, body: JSON.stringify({ target_email: transferEmail }) }); const body = await response.json().catch(() => ({})); setMessage(response.ok ? 'Owner transfer 已建立。' : 'Owner transfer 目前無法建立。'); if (response.ok) { setOwnerTransfer(body.owner_transfer); setTransferEmail(''); } }}><input required type="email" placeholder="目標 developer Email" value={transferEmail} onChange={(event) => setTransferEmail(event.target.value)} /><button type="submit" className="primary">建立轉移</button></form>{ownerTransfer ? <p className="notice">{ownerTransfer.status} · {ownerTransfer.id} {ownerTransfer.status === 'pending' ? <button type="button" className="link-button" onClick={async () => { const response = await fetch(`/api/developer/brand-clouds/${encodeURIComponent(activeCloudId)}/owner-transfer/${encodeURIComponent(ownerTransfer.id)}/cancel`, { method: 'POST', headers: { 'Idempotency-Key': `owner-transfer-cancel-${ownerTransfer.id}` } }); if (response.ok) setOwnerTransfer((current) => ({ ...current, status: 'canceled' })); }}>取消</button> : null}</p> : null}</section> : null}
     {loading ? <section className="panel split-panel"><div><h3>正在載入權限</h3></div></section> : null}
@@ -2431,6 +2433,32 @@ function BillingProfilePage({ profile, tabs, canManage, onRefresh }) {
     if (response.ok) onRefresh();
   }
   return <section className="page-content billing-page" data-testid="billing-profile-page"><div className="page-intro"><div><h2>帳單資料</h2><p>新發票會保存開立當下的收件人快照，後續修改不會改寫既有文件。</p></div></div>{tabs}<section className="panel"><form className="billing-profile-form" onSubmit={submit}><label>公司／法定名稱<input value={form.legal_name || ''} onChange={(event) => setForm({ ...form, legal_name: event.target.value })} required /></label><label>統一編號<input value={form.tax_identifier || ''} onChange={(event) => setForm({ ...form, tax_identifier: event.target.value })} /></label><label>帳單 Email<input type="email" value={form.contact_email || ''} onChange={(event) => setForm({ ...form, contact_email: event.target.value })} /></label><label className="wide">帳單地址<textarea value={form.billing_address || ''} onChange={(event) => setForm({ ...form, billing_address: event.target.value })} /></label><label>語系<input value={form.locale || 'zh-TW'} onChange={(event) => setForm({ ...form, locale: event.target.value })} /></label><label>帳務時區<input value={form.timezone || 'Asia/Taipei'} onChange={(event) => setForm({ ...form, timezone: event.target.value })} /></label><label>交付方式<select value={form.delivery_preference || 'portal'} onChange={(event) => setForm({ ...form, delivery_preference: event.target.value })}><option value="portal">Portal</option><option value="portal_and_email">Portal + Email</option></select></label><div className="wide"><button type="submit" className="primary" disabled={!canManage}>儲存帳單資料</button>{message ? <p className="notice" role="status">{message}</p> : null}</div></form></section></section>;
+}
+function PKITestBundleTool({ activeCloudId }) {
+  const [kind, setKind] = useState('app');
+  const [targetType, setTargetType] = useState('brand_cloud_user');
+  const [targetId, setTargetId] = useState('');
+  const [profileId, setProfileId] = useState('');
+  const [serial, setSerial] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState('');
+  async function issue(event) {
+    event.preventDefault(); setBusy(true); setMessage('Browser 正在產生 P-256 private key 與 CSR…');
+    try {
+      const commonName = kind === 'device' ? targetId : `${targetType === 'end_user' ? 'app-end-user' : 'app-brand-cloud-user'}:${targetId}`;
+      const key = await createP256CSR(commonName);
+      const endpoint = `/api/developer/pki/test-bundles/${kind}`;
+      const requestBody = kind === 'device'
+        ? { brand_cloud_id: activeCloudId, device_item_profile_id: profileId, device_id: targetId, serial_number: serial, csr_pem: key.csrPEM }
+        : { brand_cloud_id: activeCloudId, target_type: targetType, target_id: targetId, csr_pem: key.csrPEM };
+      const response = await fetch(endpoint, { method: 'POST', cache: 'no-store', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': crypto.randomUUID() }, body: JSON.stringify(requestBody) });
+      if (!response.ok) throw new Error((await response.text()) || 'certificate issuance failed');
+      downloadExportableBundle(await response.json(), key.privateKeyPEM);
+      setMessage('30 天測試 bundle 已下載；private key 未送往 server，也未寫入 localStorage。');
+    } catch (error) { setMessage(error.message || '無法建立測試 bundle。'); }
+    finally { setBusy(false); }
+  }
+  return <section className="panel"><div className="panel-head"><div><h3>PKI Test Bundle</h3><p>本機產生 exportable P-256 key；只將 CSR 送往後端。固定有效期 30 天，僅供 local/staging。</p></div></div><form className="inline-form" onSubmit={issue}><select value={kind} onChange={(event) => setKind(event.target.value)}><option value="app">App mTLS</option><option value="device">Device mTLS</option></select>{kind === 'app' ? <select value={targetType} onChange={(event) => setTargetType(event.target.value)}><option value="brand_cloud_user">Brand Cloud user</option><option value="end_user">End user</option></select> : null}<input required placeholder={kind === 'device' ? 'Device ID' : 'User ID'} value={targetId} onChange={(event) => setTargetId(event.target.value)} />{kind === 'device' ? <><input required placeholder="Device item profile ID" value={profileId} onChange={(event) => setProfileId(event.target.value)} /><input required placeholder="Serial number" value={serial} onChange={(event) => setSerial(event.target.value)} /></> : null}<button type="submit" className="primary" disabled={busy}>{busy ? '建立中…' : '產生並下載'}</button></form>{message ? <p className="notice" role="status">{message}</p> : null}</section>;
 }
 
 function ProvisioningPage({ canCreate }) {


### PR DESCRIPTION
## Summary

- add device/app PKI test-bundle BFF endpoints guarded by pki.test.issue and the environment feature gate
- generate exportable P-256 keys and CSRs with browser WebCrypto
- merge the returned certificate-only bundle with PKCS#8 locally and download it without sending or persisting the private key

Contracts: https://github.com/hkt999rtk/rtk_cloud_contracts_doc/pull/117
Backend dependencies:
- https://github.com/hkt999rtk/rtk_video_cloud/pull/621
- https://github.com/hkt999rtk/rtk_account_manager/pull/263

This UI is explicitly a local/staging convenience for simple SDK testing. It is not the production certificate issuance flow; production keys remain device/app generated and non-exportable.

## Validation

- GOWORK=off go test ./...
- npm test (81 passed)
- npm run build