### PR TITLE
test: restore certificate bundle coverage gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ The design and implementation context is split across these documents:
 
 - [`docs/SPEC.md`](docs/SPEC.md): product scope, source-of-truth ownership,
   HTTP routes, and runtime architecture.
+- [`docs/developer-pki-test-bundles.md`](docs/developer-pki-test-bundles.md):
+  local/staging SDK smoke-test certificate flow and production distinction.
 - [`docs/ROLES.md`](docs/ROLES.md): Tier 1/Tier 2 responsibilities,
   capabilities, and field visibility rules.
 - [`docs/webui-customer-view-design.md`](docs/webui-customer-view-design.md):

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -458,6 +458,33 @@ Production-mode readiness precedence:
   but its source facts are local projections and are not authoritative
   production readiness.
 
+## Developer PKI Test Bundles
+
+The Developer Console exposes `POST /api/developer/pki/test-bundles/app` and
+`POST /api/developer/pki/test-bundles/device` only when
+`DEVELOPER_PKI_TEST_TOOLS_ENABLED=true` and the runtime environment is local or
+staging. Production rejects these routes even if the flag is accidentally set.
+
+These routes are deliberately simplified SDK smoke-test utilities. The browser
+uses WebCrypto to generate an exportable P-256 key and PKCS#10 CSR, sends only
+the CSR to the BFF, receives a `certificate_only` RTK Certificate Bundle v1,
+and locally creates the downloadable `test_exportable` bundle. The private key
+must not enter an HTTP request, localStorage, audit event, or application log.
+
+The active Brand Cloud must match the request. Only owner/admin sessions with
+`pki.test.issue` may issue a test bundle, every request requires
+`Idempotency-Key`, and the certificate lifetime is fixed at 30 days. App
+subjects are selected by Account Manager. Device requests are constrained to
+an active device item profile and use the existing factory-enrollment trust
+boundary. See [developer-pki-test-bundles.md](developer-pki-test-bundles.md)
+and the canonical
+[CERTIFICATE_BUNDLE.md](rtk_cloud_contracts_doc/CERTIFICATE_BUNDLE.md).
+
+This workflow is not production certificate enrollment. Production device and
+app identities use non-exportable keys generated in the device secure store,
+iOS Keychain/Secure Enclave policy, or Android Keystore policy and follow the
+formal enrollment, rotation, and revocation controls.
+
 ## Configuration
 
 ### [REQ-CA-BFF-BREAK-GLASS-001] Deployment configuration cannot enable a local break-glass login

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 78.2% |
+| Go total coverage | 79.3% |
 | Go coverage gate | >= 65.0% |
 | Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
@@ -28,8 +28,8 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 85.9% |
-| `rtk_cloud_admin/internal/app` | 78.8% |
+| `rtk_cloud_admin/internal/accountclient` | 87.8% |
+| `rtk_cloud_admin/internal/app` | 80.0% |
 | `rtk_cloud_admin/internal/billingclient` | 24.4% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |

