### PR TITLE
docs: complete certificate bundle test flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The design and implementation context is split across these documents:
 
 - [`docs/SPEC.md`](docs/SPEC.md): product scope, source-of-truth ownership,
   HTTP routes, and runtime architecture.
+- [`docs/developer-pki-test-bundles.md`](docs/developer-pki-test-bundles.md):
+  local/staging SDK smoke-test certificate flow and production distinction.
 - [`docs/ROLES.md`](docs/ROLES.md): Tier 1/Tier 2 responsibilities,
   capabilities, and field visibility rules.
 - [`docs/webui-customer-view-design.md`](docs/webui-customer-view-design.md):

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -458,6 +458,33 @@ Production-mode readiness precedence:
   but its source facts are local projections and are not authoritative
   production readiness.
 
+## Developer PKI Test Bundles
+
+The Developer Console exposes `POST /api/developer/pki/test-bundles/app` and
+`POST /api/developer/pki/test-bundles/device` only when
+`DEVELOPER_PKI_TEST_TOOLS_ENABLED=true` and the runtime environment is local or
+staging. Production rejects these routes even if the flag is accidentally set.
+
+These routes are deliberately simplified SDK smoke-test utilities. The browser
+uses WebCrypto to generate an exportable P-256 key and PKCS#10 CSR, sends only
+the CSR to the BFF, receives a `certificate_only` RTK Certificate Bundle v1,
+and locally creates the downloadable `test_exportable` bundle. The private key
+must not enter an HTTP request, localStorage, audit event, or application log.
+
+The active Brand Cloud must match the request. Only owner/admin sessions with
+`pki.test.issue` may issue a test bundle, every request requires
+`Idempotency-Key`, and the certificate lifetime is fixed at 30 days. App
+subjects are selected by Account Manager. Device requests are constrained to
+an active device item profile and use the existing factory-enrollment trust
+boundary. See [developer-pki-test-bundles.md](developer-pki-test-bundles.md)
+and the canonical
+[CERTIFICATE_BUNDLE.md](rtk_cloud_contracts_doc/CERTIFICATE_BUNDLE.md).
+
+This workflow is not production certificate enrollment. Production device and
+app identities use non-exportable keys generated in the device secure store,
+iOS Keychain/Secure Enclave policy, or Android Keystore policy and follow the
+formal enrollment, rotation, and revocation controls.
+
 ## Configuration
 
 ### [REQ-CA-BFF-BREAK-GLASS-001] Deployment configuration cannot enable a local break-glass login

--- a/docs/developer-pki-test-bundles.md
+++ b/docs/developer-pki-test-bundles.md
@@ -1,0 +1,58 @@
+# Developer PKI Test Bundles
+
+This document describes the Cloud Admin BFF and browser responsibilities for
+RTK Certificate Bundle v1. The canonical JSON contract remains
+[`docs/rtk_cloud_contracts_doc/CERTIFICATE_BUNDLE.md`](rtk_cloud_contracts_doc/CERTIFICATE_BUNDLE.md)
+and its JSON Schema.
+
+> This tool exists only for simple SDK parsing, import, mTLS, and scoped-token
+> smoke tests in local or staging environments. It is not the production
+> certificate issuance or provisioning flow.
+
+## Browser and BFF flow
+
+1. The browser generates an exportable P-256 key with WebCrypto.
+2. The browser creates a PKCS#10 CSR whose subject is derived from the selected
+   app or device identity.
+3. The browser sends the CSR and bounded identity selectors to the BFF. It
+   never sends the private key.
+4. The BFF verifies the active Brand Cloud, `pki.test.issue`, owner/admin role,
+   `Idempotency-Key`, environment gate, and target policy.
+5. Account Manager issues app certificates. Device issuance creates a bounded
+   production run and calls Factory Enrollment.
+6. The BFF returns a `certificate_only` bundle with `caller_managed` key
+   material and `Cache-Control: no-store`.
+7. The browser locally changes the profile to `test_exportable`, embeds the
+   unencrypted PKCS#8 PEM, validates key/certificate matching, and downloads
+   the bundle.
+
+The endpoints are:
+
+- `POST /api/developer/pki/test-bundles/app`
+- `POST /api/developer/pki/test-bundles/device`
+
+Both return
+`application/vnd.realtek.rtk-certificate-bundle+json`. Certificate lifetime is
+fixed at 30 days and is not user-configurable.
+
+## Security boundary
+
+- Enable with `DEVELOPER_PKI_TEST_TOOLS_ENABLED=true` only in local/staging.
+- `CLOUD_ADMIN_ENV=production` or `prod` always disables the endpoints.
+- App subject and SAN policy is owned by Account Manager; arbitrary subjects
+  are rejected.
+- Device issuance requires an active device item profile in the active Brand
+  Cloud and calls Factory Enrollment over an explicitly allowed private
+  service path.
+- Audit events contain request ids, target ids, hashes, and TTL metadata only.
+  They must not contain CSR PEM, certificate PEM, private keys, session tokens,
+  factory JWTs, or login credentials.
+- Private keys must not be placed in HTTP bodies, localStorage, analytics, or
+  logs. Downloaded test bundles are handled as secrets.
+
+## Production distinction
+
+Production keys remain non-exportable and caller/device managed. Formal
+manufacturing enrollment, app bootstrap, rotation, revocation, hardware-backed
+storage policy, and attestation are separate flows. Passing this tool's SDK
+smoke test is not production identity or manufacturing approval.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -761,6 +761,72 @@ paths:
         "200": { description: Owner transfer canceled }
         "404": { description: Transfer not found }
 