--- a/docs/developer-pki-test-bundles.md
+++ b/docs/developer-pki-test-bundles.md
@@ -1,0 +1,58 @@
+# Developer PKI Test Bundles
+
+This document describes the Cloud Admin BFF and browser responsibilities for
+RTK Certificate Bundle v1. The canonical JSON contract remains
+[`docs/rtk_cloud_contracts_doc/CERTIFICATE_BUNDLE.md`](rtk_cloud_contracts_doc/CERTIFICATE_BUNDLE.md)
+and its JSON Schema.
+
+> This tool exists only for simple SDK parsing, import, mTLS, and scoped-token
+> smoke tests in local or staging environments. It is not the production
+> certificate issuance or provisioning flow.
+
+## Browser and BFF flow
+
+1. The browser generates an exportable P-256 key with WebCrypto.
+2. The browser creates a PKCS#10 CSR whose subject is derived from the selected
+   app or device identity.
+3. The browser sends the CSR and bounded identity selectors to the BFF. It
+   never sends the private key.
+4. The BFF verifies the active Brand Cloud, `pki.test.issue`, owner/admin role,
+   `Idempotency-Key`, environment gate, and target policy.
+5. Account Manager issues app certificates. Device issuance creates a bounded
+   production run and calls Factory Enrollment.
+6. The BFF returns a `certificate_only` bundle with `caller_managed` key
+   material and `Cache-Control: no-store`.
+7. The browser locally changes the profile to `test_exportable`, embeds the
+   unencrypted PKCS#8 PEM, validates key/certificate matching, and downloads
+   the bundle.
+
+The endpoints are:
+
+- `POST /api/developer/pki/test-bundles/app`
+- `POST /api/developer/pki/test-bundles/device`
+
+Both return
+`application/vnd.realtek.rtk-certificate-bundle+json`. Certificate lifetime is
+fixed at 30 days and is not user-configurable.
+
+## Security boundary
+
+- Enable with `DEVELOPER_PKI_TEST_TOOLS_ENABLED=true` only in local/staging.
+- `CLOUD_ADMIN_ENV=production` or `prod` always disables the endpoints.
+- App subject and SAN policy is owned by Account Manager; arbitrary subjects
+  are rejected.
+- Device issuance requires an active device item profile in the active Brand
+  Cloud and calls Factory Enrollment over an explicitly allowed private
+  service path.
+- Audit events contain request ids, target ids, hashes, and TTL metadata only.
+  They must not contain CSR PEM, certificate PEM, private keys, session tokens,
+  factory JWTs, or login credentials.
+- Private keys must not be placed in HTTP bodies, localStorage, analytics, or
+  logs. Downloaded test bundles are handled as secrets.
+
+## Production distinction
+
+Production keys remain non-exportable and caller/device managed. Formal
+manufacturing enrollment, app bootstrap, rotation, revocation, hardware-backed
+storage policy, and attestation are separate flows. Passing this tool's SDK
+smoke test is not production identity or manufacturing approval.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -761,6 +761,72 @@ paths:
         "200": { description: Owner transfer canceled }
         "404": { description: Transfer not found }
 
+  /api/developer/pki/test-bundles/app:
+    post:
+      operationId: postApiDeveloperPKITestBundleApp
+      tags: [Developer]
+      summary: Issue a short-lived app certificate bundle for SDK smoke testing
+      description: |
+        Local/staging SDK test utility only. The browser generates an exportable
+        P-256 private key and CSR, sends only the CSR, then locally combines the
+        certificate-only response with the PKCS#8 key. This is not the production
+        app certificate issuance flow; production private keys remain non-exportable.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeveloperPKIAppBundleRequest"
+      responses:
+        "200":
+          description: Certificate-only bundle; the private key remains in the browser.
+          headers:
+            Cache-Control: { schema: { type: string, example: no-store } }
+          content:
+            application/vnd.realtek.rtk-certificate-bundle+json:
+              schema:
+                $ref: "#/components/schemas/RTKCertificateBundleV1"
+        "400": { $ref: "#/components/responses/PlainTextError" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "404": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
+
+  /api/developer/pki/test-bundles/device:
+    post:
+      operationId: postApiDeveloperPKITestBundleDevice
+      tags: [Developer]
+      summary: Issue a short-lived device certificate bundle for SDK smoke testing
+      description: |
+        Local/staging SDK test utility only. The browser generates an exportable
+        P-256 private key and CSR, while the BFF constrains issuance to the active
+        Brand Cloud and an active device item profile. This does not replace formal
+        manufacturing enrollment or hardware-backed production device keys.
+      parameters:
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeveloperPKIDeviceBundleRequest"
+      responses:
+        "200":
+          description: Certificate-only bundle; the private key remains in the browser.
+          headers:
+            Cache-Control: { schema: { type: string, example: no-store } }
+          content:
+            application/vnd.realtek.rtk-certificate-bundle+json:
+              schema:
+                $ref: "#/components/schemas/RTKCertificateBundleV1"
+        "400": { $ref: "#/components/responses/PlainTextError" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "404": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
+
   /api/summary:
     get:
       operationId: getApiSummary
@@ -2940,6 +3006,82 @@ components:
           schema: { $ref: "#/components/schemas/PaymentError" }
 
   schemas:
+    DeveloperPKIAppBundleRequest:
+      type: object
+      additionalProperties: false
+      required: [brand_cloud_id, target_type, target_id, csr_pem]
+      properties:
+        brand_cloud_id: { type: string }
+        target_type: { type: string, enum: [brand_cloud_user, end_user] }
+        target_id: { type: string }
+        csr_pem:
+          type: string
+          description: P-256 PKCS#10 CSR. A private key must never be sent.
+    DeveloperPKIDeviceBundleRequest:
+      type: object
+      additionalProperties: false
+      required: [brand_cloud_id, device_item_profile_id, device_id, serial_number, csr_pem]
+      properties:
+        brand_cloud_id: { type: string }
+        device_item_profile_id: { type: string }
+        device_id: { type: string }
+        serial_number: { type: string }
+        csr_pem:
+          type: string
+          description: P-256 PKCS#10 CSR. A private key must never be sent.
+    RTKCertificateBundleV1:
+      type: object
+      additionalProperties: false
+      description: |
+        Shared certificate representation. `test_exportable` is only for simple
+        local/staging SDK tests and is never a production identity.
+      required: [format, version, profile, environment, usage, tenant_id, identity, key, certificate, issuance]
+      properties:
+        format: { type: string, enum: [rtk_certificate_bundle] }
+        version: { type: integer, enum: [1] }
+        profile: { type: string, enum: [certificate_only, test_exportable] }
+        environment: { type: string, enum: [local, staging, production] }
+        usage: { type: string, enum: [device_mtls, app_mtls] }
+        tenant_id: { type: string }
+        identity:
+          type: object
+          required: [kind, id, subject_dn, uri_sans]
+          properties:
+            kind: { type: string, enum: [device, app] }
+            id: { type: string }
+            subject_dn: { type: string }
+            uri_sans: { type: array, items: { type: string, format: uri } }
+        key:
+          type: object
+          required: [algorithm, spki_sha256, material]
+          properties:
+            algorithm: { type: string, enum: [ecdsa_p256, ed25519, rsa_2048] }
+            spki_sha256: { type: string, pattern: "^[0-9a-f]{64}$" }
+            material:
+              type: object
+              required: [type]
+              properties:
+                type: { type: string, enum: [caller_managed, key_reference, embedded_pkcs8_pem] }
+                provider: { type: string }
+                reference: { type: string }
+                private_key_pem:
+                  type: string
+                  description: Unencrypted PKCS#8; legal only for test_exportable in local/staging.
+        certificate:
+          type: object
+          required: [chain_pem, serial_number_hex, fingerprint_sha256, not_before, not_after]
+          properties:
+            chain_pem: { type: array, minItems: 1, items: { type: string } }
+            serial_number_hex: { type: string, pattern: "^(?:[0-9a-f]{2})+$" }
+            fingerprint_sha256: { type: string, pattern: "^[0-9a-f]{64}$" }
+            not_before: { type: string, format: date-time }
+            not_after: { type: string, format: date-time }
+        issuance:
+          type: object
+          required: [request_id, issued_at]
+          properties:
+            request_id: { type: string }
+            issued_at: { type: string, format: date-time }
     PaymentError:
       type: object
       additionalProperties: false

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -125,6 +125,10 @@ func TestClientFleetAndDeveloperWrappers(t *testing.T) {
 	check("DeveloperBrandClouds", err)
 	_, _, err = client.DeveloperBrandCloud(ctx, "access", "brand/1")
 	check("DeveloperBrandCloud", err)
+	_, err = client.IssueDeveloperPKITestAppCertificate(ctx, "access", "brand/1", "idem-1", "brand_cloud_user", "user/1", "csr")
+	check("IssueDeveloperPKITestAppCertificate", err)
+	_, err = client.CreateDeveloperPKITestProductionRun(ctx, "access", "brand/1", "profile/1", "idem-2", time.Now(), time.Now().Add(24*time.Hour))
+	check("CreateDeveloperPKITestProductionRun", err)
 	_, _, err = client.DeveloperBrandCloudMembers(ctx, "access", "brand/1", query)
 	check("DeveloperBrandCloudMembers", err)
 	_, err = client.InviteDeveloperBrandCloudMember(ctx, "access", "brand/1", "member@example.com", "observer")
@@ -194,7 +198,7 @@ func TestClientFleetAndDeveloperWrappers(t *testing.T) {
 	_, err = client.DisableDeviceItemProfile(ctx, "access", "org/1", "profile/1")
 	check("DisableDeviceItemProfile", err)
 
-	if requests < 45 {
+	if requests < 47 {
 		t.Fatalf("requests = %d, want broad wrapper coverage", requests)
 	}
 }

--- a/internal/app/developer_pki_test.go
+++ b/internal/app/developer_pki_test.go
@@ -1,0 +1,182 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"rtk_cloud_admin/internal/accountclient"
+	"rtk_cloud_admin/internal/config"
+)
+
+func TestDeveloperPKIAllowedFailsClosed(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  config.Config
+		key  string
+		want int
+	}{
+		{"disabled", config.Config{Environment: "staging"}, "idem", http.StatusNotFound},
+		{"production", config.Config{Environment: "production", DeveloperPKITestToolsEnabled: true}, "idem", http.StatusNotFound},
+		{"production alias", config.Config{Environment: "prod", DeveloperPKITestToolsEnabled: true}, "idem", http.StatusNotFound},
+		{"missing idempotency", config.Config{Environment: "staging", DeveloperPKITestToolsEnabled: true}, "", http.StatusPreconditionRequired},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := &Server{cfg: tc.cfg}
+			req := httptest.NewRequest(http.MethodPost, "/", nil)
+			req.Header.Set("Idempotency-Key", tc.key)
+			rec := httptest.NewRecorder()
+			if _, ok := srv.developerPKIAllowed(rec, req); ok {
+				t.Fatal("expected request rejection")
+			}
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d", rec.Code, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeveloperPKIAppBundleProxy(t *testing.T) {
+	var gotBody map[string]string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/developer/brand-clouds/brand-1/pki/test-app-certificates" {
+			t.Fatalf("path = %s", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer access" || r.Header.Get("Idempotency-Key") != "idem-app" {
+			t.Fatalf("headers = %#v", r.Header)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"certificate_bundle": map[string]any{"format": "rtk_certificate_bundle", "version": 1}})
+	}))
+	defer upstream.Close()
+
+	srv, sessionID := newDeveloperPKITestServer(t, upstream.URL, "")
+	req := developerPKIRequest(t, sessionID, "/api/developer/pki/test-bundles/app", "idem-app", `{"brand_cloud_id":"brand-1","target_type":"brand_cloud_user","target_id":"user-1","csr_pem":"CSR"}`)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Header().Get("Content-Type") != certificateBundleMIME || rec.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("response status=%d headers=%v body=%s", rec.Code, rec.Header(), rec.Body.String())
+	}
+	if gotBody["target_id"] != "user-1" || gotBody["csr_pem"] != "CSR" || strings.Contains(rec.Body.String(), "PRIVATE KEY") {
+		t.Fatalf("upstream body=%v response=%s", gotBody, rec.Body.String())
+	}
+
+	for _, tc := range []struct {
+		name, body, session string
+		want                int
+	}{
+		{"unauthenticated", `{}`, "", http.StatusUnauthorized},
+		{"invalid JSON", `{`, sessionID, http.StatusBadRequest},
+		{"cross tenant", `{"brand_cloud_id":"brand-2"}`, sessionID, http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := developerPKIRequest(t, tc.session, "/api/developer/pki/test-bundles/app", "idem-error", tc.body)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestDeveloperPKIDeviceBundleProxy(t *testing.T) {
+	var factoryBody map[string]any
+	factory := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/factory/enroll" || r.Header.Get("Authorization") != "Bearer factory-jwt" {
+			t.Fatalf("factory request path=%s headers=%v", r.URL.Path, r.Header)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&factoryBody); err != nil {
+			t.Fatal(err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"certificate_bundle": map[string]any{"format": "rtk_certificate_bundle", "version": 1}})
+	}))
+	defer factory.Close()
+
+	account := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && strings.HasSuffix(r.URL.Path, "/device-item-profiles/profile-1"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"device_item_profile": map[string]any{"id": "profile-1", "status": "active", "service_options": []string{"video"}}})
+		case r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/device-item-profiles/profile-1/production-runs"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"production_run": map[string]any{"id": "run-1"}, "factory_jwt": "factory-jwt"})
+		default:
+			t.Fatalf("unexpected account request: %s %s", r.Method, r.URL.Path)
+		}
+	}))
+	defer account.Close()
+
+	srv, sessionID := newDeveloperPKITestServer(t, account.URL, factory.URL)
+	body := `{"brand_cloud_id":"brand-1","device_item_profile_id":"profile-1","device_id":"device-1","serial_number":"serial-1","csr_pem":"CSR"}`
+	req := developerPKIRequest(t, sessionID, "/api/developer/pki/test-bundles/device", "idem-device", body)
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK || rec.Header().Get("Content-Type") != certificateBundleMIME {
+		t.Fatalf("response status=%d headers=%v body=%s", rec.Code, rec.Header(), rec.Body.String())
+	}
+	if factoryBody["devid"] != "device-1" || factoryBody["ttl_days"].(float64) != 30 || factoryBody["production_run_id"] != "run-1" {
+		t.Fatalf("factory body = %#v", factoryBody)
+	}
+
+	for _, tc := range []struct {
+		name, session, body string
+		want                int
+	}{
+		{"unauthenticated", "", body, http.StatusUnauthorized},
+		{"invalid JSON", sessionID, `{`, http.StatusBadRequest},
+		{"invalid fields", sessionID, `{"brand_cloud_id":"brand-2"}`, http.StatusForbidden},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := developerPKIRequest(t, tc.session, "/api/developer/pki/test-bundles/device", "idem-device-error", tc.body)
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, req)
+			if rec.Code != tc.want {
+				t.Fatalf("status = %d, want %d; body=%s", rec.Code, tc.want, rec.Body.String())
+			}
+		})
+	}
+
+	noFactory, noFactorySession := newDeveloperPKITestServer(t, account.URL, "")
+	req = developerPKIRequest(t, noFactorySession, "/api/developer/pki/test-bundles/device", "idem-device-2", body)
+	rec = httptest.NewRecorder()
+	noFactory.ServeHTTP(rec, req)
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("unconfigured factory status = %d", rec.Code)
+	}
+}
+
+func newDeveloperPKITestServer(t *testing.T, accountURL, factoryURL string) (*Server, string) {
+	t.Helper()
+	st := mustOpenStore(t)
+	session, err := st.CreateSession("customer", "user-1", "developer@example.com", "access", "refresh", "brand-1", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv := NewWithOptions(st, Options{
+		Config: config.Config{
+			Environment: "staging", DeveloperPKITestToolsEnabled: true,
+			AccountManagerBaseURL: accountURL, FactoryEnrollBaseURL: factoryURL,
+		},
+		AccountClient: accountclient.New(accountURL),
+	})
+	return srv, session.ID
+}
+
+func developerPKIRequest(t *testing.T, sessionID, path, key, body string) *http.Request {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req := httptest.NewRequest(http.MethodPost, path, reader)
+	req.Header.Set("Idempotency-Key", key)
+	if sessionID != "" {
+		req.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: sessionID})
+	}
+	return req
+}


### PR DESCRIPTION
## Summary
- cover Account Manager PKI wrapper request construction
- cover app/device Developer PKI BFF boundaries and fail-closed behavior
- restore accountclient and internal/app coverage ratchets without lowering thresholds

## Tests
- `GOWORK=off go test ./internal/accountclient ./internal/app -count=1`
- accountclient coverage: 87.8% (ratchet 87.5%)
- internal/app coverage: 80.0% (ratchet 79.9%)

Required by hkt999rtk/rtk_cloud_workspace#323.