+  /api/developer/pki/test-bundles/app:
+    post:
+      operationId: postApiDeveloperPKITestBundleApp
+      tags: [Developer]
+      summary: Issue a short-lived app certificate bundle for SDK smoke testing
+      description: |
+        Local/staging SDK test utility only. The browser generates an exportable
+        P-256 private key and CSR, sends only the CSR, then locally combines the
+        certificate-only response with the PKCS#8 key. This is not the production
+        app certificate issuance flow; production private keys remain non-exportable.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeveloperPKIAppBundleRequest"
+      responses:
+        "200":
+          description: Certificate-only bundle; the private key remains in the browser.
+          headers:
+            Cache-Control: { schema: { type: string, example: no-store } }
+          content:
+            application/vnd.realtek.rtk-certificate-bundle+json:
+              schema:
+                $ref: "#/components/schemas/RTKCertificateBundleV1"
+        "400": { $ref: "#/components/responses/PlainTextError" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "404": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
+
+  /api/developer/pki/test-bundles/device:
+    post:
+      operationId: postApiDeveloperPKITestBundleDevice
+      tags: [Developer]
+      summary: Issue a short-lived device certificate bundle for SDK smoke testing
+      description: |
+        Local/staging SDK test utility only. The browser generates an exportable
+        P-256 private key and CSR, while the BFF constrains issuance to the active
+        Brand Cloud and an active device item profile. This does not replace formal
+        manufacturing enrollment or hardware-backed production device keys.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeveloperPKIDeviceBundleRequest"
+      responses:
+        "200":
+          description: Certificate-only bundle; the private key remains in the browser.
+          headers:
+            Cache-Control: { schema: { type: string, example: no-store } }
+          content:
+            application/vnd.realtek.rtk-certificate-bundle+json:
+              schema:
+                $ref: "#/components/schemas/RTKCertificateBundleV1"
+        "400": { $ref: "#/components/responses/PlainTextError" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "404": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
+
   /api/summary:
     get:
       operationId: getApiSummary
@@ -2940,6 +3006,82 @@ components:
           schema: { $ref: "#/components/schemas/PaymentError" }
 
   schemas:
+    DeveloperPKIAppBundleRequest:
+      type: object
+      additionalProperties: false
+      required: [brand_cloud_id, target_type, target_id, csr_pem]
+      properties:
+        brand_cloud_id: { type: string }
+        target_type: { type: string, enum: [brand_cloud_user, end_user] }
+        target_id: { type: string }
+        csr_pem:
+          type: string
+          description: P-256 PKCS#10 CSR. A private key must never be sent.
+    DeveloperPKIDeviceBundleRequest:
+      type: object
+      additionalProperties: false
+      required: [brand_cloud_id, device_item_profile_id, device_id, serial_number, csr_pem]
+      properties:
+        brand_cloud_id: { type: string }
+        device_item_profile_id: { type: string }
+        device_id: { type: string }
+        serial_number: { type: string }
+        csr_pem:
+          type: string
+          description: P-256 PKCS#10 CSR. A private key must never be sent.
+    RTKCertificateBundleV1:
+      type: object
+      additionalProperties: false
+      description: |
+        Shared certificate representation. `test_exportable` is only for simple
+        local/staging SDK tests and is never a production identity.
+      required: [format, version, profile, environment, usage, tenant_id, identity, key, certificate, issuance]
+      properties:
+        format: { type: string, enum: [rtk_certificate_bundle] }
+        version: { type: integer, enum: [1] }
+        profile: { type: string, enum: [certificate_only, test_exportable] }
+        environment: { type: string, enum: [local, staging, production] }
+        usage: { type: string, enum: [device_mtls, app_mtls] }
+        tenant_id: { type: string }
+        identity:
+          type: object
+          required: [kind, id, subject_dn, uri_sans]
+          properties:
+            kind: { type: string, enum: [device, app] }
+            id: { type: string }
+            subject_dn: { type: string }
+            uri_sans: { type: array, items: { type: string, format: uri } }
+        key:
+          type: object
+          required: [algorithm, spki_sha256, material]
+          properties:
+            algorithm: { type: string, enum: [ecdsa_p256, ed25519, rsa_2048] }
+            spki_sha256: { type: string, pattern: "^[0-9a-f]{64}$" }
+            material:
+              type: object
+              required: [type]
+              properties:
+                type: { type: string, enum: [caller_managed, key_reference, embedded_pkcs8_pem] }
+                provider: { type: string }
+                reference: { type: string }
+                private_key_pem:
+                  type: string
+                  description: Unencrypted PKCS#8; legal only for test_exportable in local/staging.
+        certificate:
+          type: object
+          required: [chain_pem, serial_number_hex, fingerprint_sha256, not_before, not_after]
+          properties:
+            chain_pem: { type: array, minItems: 1, items: { type: string } }
+            serial_number_hex: { type: string, pattern: "^(?:[0-9a-f]{2})+$" }
+            fingerprint_sha256: { type: string, pattern: "^[0-9a-f]{64}$" }
+            not_before: { type: string, format: date-time }
+            not_after: { type: string, format: date-time }
+        issuance:
+          type: object
+          required: [request_id, issued_at]
+          properties:
+            request_id: { type: string }
+            issued_at: { type: string, format: date-time }
     PaymentError:
       type: object
       additionalProperties: false


### PR DESCRIPTION
## Summary
- document the browser/BFF P-256 SDK smoke-test flow and production distinction
- add both PKI test bundle endpoints and Certificate Bundle v1 to the normative OpenAPI
- sync the canonical contracts submodule to contracts PR #117

## Validation
- OpenAPI YAML and local references validate
- Cloud Admin Go package tests pass