### PR TITLE
Improve signup verification and responsive console UX

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -28,7 +28,7 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 88.2% |
+| `rtk_cloud_admin/internal/accountclient` | 88.3% |
 | `rtk_cloud_admin/internal/app` | 80.0% |
 | `rtk_cloud_admin/internal/billingclient` | 24.4% |
 | `rtk_cloud_admin/internal/config` | 100.0% |

--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -121,6 +121,8 @@ Reference: `docs/assets/webui-design/customer-view-refresh-mock.html` — 影像
 - The verification page shows `New password` and sends exactly `token` and
   `new_password`; successful activation creates the initial authenticated
   session.
+- The verification token is consumed from the callback URL only. Its value is
+  not rendered in page text, form controls, the DOM, or screenshots.
 - Check-email and verification routes cover pending verification, success,
   expired token, invalid token, already verified, resend, and service-unavailable
   states.

--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -123,6 +123,8 @@ Reference: `docs/assets/webui-design/customer-view-refresh-mock.html` — 影像
   session.
 - The verification token is consumed from the callback URL only. Its value is
   not rendered in page text, form controls, the DOM, or screenshots.
+- Verification links expire after the Account Manager-configured TTL (30
+  minutes by default); expired links are rejected and the user must resend.
 - Check-email and verification routes cover pending verification, success,
   expired token, invalid token, already verified, resend, and service-unavailable
   states.

--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -108,6 +108,16 @@ Reference: `docs/assets/webui-design/customer-view-refresh-mock.html` — 影像
 
 - Signup route is evaluation-tier only and does not imply commercial brand-cloud
   user creation.
+- The standalone auth page labels its two first-class tabs `Login` and
+  `Sign Up`; it does not use `Sign-in` as the signup label.
+- `Login` authenticates an existing account. `Sign Up` opens the same
+  evaluation-account creation flow as `/signup` and continues to the
+  signup check-email state.
+- Both Sign Up entry points show only `Email` and `Password`. They do not show
+  organization name, display name, a manual CAPTCHA token, or a
+  terms-acceptance checkbox.
+- Submitting either Sign Up entry point sends exactly `email` and `password` to
+  `POST /api/auth/customer/signup`.
 - Check-email and verification routes cover pending verification, success,
   expired token, invalid token, already verified, resend, and service-unavailable
   states.

--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -113,11 +113,14 @@ Reference: `docs/assets/webui-design/customer-view-refresh-mock.html` — 影像
 - `Login` authenticates an existing account. `Sign Up` opens the same
   evaluation-account creation flow as `/signup` and continues to the
   signup check-email state.
-- Both Sign Up entry points show only `Email` and `Password`. They do not show
+- Both Sign Up entry points show only `Email`. They do not show password,
   organization name, display name, a manual CAPTCHA token, or a
   terms-acceptance checkbox.
-- Submitting either Sign Up entry point sends exactly `email` and `password` to
+- Submitting either Sign Up entry point sends exactly `email` to
   `POST /api/auth/customer/signup`.
+- The verification page shows `New password` and sends exactly `token` and
+  `new_password`; successful activation creates the initial authenticated
+  session.
 - Check-email and verification routes cover pending verification, success,
   expired token, invalid token, already verified, resend, and service-unavailable
   states.

--- a/docs/customer-view-visual-qa-checklist.md
+++ b/docs/customer-view-visual-qa-checklist.md
@@ -161,7 +161,7 @@ Use this mapping when reviewing developer issues opened from
 | --- | --- |
 | 1. WebUI foundation cleanup and route guards | Global shell, hidden Groups, role-gated Platform switcher, wrong-role route gates |
 | 2. Customer View source-aware page states | Loading, empty, filtered-empty, source-unavailable, gateway-error, and read-only panel states |
-| 3. Fleet Health Overview completion | Overview KPI strip, trend chart, health distribution, recent alerts, attention queue, quota callout |
+| 3. Fleet Health Overview completion | Overview KPI strip, health distribution, trend chart, combined attention list, region summary, quota callout |
 | 4. Devices table and detail drawer completion | Device filters, selected row, drawer overview, source facts, telemetry panels, provision/deactivate states |
 | 5. Firmware & OTA read-only workflows | Firmware distribution, campaign summary/table, read-only drill-down, unsupported policies, firmware risk queue |
 | 6. Stream Health read-only workflows | Stream KPIs, trend, source-backed By Mode rows, per-device table, attention routing |
@@ -172,7 +172,10 @@ Use this mapping when reviewing developer issues opened from
 ## Responsive Checks
 
 - At desktop width, sidebar stays fixed-width and tables remain readable.
-- At tablet/mobile width, sidebar stacks above content.
+- Below 1024px, the persistent sidebar is replaced by a sticky app bar and
+  off-canvas drawer with focus containment and Escape-to-close.
+- Overview is checked at 360×800, 390×844, 768×1024, 1024×768, and 1440×1000;
+  none may introduce page-level horizontal overflow.
 - Tables scroll horizontally rather than clipping columns.
 - Drawer fits within viewport and remains scrollable.
 - Charts remain visible and do not overlap adjacent panels.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -150,7 +150,7 @@ paths:
         - REQ-E2E-CA-SIGNUP-EMAIL-001
       tags: [Auth]
       summary: Verify a customer signup email and set its initial password
-      description: Proxies the token and new password to Account Manager and creates a customer session when tokens are returned.
+      description: Proxies the callback token and new password to Account Manager and creates a customer session when tokens are returned. The Web UI consumes the opaque token from the callback URL without rendering it or exposing an editable token field.
       security: []
       requestBody:
         required: true

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3357,7 +3357,7 @@ components:
           minLength: 8
     SignupRequest:
       type: object
-      required: [email, password, organization_name]
+      required: [email, password]
       properties:
         email:
           type: string
@@ -3365,10 +3365,12 @@ components:
         password:
           type: string
           format: password
+          minLength: 8
         display_name:
           type: string
         organization_name:
           type: string
+          description: Optional initial Brand Cloud name. Blank or omitted values fall back to the normalized email.
         captcha_token:
           type: string
     SignupResult:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -149,15 +149,15 @@ paths:
       x-rtk-requirement-ids:
         - REQ-E2E-CA-SIGNUP-EMAIL-001
       tags: [Auth]
-      summary: Verify a customer signup email token
-      description: Proxies token verification to Account Manager and creates a customer session when tokens are returned.
+      summary: Verify a customer signup email and set its initial password
+      description: Proxies the token and new password to Account Manager and creates a customer session when tokens are returned.
       security: []
       requestBody:
         required: true
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/AuthTokenRequest"
+              $ref: "#/components/schemas/VerifyEmailRequest"
       responses:
         "200":
           description: Verification succeeded.
@@ -3357,22 +3357,12 @@ components:
           minLength: 8
     SignupRequest:
       type: object
-      required: [email, password]
+      required: [email]
       properties:
         email:
           type: string
           format: email
-        password:
-          type: string
-          format: password
-          minLength: 8
-        display_name:
-          type: string
-        organization_name:
-          type: string
-          description: Optional initial Brand Cloud name. Blank or omitted values fall back to the normalized email.
-        captcha_token:
-          type: string
+      additionalProperties: false
     SignupResult:
       type: object
       required: [user, organization]
@@ -3387,6 +3377,17 @@ components:
       properties:
         token:
           type: string
+    VerifyEmailRequest:
+      type: object
+      required: [token, new_password]
+      properties:
+        token:
+          type: string
+        new_password:
+          type: string
+          format: password
+          minLength: 8
+      additionalProperties: false
     VerifyEmailResult:
       type: object
       required: [user]

--- a/docs/webui-browser-qa.md
+++ b/docs/webui-browser-qa.md
@@ -34,8 +34,12 @@ gitignored.
   - Platform Operations Log
   - Platform SSO Providers
   - Platform Audit Log
+- Responsive Overview at 360px, 390px, 768px, 1024px, and 1440px:
+  - No page-level horizontal overflow
+  - KPI and operational panels follow the status-first hierarchy
+  - Below 1024px, the sticky app bar opens a keyboard-accessible navigation
+    drawer; Escape closes it
 - Mobile 390px:
-  - Customer sidebar/nav remains visible
   - Devices uses compact rows instead of rendering the full table
   - Platform Dashboard remains navigable and readable on a narrow viewport
   - Public signup remains usable on a narrow viewport

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -304,28 +304,27 @@ Login page:
 
 - Use the Realtek logo asset, followed by the `Connect+ Ops` product label.
 - The auth page is a normal website-style entry page with two first-class
-  modes: `Login` and `Sign-in`. Do not model either mode as a fallback hidden
-  behind copy such as `Use password instead`.
+  modes: `Login` and `Sign Up`. Do not model either mode as a fallback hidden
+  behind secondary copy.
 - `Login` is the default mode for an existing Admin Console user. It shows
   `Email`, `Password`, a primary `Login` action, and a `Forgot password?`
   link. Password login keeps the existing platform/customer login behavior.
-- `Sign-in` is the email activation-link mode. It shows one `Email` field and
-  a primary `Continue` action that calls `POST /api/auth/sign-in`. The UI copy
-  must make clear that this sends an activation/sign-in link instead of
-  logging in immediately.
-- The `Login` / `Sign-in` switcher must be visible in the first viewport, for
+- `Sign Up` is the public evaluation-account creation mode. It collects the
+  minimum Account Manager signup fields: `Email` and `Password`. It does not ask
+  for `Organization name`, `Display name`, a manual `CAPTCHA token`, or terms
+  acceptance. It calls
+  `POST /api/auth/customer/signup`; a successful response creates a new
+  pending-verification account, uses the normalized email as the default initial
+  Brand Cloud name, and routes to `/signup/check-email`.
+- The `Login` / `Sign Up` switcher must be visible in the first viewport, for
   example as tabs or a segmented control directly above the form.
 - The email field label is `Email`; do not use `Work email`.
 - Do not show a top-right `Need help?` link on the login page.
 - Keep login copy short and operational. Avoid support, marketing, or
   instructional links in the first viewport.
-- `/login/check-email` confirms that a sign-in request was accepted. The copy
-  must be enumeration-safe and must not reveal whether the account exists,
-  is disabled, or was rate limited.
-- `/login/activate` consumes a login activation token and creates the Admin
-  Console session only after Account Manager returns successful credentials.
-  Invalid, expired, or replayed tokens show a compact failure state with a
-  route back to `/login`.
+- The existing Account Manager email activation-link sign-in API remains an
+  authentication capability, but it is not exposed as the account-creation tab
+  and must not be labeled `Sign Up`.
 - `/forgot-password` requests a password reset token by email and returns the
   same accepted UI for known, unknown, disabled, or throttled accounts.
 - `/reset-password` consumes a reset token, writes the new password through
@@ -373,10 +372,10 @@ Capability and role behavior:
 Auth and access states:
 
 - Unauthenticated users see the standalone Admin Console auth page. `Login`
-  and `Sign-in` are both first-class modes, with `Login` selected by default.
-- Signup entry points route to the self-service evaluation flow documented in
-  `SPEC.md`; commercial brand-cloud user creation is separate and platform
-  admin-owned.
+  and `Sign Up` are both first-class modes, with `Login` selected by default.
+- The `Sign Up` tab and direct `/signup` route open the same self-service
+  evaluation flow documented in `SPEC.md`; commercial brand-cloud user
+  creation is separate and platform admin-owned.
 - SSO callback, verification, expired-token, and gateway-error states need
   dedicated copy. Do not leave users on a blank dashboard shell while auth state
   is pending.
@@ -575,9 +574,13 @@ Design requirements:
 - Signup is for public evaluation-tier onboarding only. It creates a pending
   Account Manager signup and must not be used for commercial brand-cloud user
   creation.
-- The signup form collects the minimum Account Manager fields needed to start
-  evaluation onboarding and shows that verification email is required before
-  account use.
+- The `Sign Up` tab on the standalone auth page and the direct `/signup` route
+  are two entry points to this same flow; they must submit the same payload,
+  containing only `email` and `password`, and produce the same
+  pending-verification state.
+- The signup form collects only email and password. Optional profile,
+  organization-name, manual CAPTCHA-token, and terms-acceptance fields are not
+  exposed. Verification email is required before account use.
 - The check-email state explains that the user must verify email before signing
   in. It may offer resend only through the Account Manager-backed API.
 - The verification landing state handles success, expired token, invalid token,

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -275,7 +275,9 @@ Status color usage:
 
 ## App Shell
 
-The Customer View shell uses a fixed left sidebar and a full-height work area.
+The Customer View shell uses a fixed left sidebar and a full-height work area on
+desktop. Below 1024px, it uses a sticky top app bar and an off-canvas navigation
+drawer; the full sidebar must not consume the first mobile viewport.
 
 Sidebar:
 
@@ -391,12 +393,25 @@ Required layout:
 
 - KPI strip with current online devices, seven-day online ratio, devices needing
   attention, and devices playing now.
-- Large device-status trend chart with online ratio plus attention trends.
 - Health distribution panel with Normal, Needs attention, Serious problem, and
   No data.
+- Large device-status trend chart with online ratio plus attention trends.
 - One **Devices that need attention** list with Device, Problem, Time, and one
   direct action. Do not render separate Recent Alerts and Attention Queue
   panels.
+- Region summary follows the attention list. Ranked region bars are primary on
+  mobile; the map is available behind a `View map` disclosure.
+
+Responsive hierarchy:
+
+- At 1280px and wider, show four KPI cards, the desktop sidebar, and the
+  two-column Health Distribution / Fleet Health Trend row.
+- From 1024px through 1279px, keep the desktop sidebar, use a 2 × 2 KPI grid,
+  and stack operational panels into one column.
+- Below 1024px, use the sticky app bar and keyboard-accessible navigation
+  drawer, a 2 × 2 KPI grid, and single-column operational panels.
+- Below 360px, KPI cards may collapse to one column. No supported viewport may
+  introduce page-level horizontal overflow.
 
 Behavior notes:
 
@@ -641,8 +656,9 @@ before implementation is considered complete:
 - Partial failure: keep successful rows/results visible and identify retryable
   failed items.
 - Read-only: expose data normally and remove or disable write controls.
-- Mobile/tablet: keep the sidebar and tables usable; tables may scroll
-  horizontally rather than dropping required columns.
+- Mobile/tablet: use the sticky app bar and off-canvas navigation drawer below
+  1024px. Purpose-built compact lists are preferred where defined; data tables
+  may scroll horizontally rather than dropping required columns.
 
 ## Implementation Notes
 
@@ -662,7 +678,8 @@ before implementation is considered complete:
 ## Review Checklist
 
 - Customer View pages use the Realtek Ops Console palette and density.
-- All pages keep the left sidebar + main work area structure.
+- Desktop pages keep the left sidebar + main work area structure; below 1024px
+  they use the shared top app bar + off-canvas drawer shell.
 - Customer View does not contain Platform View content.
 - Brand Fleet navigation exposes Groups, Tags, Batch Jobs, and Reports according
   to role capabilities, without a second device-registration workflow.

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -584,8 +584,10 @@ Design requirements:
 - The verification landing state asks the user to create a password of at least
   eight characters. It submits `token` and `new_password` together so Account
   Manager atomically sets the initial password, verifies the email, clears the
-  pending state, and issues the initial session. It also handles expired token,
-  invalid token, already verified, and service-unavailable outcomes.
+  pending state, and issues the initial session. The callback token is an opaque
+  credential read from the URL and must never be rendered as page text, a form
+  control, or any other DOM content. It also handles expired token, invalid
+  token, already verified, and service-unavailable outcomes.
 - Evaluation-tier quota copy uses the Account Manager quota fields
   `tier=evaluation` and `evaluation_device_quota`; it must not imply commercial
   entitlement or automatic quota approval.

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -586,8 +586,11 @@ Design requirements:
   Manager atomically sets the initial password, verifies the email, clears the
   pending state, and issues the initial session. The callback token is an opaque
   credential read from the URL and must never be rendered as page text, a form
-  control, or any other DOM content. It also handles expired token, invalid
-  token, already verified, and service-unavailable outcomes.
+  control, or any other DOM content. Verification links expire according to
+  Account Manager's `EMAIL_VERIFICATION_TTL`, which defaults to 30 minutes;
+  expired links must be rejected and direct the user to request another email.
+  It also handles invalid token, already verified, and service-unavailable
+  outcomes.
 - Evaluation-tier quota copy uses the Account Manager quota fields
   `tier=evaluation` and `evaluation_device_quota`; it must not imply commercial
   entitlement or automatic quota approval.

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -622,6 +622,32 @@ Design requirements:
   `tier=evaluation` and `evaluation_device_quota`; it must not imply commercial
   entitlement or automatic quota approval.
 
+#### Signup And Verification Lifecycle
+
+The WebUI lifecycle is:
+
+| Stage | Account/token state | Required UI | Next transition |
+| --- | --- | --- | --- |
+| Start | No account exists for the email | `Sign Up` on `/login` or `/signup`; collect only email | Submit signup and open `/signup/check-email` |
+| Awaiting verification | Account is enabled, unverified, signup-pending, and has an active verification token | Explain that a verification email was sent; do not expose the token | Open the email link or request resend through the Account Manager-backed API |
+| Valid link | The non-consuming status check returns `valid` | `/verify` shows only the new-password form and never renders the token | Submit `token` and `new_password` to complete verification |
+| Expired link | The status check returns `expired` | Immediately replace the location with `/signup/verification-expired`; show no password field or token | `Sign up again` opens `/signup` |
+| Restart after expiry | The account is still unverified and signup-pending, with no active verification token | Accept the same email as a recovery signup | Reuse the pending account and Brand Cloud, issue a fresh token, and return to `/signup/check-email` |
+| Completed | Email is verified, signup-pending is cleared, the password is stored, and an initial session exists | Redirect to `/console/overview` | Future access uses `Login` |
+
+Exception rules:
+
+- Signup for a verified account or a pending account that still has an active
+  verification token is a conflict; the WebUI must not create another account.
+- `invalid` is distinct from `expired`. An invalid or already-consumed token
+  must not be described as an expired link.
+- The Account Manager verification response remains authoritative. If the token
+  expires after the initial status check but before submission, verification
+  must fail without changing the account. Refreshing or reopening the link runs
+  the status check again and transitions to the expired-verification page.
+- Network and upstream failures preserve the current state and show a retryable,
+  customer-safe error; they must not be presented as token expiry.
+
 ### SSO Login And Session Gates
 
 Required behavior:

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -320,6 +320,10 @@ Login page:
 - The `Login` / `Sign Up` switcher must be visible in the first viewport, for
   example as tabs or a segmented control directly above the form.
 - The email field label is `Email`; do not use `Work email`.
+- A duplicate signup email is an account conflict, not a service outage. Show
+  `An account already exists for this email. Log in or reset your password.`;
+  reserve the temporary-unavailable message for gateway, timeout, and 5xx
+  failures.
 - Do not show a top-right `Need help?` link on the login page.
 - Keep login copy short and operational. Avoid support, marketing, or
   instructional links in the first viewport.

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -309,10 +309,9 @@ Login page:
 - `Login` is the default mode for an existing Admin Console user. It shows
   `Email`, `Password`, a primary `Login` action, and a `Forgot password?`
   link. Password login keeps the existing platform/customer login behavior.
-- `Sign Up` is the public evaluation-account creation mode. It collects the
-  minimum Account Manager signup fields: `Email` and `Password`. It does not ask
-  for `Organization name`, `Display name`, a manual `CAPTCHA token`, or terms
-  acceptance. It calls
+- `Sign Up` is the public evaluation-account creation mode. It collects only
+  `Email`. It does not ask for a password, `Organization name`, `Display name`,
+  a manual `CAPTCHA token`, or terms acceptance. It calls
   `POST /api/auth/customer/signup`; a successful response creates a new
   pending-verification account, uses the normalized email as the default initial
   Brand Cloud name, and routes to `/signup/check-email`.
@@ -576,16 +575,17 @@ Design requirements:
   creation.
 - The `Sign Up` tab on the standalone auth page and the direct `/signup` route
   are two entry points to this same flow; they must submit the same payload,
-  containing only `email` and `password`, and produce the same
-  pending-verification state.
-- The signup form collects only email and password. Optional profile,
+  containing only `email`, and produce the same pending-verification state.
+- The signup form collects only email. Password, optional profile,
   organization-name, manual CAPTCHA-token, and terms-acceptance fields are not
-  exposed. Verification email is required before account use.
+  exposed during signup. Verification email is required before account use.
 - The check-email state explains that the user must verify email before signing
   in. It may offer resend only through the Account Manager-backed API.
-- The verification landing state handles success, expired token, invalid token,
-  already verified, and service-unavailable outcomes. Success routes users
-  toward the email/password login flow for the newly verified account.
+- The verification landing state asks the user to create a password of at least
+  eight characters. It submits `token` and `new_password` together so Account
+  Manager atomically sets the initial password, verifies the email, clears the
+  pending state, and issues the initial session. It also handles expired token,
+  invalid token, already verified, and service-unavailable outcomes.
 - Evaluation-tier quota copy uses the Account Manager quota fields
   `tier=evaluation` and `evaluation_device_quota`; it must not imply commercial
   entitlement or automatic quota approval.

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -585,6 +585,7 @@ Required routes:
 
 - `/signup`
 - `/signup/check-email`
+- `/signup/verification-expired`
 - `/verify`
 
 Design requirements:
@@ -606,10 +607,17 @@ Design requirements:
   pending state, and issues the initial session. The callback token is an opaque
   credential read from the URL and must never be rendered as page text, a form
   control, or any other DOM content. Verification links expire according to
-  Account Manager's `EMAIL_VERIFICATION_TTL`, which defaults to 30 minutes;
-  expired links must be rejected and direct the user to request another email.
-  It also handles invalid token, already verified, and service-unavailable
-  outcomes.
+  Account Manager's `EMAIL_VERIFICATION_TTL`, which defaults to 30 minutes.
+  Before rendering the password form, the page must perform a non-consuming
+  token-status check. A valid link may show the password form; an expired link
+  must immediately replace the browser location with
+  `/signup/verification-expired`.
+- The dedicated expired-verification page is a terminal explanation state. It
+  must not render the token or password form. Its primary action is
+  `Sign up again`, linking to `/signup`, so an unverified account whose last
+  verification token expired can restart signup and receive a new email.
+  Invalid-token, already-verified, and service-unavailable outcomes remain
+  distinct states and must not be presented as an expired link.
 - Evaluation-tier quota copy uses the Account Manager quota fields
   `tier=evaluation` and `evaluation_device_quota`; it must not imply commercial
   entitlement or automatic quota approval.

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -431,9 +431,12 @@ sign-in path.
 - Replace the ambiguous `Login` / `Sign-in` auth-mode tabs with `Login` /
   `Sign Up`. `Login` authenticates an existing account; `Sign Up` executes the
   public evaluation-account creation flow and proceeds to email verification.
-- Keep both Sign Up entry points minimal: show only `Email` and `Password`, and
-  submit only `email` and `password`. Do not expose organization name, display
-  name, a manual CAPTCHA token, or a terms-acceptance checkbox.
+- Keep both Sign Up entry points minimal: show only `Email` and submit only
+  `email`. Do not expose password, organization name, display name, a manual
+  CAPTCHA token, or a terms-acceptance checkbox during signup.
+- On the verification page, collect `New password` and submit it with the
+  verification token. Account Manager must set the initial password and verify
+  the account atomically before issuing the first session.
 - Route platform password login through Account Manager platform-admin
   authorization during migration.
 - Complete `/signup`, `/signup/check-email`, and `/verify` states for public
@@ -466,10 +469,12 @@ sign-in path.
   tabs, with `Login` selected by default.
 - The `Sign Up` tab and `/signup` route submit the same Account Manager-backed
   evaluation signup and create a pending-verification account.
-- Both signup entry points show only `Email` and `Password`; their request body
-  contains exactly `email` and `password`.
-- Signup does not show organization-name, display-name, manual CAPTCHA-token,
-  or terms-acceptance controls.
+- Both signup entry points show only `Email`; their request body contains
+  exactly `email`.
+- Signup does not show password, organization-name, display-name, manual
+  CAPTCHA-token, or terms-acceptance controls.
+- Verification requires `token` and `new_password`; success leaves no verified
+  account without a usable password.
 - Signup is clearly evaluation-tier only.
 - Verification and login errors use user-facing copy without exposing internal
   upstream payloads.
@@ -481,8 +486,9 @@ sign-in path.
 - `cd web && npm test`
 - `cd web && npm run build`
 - `cd web && npm run browser:smoke`
-- Browser smoke verifies the two-field signup form and exact
-  `{email, password}` request payload on `/login` and `/signup`.
+- Browser smoke verifies the email-only signup form and exact `{email}` request
+  payload on `/login` and `/signup`, then verifies the `{token, new_password}`
+  activation payload.
 - `GOWORK=off go test ./...` if BFF auth, signup, verification, or quota behavior
   changes.
 

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -428,6 +428,12 @@ sign-in path.
 
 - Polish email/password login states: idle, submitting, denied access,
   unavailable source, and retry.
+- Replace the ambiguous `Login` / `Sign-in` auth-mode tabs with `Login` /
+  `Sign Up`. `Login` authenticates an existing account; `Sign Up` executes the
+  public evaluation-account creation flow and proceeds to email verification.
+- Keep both Sign Up entry points minimal: show only `Email` and `Password`, and
+  submit only `email` and `password`. Do not expose organization name, display
+  name, a manual CAPTCHA token, or a terms-acceptance checkbox.
 - Route platform password login through Account Manager platform-admin
   authorization during migration.
 - Complete `/signup`, `/signup/check-email`, and `/verify` states for public
@@ -456,6 +462,14 @@ sign-in path.
 ## Acceptance Criteria
 
 - Public auth pages are outside Customer View and Platform View section nav.
+- The first auth viewport presents `Login` and `Sign Up` as the two first-class
+  tabs, with `Login` selected by default.
+- The `Sign Up` tab and `/signup` route submit the same Account Manager-backed
+  evaluation signup and create a pending-verification account.
+- Both signup entry points show only `Email` and `Password`; their request body
+  contains exactly `email` and `password`.
+- Signup does not show organization-name, display-name, manual CAPTCHA-token,
+  or terms-acceptance controls.
 - Signup is clearly evaluation-tier only.
 - Verification and login errors use user-facing copy without exposing internal
   upstream payloads.
@@ -467,7 +481,10 @@ sign-in path.
 - `cd web && npm test`
 - `cd web && npm run build`
 - `cd web && npm run browser:smoke`
-- `go test ./...` if BFF auth, signup, verification, or quota behavior changes.
+- Browser smoke verifies the two-field signup form and exact
+  `{email, password}` request payload on `/login` and `/signup`.
+- `GOWORK=off go test ./...` if BFF auth, signup, verification, or quota behavior
+  changes.
 
 ## References
 

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -437,6 +437,9 @@ sign-in path.
 - On the verification page, collect `New password` and submit it with the
   verification token. Account Manager must set the initial password and verify
   the account atomically before issuing the first session.
+- Treat the callback verification token as an opaque credential. Read it from
+  the URL and submit it internally, but never render its value or expose an
+  editable token field in the page DOM.
 - Route platform password login through Account Manager platform-admin
   authorization during migration.
 - Complete `/signup`, `/signup/check-email`, and `/verify` states for public

--- a/docs/webui-implementation-roadmap.md
+++ b/docs/webui-implementation-roadmap.md
@@ -440,6 +440,9 @@ sign-in path.
 - Treat the callback verification token as an opaque credential. Read it from
   the URL and submit it internally, but never render its value or expose an
   editable token field in the page DOM.
+- Verification links use Account Manager's configurable
+  `EMAIL_VERIFICATION_TTL` and expire after 30 minutes by default. Expired links
+  are rejected and require a resend.
 - Route platform password login through Account Manager platform-admin
   authorization during migration.
 - Complete `/signup`, `/signup/check-email`, and `/verify` states for public

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -445,6 +445,10 @@ type VerifyEmailRequest struct {
 	NewPassword string `json:"new_password"`
 }
 
+type VerificationStatusResult struct {
+	Status string `json:"status"`
+}
+
 type ResetPasswordRequest struct {
 	Token       string `json:"token"`
 	NewPassword string `json:"new_password"`
@@ -554,6 +558,12 @@ func (c *Client) Signup(ctx context.Context, req SignupRequest) (SignupResult, e
 func (c *Client) VerifyEmail(ctx context.Context, req VerifyEmailRequest) (VerifyEmailResult, error) {
 	var out VerifyEmailResult
 	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/verify-email", "", req, &out)
+	return out, err
+}
+
+func (c *Client) VerificationStatus(ctx context.Context, token string) (VerificationStatusResult, error) {
+	var out VerificationStatusResult
+	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/verify-email/status", "", AuthTokenRequest{Token: token}, &out)
 	return out, err
 }
 

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -428,11 +428,7 @@ type SSOProviderConfigRequest struct {
 }
 
 type SignupRequest struct {
-	Email            string `json:"email"`
-	Password         string `json:"password"`
-	DisplayName      string `json:"display_name,omitempty"`
-	OrganizationName string `json:"organization_name,omitempty"`
-	CaptchaToken     string `json:"captcha_token,omitempty"`
+	Email string `json:"email"`
 }
 
 type SignupResult struct {
@@ -442,6 +438,11 @@ type SignupResult struct {
 
 type AuthTokenRequest struct {
 	Token string `json:"token"`
+}
+
+type VerifyEmailRequest struct {
+	Token       string `json:"token"`
+	NewPassword string `json:"new_password"`
 }
 
 type ResetPasswordRequest struct {
@@ -550,9 +551,9 @@ func (c *Client) Signup(ctx context.Context, req SignupRequest) (SignupResult, e
 	return out, err
 }
 
-func (c *Client) VerifyEmail(ctx context.Context, token string) (VerifyEmailResult, error) {
+func (c *Client) VerifyEmail(ctx context.Context, req VerifyEmailRequest) (VerifyEmailResult, error) {
 	var out VerifyEmailResult
-	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/verify-email", "", AuthTokenRequest{Token: token}, &out)
+	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/verify-email", "", req, &out)
 	return out, err
 }
 

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -431,7 +431,7 @@ type SignupRequest struct {
 	Email            string `json:"email"`
 	Password         string `json:"password"`
 	DisplayName      string `json:"display_name,omitempty"`
-	OrganizationName string `json:"organization_name"`
+	OrganizationName string `json:"organization_name,omitempty"`
 	CaptchaToken     string `json:"captcha_token,omitempty"`
 }
 

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -400,11 +400,18 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatalf("decode signup body: %v", err)
 			}
-			if len(body) != 2 || body["email"] != "signup@example.com" || body["password"] != "password123" {
+			if len(body) != 1 || body["email"] != "signup@example.com" {
 				t.Fatalf("signup body = %#v", body)
 			}
 			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"signup@example.com","name":"Signup"},"organization":{"id":"org-1","name":"Acme","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
 		case "/v1/auth/verify-email":
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode verify body: %v", err)
+			}
+			if len(body) != 2 || body["token"] != "token-1" || body["new_password"] != "password123" {
+				t.Fatalf("verify body = %#v", body)
+			}
 			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"signup@example.com","name":"Signup"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
 		case "/v1/auth/resend-verification":
 			w.WriteHeader(http.StatusAccepted)
@@ -420,7 +427,7 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 	defer upstream.Close()
 
 	client := New(upstream.URL)
-	signup, err := client.Signup(t.Context(), SignupRequest{Email: "signup@example.com", Password: "password123"})
+	signup, err := client.Signup(t.Context(), SignupRequest{Email: "signup@example.com"})
 	if err != nil {
 		t.Fatalf("Signup returned error: %v", err)
 	}
@@ -428,7 +435,7 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 		t.Fatalf("signup organization = %#v", signup.Organization)
 	}
 
-	verify, err := client.VerifyEmail(t.Context(), "token-1")
+	verify, err := client.VerifyEmail(t.Context(), VerifyEmailRequest{Token: "token-1", NewPassword: "password123"})
 	if err != nil {
 		t.Fatalf("VerifyEmail returned error: %v", err)
 	}

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -413,6 +413,12 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 				t.Fatalf("verify body = %#v", body)
 			}
 			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"signup@example.com","name":"Signup"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
+		case "/v1/auth/verify-email/status":
+			var body AuthTokenRequest
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Token != "token-1" {
+				t.Fatalf("verification status body = %#v, err=%v", body, err)
+			}
+			_, _ = w.Write([]byte(`{"status":"valid"}`))
 		case "/v1/auth/resend-verification":
 			w.WriteHeader(http.StatusAccepted)
 		case "/v1/orgs/org-1/quota-raise-requests":
@@ -433,6 +439,10 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 	}
 	if signup.Organization.Tier != "evaluation" || signup.Organization.EvaluationDeviceQuota != 5 {
 		t.Fatalf("signup organization = %#v", signup.Organization)
+	}
+	status, err := client.VerificationStatus(t.Context(), "token-1")
+	if err != nil || status.Status != "valid" {
+		t.Fatalf("VerificationStatus = %#v, err=%v", status, err)
 	}
 
 	verify, err := client.VerifyEmail(t.Context(), VerifyEmailRequest{Token: "token-1", NewPassword: "password123"})

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -396,6 +396,13 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 			if r.Method != http.MethodPost {
 				t.Fatalf("signup method = %s", r.Method)
 			}
+			var body map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+				t.Fatalf("decode signup body: %v", err)
+			}
+			if len(body) != 2 || body["email"] != "signup@example.com" || body["password"] != "password123" {
+				t.Fatalf("signup body = %#v", body)
+			}
 			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"signup@example.com","name":"Signup"},"organization":{"id":"org-1","name":"Acme","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
 		case "/v1/auth/verify-email":
 			_, _ = w.Write([]byte(`{"user":{"id":"u1","email":"signup@example.com","name":"Signup"},"tokens":{"access_token":"access","refresh_token":"refresh","expires_in":3600}}`))
@@ -413,11 +420,7 @@ func TestClientSignupVerifyResendAndQuotaRaise(t *testing.T) {
 	defer upstream.Close()
 
 	client := New(upstream.URL)
-	signup, err := client.Signup(t.Context(), SignupRequest{
-		Email:            "signup@example.com",
-		Password:         "password123",
-		OrganizationName: "Acme",
-	})
+	signup, err := client.Signup(t.Context(), SignupRequest{Email: "signup@example.com", Password: "password123"})
 	if err != nil {
 		t.Fatalf("Signup returned error: %v", err)
 	}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -279,6 +279,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/auth/customer/signup", s.apiCustomerSignup)
 	s.mux.HandleFunc("POST /api/auth/customer/login", s.apiCustomerLogin)
 	s.mux.HandleFunc("POST /api/auth/customer/verify-email", s.apiCustomerVerifyEmail)
+	s.mux.HandleFunc("POST /api/auth/customer/verification-status", s.apiCustomerVerificationStatus)
 	s.mux.HandleFunc("POST /api/auth/customer/resend-verification", s.apiCustomerResendVerification)
 	s.mux.HandleFunc("POST /api/auth/sign-in", s.apiAuthSignIn)
 	s.mux.HandleFunc("POST /api/auth/login/activate", s.apiAuthLoginActivate)
@@ -402,6 +403,7 @@ func (s *Server) routes() {
 		"/reset-password",
 		"/signup",
 		"/signup/check-email",
+		"/signup/verification-expired",
 		"/signup/verify",
 		"/signup/verify/",
 		"/verify",
@@ -1031,6 +1033,26 @@ func (s *Server) apiCustomerVerifyEmail(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		setSessionCookie(w, session.ID)
+	}
+	writeJSONStatus(w, http.StatusOK, result)
+}
+
+func (s *Server) apiCustomerVerificationStatus(w http.ResponseWriter, r *http.Request) {
+	if !s.accountClient.Enabled() {
+		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
+		return
+	}
+	var body accountclient.AuthTokenRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil || strings.TrimSpace(body.Token) == "" {
+		http.Error(w, "token is required", http.StatusBadRequest)
+		return
+	}
+	result, err := s.accountClient.VerificationStatus(r.Context(), strings.TrimSpace(body.Token))
+	if err != nil {
+		s.writeAuthProxyError(w, err)
+		return
 	}
 	writeJSONStatus(w, http.StatusOK, result)
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -991,10 +991,20 @@ func (s *Server) apiCustomerSignup(w http.ResponseWriter, r *http.Request) {
 	}
 	result, err := s.accountClient.Signup(r.Context(), body)
 	if err != nil {
-		s.writeCustomerError(w, err)
+		s.writeSignupError(w, err)
 		return
 	}
 	writeJSONStatus(w, http.StatusAccepted, result)
+}
+
+func (s *Server) writeSignupError(w http.ResponseWriter, err error) {
+	var httpErr *accountclient.HTTPError
+	if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusConflict {
+		s.logUpstreamError("account_manager", err)
+		http.Error(w, "An account already exists for this email", http.StatusConflict)
+		return
+	}
+	s.writeCustomerError(w, err)
 }
 
 func (s *Server) apiCustomerVerifyEmail(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -983,7 +983,9 @@ func (s *Server) apiCustomerSignup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var body accountclient.SignupRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil || strings.TrimSpace(body.Email) == "" {
 		http.Error(w, "invalid signup request", http.StatusBadRequest)
 		return
 	}
@@ -1000,12 +1002,14 @@ func (s *Server) apiCustomerVerifyEmail(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
 		return
 	}
-	var body accountclient.AuthTokenRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.Token) == "" {
-		http.Error(w, "token is required", http.StatusBadRequest)
+	var body accountclient.VerifyEmailRequest
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil || strings.TrimSpace(body.Token) == "" || len(body.NewPassword) < 8 {
+		http.Error(w, "token and new_password are required", http.StatusBadRequest)
 		return
 	}
-	result, err := s.accountClient.VerifyEmail(r.Context(), body.Token)
+	result, err := s.accountClient.VerifyEmail(r.Context(), body)
 	if err != nil {
 		s.writeAuthProxyError(w, err)
 		return

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -246,6 +246,32 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 	}
 }
 
+func TestPublicSignupPreservesExistingAccountConflict(t *testing.T) {
+	t.Parallel()
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/auth/signup" {
+			t.Fatalf("unexpected upstream request path: %s", r.URL.Path)
+		}
+		http.Error(w, `{"error":{"code":"conflict","message":"duplicate user","internal":"secret"}}`, http.StatusConflict)
+	}))
+	defer upstream.Close()
+
+	srv := NewWithOptions(mustOpenStore(t), Options{
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		AccountClient: accountclient.New(upstream.URL),
+	})
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/signup", strings.NewReader(`{"email":"existing@example.com"}`)))
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("signup status = %d, want 409; body=%s", rec.Code, rec.Body.String())
+	}
+	if got := rec.Body.String(); !strings.Contains(got, "An account already exists for this email") || strings.Contains(got, "secret") || strings.Contains(got, "duplicate user") {
+		t.Fatalf("signup conflict body is not customer-safe: %s", got)
+	}
+}
+
 func TestSSOStartAndCallbackCreateSessions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -150,6 +150,8 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 				return
 			}
 			_, _ = w.Write([]byte(`{"user":{"id":"u-signup","email":"signup@example.com","name":"Signup User"},"tokens":{"access_token":"access-1","refresh_token":"refresh-1","expires_in":3600}}`))
+		case "/v1/auth/verify-email/status":
+			_, _ = w.Write([]byte(`{"status":"valid"}`))
 		case "/v1/auth/resend-verification":
 			w.WriteHeader(http.StatusAccepted)
 		case "/v1/me":
@@ -174,7 +176,7 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
-	for _, path := range []string{"/login", "/signup", "/signup/check-email", "/signup/verify", "/signup/verify/", "/verify"} {
+	for _, path := range []string{"/login", "/signup", "/signup/check-email", "/signup/verification-expired", "/signup/verify", "/signup/verify/", "/verify"} {
 		rec := httptest.NewRecorder()
 		srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
 		if rec.Code != http.StatusOK {
@@ -200,6 +202,11 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 	srv.ServeHTTP(resendRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/resend-verification", strings.NewReader(`{"email":"signup@example.com"}`)))
 	if resendRec.Code != http.StatusAccepted {
 		t.Fatalf("resend status = %d, body=%s", resendRec.Code, resendRec.Body.String())
+	}
+	statusRec := httptest.NewRecorder()
+	srv.ServeHTTP(statusRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verification-status", strings.NewReader(`{"token":"token-1"}`)))
+	if statusRec.Code != http.StatusOK || !strings.Contains(statusRec.Body.String(), `"status":"valid"`) {
+		t.Fatalf("verification status = %d, body=%s", statusRec.Code, statusRec.Body.String())
 	}
 
 	verifyRec := httptest.NewRecorder()

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -143,7 +143,7 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 		case "/v1/auth/signup":
 			_, _ = w.Write([]byte(`{"user":{"id":"u-signup","email":"signup@example.com","name":"Signup User"},"organization":{"id":"org-1","name":"Acme Eval","role":"owner","tier":"evaluation","evaluation_device_quota":5}}`))
 		case "/v1/auth/verify-email":
-			var body accountclient.AuthTokenRequest
+			var body accountclient.VerifyEmailRequest
 			_ = json.NewDecoder(r.Body).Decode(&body)
 			if body.Token == "consumed-token" {
 				http.Error(w, "Invalid or expired verification token", http.StatusBadRequest)
@@ -183,12 +183,17 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 	}
 
 	signupRec := httptest.NewRecorder()
-	srv.ServeHTTP(signupRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/signup", strings.NewReader(`{"email":"signup@example.com","password":"password123","organization_name":"Acme Eval","display_name":"Signup User"}`)))
+	srv.ServeHTTP(signupRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/signup", strings.NewReader(`{"email":"signup@example.com"}`)))
 	if signupRec.Code != http.StatusAccepted {
 		t.Fatalf("signup status = %d, body=%s", signupRec.Code, signupRec.Body.String())
 	}
 	if !strings.Contains(signupRec.Body.String(), `"tier":"evaluation"`) {
 		t.Fatalf("signup body = %s", signupRec.Body.String())
+	}
+	legacySignupRec := httptest.NewRecorder()
+	srv.ServeHTTP(legacySignupRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/signup", strings.NewReader(`{"email":"legacy@example.com","password":"password123"}`)))
+	if legacySignupRec.Code != http.StatusBadRequest {
+		t.Fatalf("legacy signup fields status = %d, want 400", legacySignupRec.Code)
 	}
 
 	resendRec := httptest.NewRecorder()
@@ -198,17 +203,22 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 	}
 
 	verifyRec := httptest.NewRecorder()
-	srv.ServeHTTP(verifyRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"token-1"}`)))
+	srv.ServeHTTP(verifyRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"token-1","new_password":"password123"}`)))
 	if verifyRec.Code != http.StatusOK {
 		t.Fatalf("verify status = %d, body=%s", verifyRec.Code, verifyRec.Body.String())
 	}
 	if len(verifyRec.Result().Cookies()) != 1 {
 		t.Fatalf("verify did not set a session cookie")
 	}
+	missingPasswordRec := httptest.NewRecorder()
+	srv.ServeHTTP(missingPasswordRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"token-1"}`)))
+	if missingPasswordRec.Code != http.StatusBadRequest {
+		t.Fatalf("missing verification password status = %d, want 400", missingPasswordRec.Code)
+	}
 	sessionCookie := verifyRec.Result().Cookies()[0]
 
 	replayRec := httptest.NewRecorder()
-	srv.ServeHTTP(replayRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"consumed-token"}`)))
+	srv.ServeHTTP(replayRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"consumed-token","new_password":"password123"}`)))
 	if replayRec.Code != http.StatusBadRequest {
 		t.Fatalf("replayed verification status = %d, want 400; body=%s", replayRec.Code, replayRec.Body.String())
 	}

--- a/internal/app/batch_job_coverage_test.go
+++ b/internal/app/batch_job_coverage_test.go
@@ -931,8 +931,8 @@ func TestPublicAuthProxySuccessFailureAndValidation(t *testing.T) {
 		successCode int
 		failureBody string
 	}{
-		{"/api/auth/customer/signup", `{"email":"owner@example.com","password":"password123","organization_name":"Acme"}`, http.StatusAccepted, `{"email":"fail@example.com","password":"password123","organization_name":"Acme"}`},
-		{"/api/auth/customer/verify-email", `{"token":"verify-token"}`, http.StatusOK, `{"token":"fail-token"}`},
+		{"/api/auth/customer/signup", `{"email":"owner@example.com"}`, http.StatusAccepted, `{"email":"fail@example.com"}`},
+		{"/api/auth/customer/verify-email", `{"token":"verify-token","new_password":"password123"}`, http.StatusOK, `{"token":"fail-token","new_password":"password123"}`},
 		{"/api/auth/customer/resend-verification", `{"email":"owner@example.com"}`, http.StatusAccepted, `{"email":"fail@example.com"}`},
 		{"/api/auth/sign-in", `{"email":"owner@example.com"}`, http.StatusAccepted, `{"email":"fail@example.com"}`},
 		{"/api/auth/forgot-password", `{"email":"owner@example.com"}`, http.StatusAccepted, `{"email":"fail@example.com"}`},

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -650,6 +650,51 @@ async function runMobileSmoke(browserContext) {
   await screenshot(page, 'mobile-signup-tab.png');
   await page.unroute('**/api/**');
   await installApiMocks(page);
+
+  await page.setViewportSize({ width: 360, height: 800 });
+  await gotoAndAssert(page, '/console/overview', '設備總覽');
+  await expectText(page, 'Devices that need attention');
+  await assertNoHorizontalOverflow(page, '360px Overview');
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await gotoAndAssert(page, '/console/overview', '設備總覽');
+  await assertNoHorizontalOverflow(page, '390px Overview');
+  const menuButton = page.getByRole('button', { name: 'Open navigation' });
+  if (await menuButton.getAttribute('aria-expanded') !== 'false') {
+    throw new Error('Mobile navigation must be closed by default.');
+  }
+  await menuButton.click();
+  if (await menuButton.getAttribute('aria-expanded') !== 'true') {
+    throw new Error('Mobile navigation button must expose its open state.');
+  }
+  await page.waitForFunction(() => document.querySelector('#primary-navigation')?.getBoundingClientRect().left >= -1);
+  const drawerLeft = await page.locator('#primary-navigation').evaluate((element) => element.getBoundingClientRect().left);
+  if (drawerLeft < -1) {
+    throw new Error('Mobile navigation drawer must move on screen when opened.');
+  }
+  await page.keyboard.press('Escape');
+  if (await menuButton.getAttribute('aria-expanded') !== 'false') {
+    throw new Error('Escape must close the mobile navigation drawer.');
+  }
+  await page.waitForFunction(() => document.querySelector('#primary-navigation')?.getBoundingClientRect().right <= 1);
+  await page.locator('.overview-layout').waitFor({ state: 'visible', timeout: 5000 });
+  await assertOverviewStartsInViewport(page, '390px Overview');
+  await screenshot(page, 'mobile-overview.png');
+
+  await page.setViewportSize({ width: 768, height: 1024 });
+  await gotoAndAssert(page, '/console/overview', '設備總覽');
+  await page.locator('.overview-layout').waitFor({ state: 'visible', timeout: 5000 });
+  await assertOverviewStartsInViewport(page, '768px Overview');
+  await assertNoHorizontalOverflow(page, '768px Overview');
+  await screenshot(page, 'tablet-overview.png');
+
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await gotoAndAssert(page, '/console/overview', '設備總覽');
+  await page.locator('.overview-layout').waitFor({ state: 'visible', timeout: 5000 });
+  await assertNoHorizontalOverflow(page, '1024px Overview');
+  await screenshot(page, 'compact-desktop-overview.png');
+
+  await page.setViewportSize({ width: 390, height: 844 });
   await gotoAndAssert(page, '/console/devices', 'Devices');
   await expectText(page, '設備總覽');
   await expectText(page, '影像播放狀況');
@@ -698,10 +743,32 @@ async function gotoAndAssert(page, routePath, expectedTitle) {
   if (/Internal server error|vite|webpack|ReferenceError|TypeError/.test(rootText)) {
     throw new Error(`Framework/runtime overlay detected at ${routePath}`);
   }
+  await page.evaluate(() => window.scrollTo(0, 0));
 }
 
 async function expectText(page, text) {
-  await page.getByText(text, { exact: false }).first().waitFor({ state: 'visible', timeout: 5000 });
+  await page.getByText(text, { exact: false }).filter({ visible: true }).first().waitFor({ state: 'visible', timeout: 5000 });
+}
+
+async function assertNoHorizontalOverflow(page, label) {
+  const dimensions = await page.evaluate(() => ({
+    viewport: window.innerWidth,
+    document: document.documentElement.scrollWidth,
+  }));
+  if (dimensions.document > dimensions.viewport + 1) {
+    throw new Error(`${label} must not overflow horizontally: ${JSON.stringify(dimensions)}`);
+  }
+}
+
+async function assertOverviewStartsInViewport(page, label) {
+  const position = await page.locator('.overview-layout').evaluate((element) => ({
+    top: element.getBoundingClientRect().top,
+    height: element.getBoundingClientRect().height,
+    viewportHeight: window.innerHeight,
+  }));
+  if (position.top >= position.viewportHeight) {
+    throw new Error(`${label} content must begin in the first viewport: ${JSON.stringify(position)}`);
+  }
 }
 
 async function screenshot(page, name) {

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -523,6 +523,12 @@ async function runAuthSmoke(browserContext) {
   await page.waitForURL(`${baseURL}/signup/check-email?email=new.customer%40example.com`);
   await expectText(page, 'We sent a verification link to new.customer@example.com.');
   await page.goto(`${baseURL}/verify?token=verification-token`, { waitUntil: 'networkidle' });
+  if (await page.getByLabel('Verification token').count()) {
+    throw new Error('Verification page must not render the token as a field.');
+  }
+  if ((await page.locator('body').innerText()).includes('verification-token')) {
+    throw new Error('Verification page must not render the token value.');
+  }
   await page.getByLabel('New password').fill('password123');
   await page.getByRole('button', { name: 'Verify and continue', exact: true }).click();
   await page.waitForURL(`${baseURL}/console/overview`);
@@ -564,8 +570,11 @@ async function runDesktopSmoke(page) {
   await expectText(page, 'Create account');
   await gotoAndAssert(page, '/signup/check-email?email=fleet.manager%40example.com', 'Check your email');
   await expectText(page, 'Resend');
-  await gotoAndAssert(page, '/verify', 'Verify email');
+  await gotoAndAssert(page, '/verify?token=visual-check-token', 'Verify email');
   await expectText(page, 'Create your password to finish verification');
+  if ((await page.locator('body').innerText()).includes('visual-check-token')) {
+    throw new Error('Verification page screenshot state must not render the token value.');
+  }
   await screenshot(page, 'desktop-public-auth.png');
 
   await gotoAndAssert(page, '/console/devices?device=dev-1002', 'Devices');

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -460,6 +460,16 @@ async function installApiMocks(page, { sessionForPath } = {}) {
         },
       });
     }
+    if (pathName === '/api/auth/customer/verification-status') {
+      if (request.method() !== 'POST') {
+        throw new Error(`Verification status must use POST, got ${request.method()}`);
+      }
+      const payload = request.postDataJSON();
+      if (!payload.token) {
+        throw new Error('Verification status requires a token.');
+      }
+      return route.fulfill({ json: { status: payload.token === 'expired-token' ? 'expired' : 'valid' } });
+    }
     if (pathName === '/api/summary' || pathName === '/api/admin/summary') return route.fulfill({ json: summary });
     if (pathName === '/api/developer/brand-clouds') return route.fulfill({ json: { brand_clouds: [] } });
     if (pathName === '/api/customers' || pathName === '/api/admin/customers') return route.fulfill({ json: customers });
@@ -540,6 +550,17 @@ async function runAuthSmoke(browserContext) {
   await page.getByRole('button', { name: 'Create account', exact: true }).click();
   await page.waitForURL(`${baseURL}/signup/check-email?email=new.customer%40example.com`);
   await expectText(page, 'We sent a verification link to new.customer@example.com.');
+  await page.goto(`${baseURL}/verify?token=expired-token`, { waitUntil: 'networkidle' });
+  await page.waitForURL(`${baseURL}/signup/verification-expired`);
+  await expectText(page, 'Verification link expired');
+  await expectText(page, 'Start Sign Up again to receive a new verification email.');
+  if (await page.getByLabel('New password').count()) {
+    throw new Error('Expired verification page must not render the password form.');
+  }
+  if (await page.getByRole('link', { name: 'Sign up again', exact: true }).count() !== 1) {
+    throw new Error('Expired verification page must offer one Sign up again action.');
+  }
+  await screenshot(page, 'desktop-verification-expired.png');
   await page.goto(`${baseURL}/verify?token=verification-token`, { waitUntil: 'networkidle' });
   if (await page.getByLabel('Verification token').count()) {
     throw new Error('Verification page must not render the token as a field.');

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -417,7 +417,28 @@ async function installApiMocks(page, { sessionForPath } = {}) {
       }
       return route.fulfill({ json: isPlatformFrame ? platformMe : customerMe });
     }
+    if (pathName === '/api/auth/customer/signup') {
+      if (request.method() !== 'POST') {
+        throw new Error(`Signup must use POST, got ${request.method()}`);
+      }
+      const payload = request.postDataJSON();
+      const expected = {
+        email: 'new.customer@example.com',
+        password: 'password123',
+      };
+      if (JSON.stringify(payload) !== JSON.stringify(expected)) {
+        throw new Error(`Unexpected signup payload: ${JSON.stringify(payload)}`);
+      }
+      return route.fulfill({
+        status: 202,
+        json: {
+          user: { id: 'user-new-customer', email: expected.email },
+          organization: { id: 'org-new-customer', name: expected.email, tier: 'evaluation' },
+        },
+      });
+    }
     if (pathName === '/api/summary' || pathName === '/api/admin/summary') return route.fulfill({ json: summary });
+    if (pathName === '/api/developer/brand-clouds') return route.fulfill({ json: { brand_clouds: [] } });
     if (pathName === '/api/customers' || pathName === '/api/admin/customers') return route.fulfill({ json: customers });
     if (pathName === '/api/devices' || pathName === '/api/admin/devices') return route.fulfill({ json: devices });
     if (pathName === '/api/fleet/devices') return route.fulfill({ json: { devices, pagination: { limit: 100, offset: 0, total: devices.length }, query: { server_side: true } } });
@@ -468,7 +489,24 @@ async function runAuthSmoke(browserContext) {
   if (await page.locator('.login-preview').count()) {
     throw new Error('Login page must not render destination preview panels.');
   }
+  const loginTab = page.getByRole('tab', { name: 'Login', exact: true });
+  const signUpTab = page.getByRole('tab', { name: 'Sign Up', exact: true });
+  if (await loginTab.getAttribute('aria-selected') !== 'true') {
+    throw new Error('Login must be the default auth tab.');
+  }
+  if (await page.getByRole('tab', { name: 'Sign-in', exact: true }).count()) {
+    throw new Error('Login page must not expose the retired Sign-in tab.');
+  }
   await screenshot(page, 'desktop-login.png');
+
+  await signUpTab.click();
+  await expectText(page, 'Create account');
+  await page.getByLabel('Email').fill('new.customer@example.com');
+  await page.getByLabel('Password').fill('password123');
+  await screenshot(page, 'desktop-signup-tab.png');
+  await page.getByRole('button', { name: 'Create account', exact: true }).click();
+  await page.waitForURL(`${baseURL}/signup/check-email?email=new.customer%40example.com`);
+  await expectText(page, 'We sent a verification link to new.customer@example.com.');
   if (consoleIssues.length) {
     throw new Error(`Auth smoke console issues detected:\n${consoleIssues.join('\n')}`);
   }
@@ -479,7 +517,8 @@ function collectConsoleIssues(page) {
   const issues = [];
   page.on('console', (message) => {
     if (!['error', 'warning'].includes(message.type())) return;
-    issues.push(`${message.type()}: ${message.text()}`);
+    const location = message.location().url;
+    issues.push(`${message.type()}: ${message.text()}${location ? ` (${location})` : ''}`);
   });
   page.on('pageerror', (error) => {
     issues.push(`pageerror: ${error.message}`);
@@ -503,7 +542,6 @@ async function runDesktopSmoke(page) {
   await screenshot(page, 'desktop-overview.png');
 
   await gotoAndAssert(page, '/signup', 'Sign up');
-  await expectText(page, 'evaluation-tier');
   await expectText(page, 'Create account');
   await gotoAndAssert(page, '/signup/check-email?email=fleet.manager%40example.com', 'Check your email');
   await expectText(page, 'Resend');
@@ -562,6 +600,26 @@ async function runMobileSmoke(browserContext) {
     throw new Error('Mobile login page must not render recovery access controls.');
   }
   await screenshot(page, 'mobile-login.png');
+  await page.getByRole('tab', { name: 'Sign Up', exact: true }).click();
+  await expectText(page, 'Create account');
+  const signupOverflow = await page.evaluate(() => document.documentElement.scrollWidth > window.innerWidth + 1);
+  if (signupOverflow) {
+    const overflowDetails = await page.evaluate(() => ({
+      viewport: window.innerWidth,
+      document: document.documentElement.scrollWidth,
+      html: { clientWidth: document.documentElement.clientWidth, scrollWidth: document.documentElement.scrollWidth },
+      body: { clientWidth: document.body.clientWidth, scrollWidth: document.body.scrollWidth, width: document.body.getBoundingClientRect().width },
+      elements: [...document.querySelectorAll('body *')]
+        .map((element) => {
+          const rect = element.getBoundingClientRect();
+          return { tag: element.tagName, className: element.className, left: rect.left, right: rect.right, width: rect.width };
+        })
+        .filter((item) => item.left < -1 || item.right > window.innerWidth + 1)
+        .slice(0, 8),
+    }));
+    throw new Error(`Mobile Sign Up tab must not overflow horizontally: ${JSON.stringify(overflowDetails)}`);
+  }
+  await screenshot(page, 'mobile-signup-tab.png');
   await page.unroute('**/api/**');
   await installApiMocks(page);
   await gotoAndAssert(page, '/console/devices', 'Devices');

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -528,6 +528,10 @@ async function runAuthSmoke(browserContext) {
   await page.getByLabel('Email').fill('existing.customer@example.com');
   await page.getByRole('button', { name: 'Create account', exact: true }).click();
   await expectText(page, 'An account already exists for this email. Log in or reset your password.');
+  const duplicateMessages = await page.getByText('An account already exists for this email. Log in or reset your password.', { exact: true }).count();
+  if (duplicateMessages !== 1) {
+    throw new Error(`Duplicate signup must show exactly one error message, got ${duplicateMessages}.`);
+  }
   if (page.url() !== signupURL) {
     throw new Error(`Duplicate signup must stay on the signup form, got ${page.url()}`);
   }

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -422,6 +422,13 @@ async function installApiMocks(page, { sessionForPath } = {}) {
         throw new Error(`Signup must use POST, got ${request.method()}`);
       }
       const payload = request.postDataJSON();
+      if (payload.email === 'existing.customer@example.com') {
+        return route.fulfill({
+          status: 409,
+          contentType: 'text/plain',
+          body: 'An account already exists for this email',
+        });
+      }
       const expected = {
         email: 'new.customer@example.com',
       };
@@ -488,7 +495,7 @@ async function installApiMocks(page, { sessionForPath } = {}) {
 async function runAuthSmoke(browserContext) {
   const page = await browserContext.newPage();
   await installApiMocks(page, { sessionForPath: () => anonymousMe });
-  const consoleIssues = collectConsoleIssues(page);
+  const consoleIssues = collectConsoleIssues(page, [/409 \(Conflict\).*\/api\/auth\/customer\/signup/]);
   await page.setViewportSize({ width: 1440, height: 1000 });
   await page.goto(`${baseURL}/admin`, { waitUntil: 'networkidle' });
   if (page.url() !== `${baseURL}/login?next=%2Fadmin`) {
@@ -517,6 +524,13 @@ async function runAuthSmoke(browserContext) {
 
   await signUpTab.click();
   await expectText(page, 'Create account');
+  const signupURL = page.url();
+  await page.getByLabel('Email').fill('existing.customer@example.com');
+  await page.getByRole('button', { name: 'Create account', exact: true }).click();
+  await expectText(page, 'An account already exists for this email. Log in or reset your password.');
+  if (page.url() !== signupURL) {
+    throw new Error(`Duplicate signup must stay on the signup form, got ${page.url()}`);
+  }
   await page.getByLabel('Email').fill('new.customer@example.com');
   await screenshot(page, 'desktop-signup-tab.png');
   await page.getByRole('button', { name: 'Create account', exact: true }).click();
@@ -538,12 +552,14 @@ async function runAuthSmoke(browserContext) {
   await page.close();
 }
 
-function collectConsoleIssues(page) {
+function collectConsoleIssues(page, ignoredPatterns = []) {
   const issues = [];
   page.on('console', (message) => {
     if (!['error', 'warning'].includes(message.type())) return;
     const location = message.location().url;
-    issues.push(`${message.type()}: ${message.text()}${location ? ` (${location})` : ''}`);
+    const issue = `${message.type()}: ${message.text()}${location ? ` (${location})` : ''}`;
+    if (ignoredPatterns.some((pattern) => pattern.test(issue))) return;
+    issues.push(issue);
   });
   page.on('pageerror', (error) => {
     issues.push(`pageerror: ${error.message}`);

--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -424,7 +424,6 @@ async function installApiMocks(page, { sessionForPath } = {}) {
       const payload = request.postDataJSON();
       const expected = {
         email: 'new.customer@example.com',
-        password: 'password123',
       };
       if (JSON.stringify(payload) !== JSON.stringify(expected)) {
         throw new Error(`Unexpected signup payload: ${JSON.stringify(payload)}`);
@@ -434,6 +433,23 @@ async function installApiMocks(page, { sessionForPath } = {}) {
         json: {
           user: { id: 'user-new-customer', email: expected.email },
           organization: { id: 'org-new-customer', name: expected.email, tier: 'evaluation' },
+        },
+      });
+    }
+    if (pathName === '/api/auth/customer/verify-email') {
+      if (request.method() !== 'POST') {
+        throw new Error(`Verification must use POST, got ${request.method()}`);
+      }
+      const payload = request.postDataJSON();
+      const expected = { token: 'verification-token', new_password: 'password123' };
+      if (JSON.stringify(payload) !== JSON.stringify(expected)) {
+        throw new Error(`Unexpected verification payload: ${JSON.stringify(payload)}`);
+      }
+      return route.fulfill({
+        status: 200,
+        json: {
+          user: { id: 'user-new-customer', email: 'new.customer@example.com' },
+          tokens: { access_token: 'access-token', refresh_token: 'refresh-token', expires_in: 3600 },
         },
       });
     }
@@ -502,11 +518,14 @@ async function runAuthSmoke(browserContext) {
   await signUpTab.click();
   await expectText(page, 'Create account');
   await page.getByLabel('Email').fill('new.customer@example.com');
-  await page.getByLabel('Password').fill('password123');
   await screenshot(page, 'desktop-signup-tab.png');
   await page.getByRole('button', { name: 'Create account', exact: true }).click();
   await page.waitForURL(`${baseURL}/signup/check-email?email=new.customer%40example.com`);
   await expectText(page, 'We sent a verification link to new.customer@example.com.');
+  await page.goto(`${baseURL}/verify?token=verification-token`, { waitUntil: 'networkidle' });
+  await page.getByLabel('New password').fill('password123');
+  await page.getByRole('button', { name: 'Verify and continue', exact: true }).click();
+  await page.waitForURL(`${baseURL}/console/overview`);
   if (consoleIssues.length) {
     throw new Error(`Auth smoke console issues detected:\n${consoleIssues.join('\n')}`);
   }
@@ -546,7 +565,7 @@ async function runDesktopSmoke(page) {
   await gotoAndAssert(page, '/signup/check-email?email=fleet.manager%40example.com', 'Check your email');
   await expectText(page, 'Resend');
   await gotoAndAssert(page, '/verify', 'Verify email');
-  await expectText(page, 'Waiting for verification link');
+  await expectText(page, 'Create your password to finish verification');
   await screenshot(page, 'desktop-public-auth.png');
 
   await gotoAndAssert(page, '/console/devices?device=dev-1002', 'Devices');

--- a/web/scripts/email-signup-live-e2e.mjs
+++ b/web/scripts/email-signup-live-e2e.mjs
@@ -25,7 +25,6 @@ try {
   const signupPage = await signupContext.newPage();
   await signupPage.goto(`${baseURL}/signup`, { waitUntil: 'networkidle' });
   await signupPage.getByLabel('Email', { exact: true }).fill(emailAddress);
-  await signupPage.getByLabel('Password', { exact: true }).fill(password);
   await signupPage.getByRole('button', { name: 'Create account' }).click();
   await signupPage.waitForURL(/\/signup\/check-email(?:\?|$)/, { timeout: 30_000 });
   await signupPage.getByText('We sent a verification link', { exact: false }).waitFor();
@@ -51,16 +50,8 @@ try {
     return response;
   });
   await verifyPage.goto(delivered.url, { waitUntil: 'networkidle' });
-  await Promise.race([
-    verifyResponsePromise,
-    new Promise((resolve) => setTimeout(resolve, 2_000)),
-  ]);
-  if (!verifyResponse) {
-    const verifyButton = verifyPage.getByRole('button', { name: 'Verify', exact: true });
-    if (await verifyButton.isEnabled()) {
-      await verifyButton.click();
-    }
-  }
+  await verifyPage.getByLabel('New password', { exact: true }).fill(password);
+  await verifyPage.getByRole('button', { name: 'Verify and continue', exact: true }).click();
   verifyResponse = await verifyResponsePromise;
   if (verifyResponse.status() !== 200) {
     throw new Error(`email verification returned HTTP ${verifyResponse.status()}`);
@@ -75,8 +66,8 @@ try {
     throw new Error(`verified Admin Console session returned HTTP ${meResponse.status()}`);
   }
   const me = await meResponse.json();
-  if (!me.memberships?.some((membership) => membership.organization === organizationName)) {
-    throw new Error('verified account organization name did not match the signup form');
+  if (!me.memberships?.some((membership) => membership.organization === emailAddress.toLowerCase())) {
+    throw new Error('verified account default organization name did not match the signup email');
   }
   await verifyContext.close();
 
@@ -112,6 +103,8 @@ try {
     new URL(response.url()).pathname === '/api/auth/customer/verify-email'
   ));
   await replayPage.goto(delivered.url, { waitUntil: 'networkidle' });
+  await replayPage.getByLabel('New password', { exact: true }).fill(password);
+  await replayPage.getByRole('button', { name: 'Verify and continue', exact: true }).click();
   const replayResponse = await replayResponsePromise;
   if (replayResponse.status() !== 400) {
     throw new Error(`replayed verification token returned HTTP ${replayResponse.status()}`);

--- a/web/scripts/email-signup-live-e2e.mjs
+++ b/web/scripts/email-signup-live-e2e.mjs
@@ -12,7 +12,6 @@ const imapHelper = requiredEnv('EMAIL_E2E_IMAP_HELPER');
 const runID = optionalEnv('EMAIL_E2E_RUN_ID') || 'local';
 const evidencePath = optionalEnv('EMAIL_E2E_EVIDENCE_PATH');
 const python = process.env.PYTHON || 'python3';
-const organizationName = `E2E Email Signup ${runID}`;
 
 const snapshot = await runIMAP('snapshot');
 if (!Number.isInteger(snapshot.uid_next) || snapshot.uid_next < 1) {
@@ -27,9 +26,6 @@ try {
   await signupPage.goto(`${baseURL}/signup`, { waitUntil: 'networkidle' });
   await signupPage.getByLabel('Email', { exact: true }).fill(emailAddress);
   await signupPage.getByLabel('Password', { exact: true }).fill(password);
-  await signupPage.getByLabel('Organization name', { exact: true }).fill(organizationName);
-  await signupPage.getByLabel('Display name', { exact: true }).fill(`E2E Email Signup ${runID}`);
-  await signupPage.getByLabel('I accept the evaluation-tier terms.').check();
   await signupPage.getByRole('button', { name: 'Create account' }).click();
   await signupPage.waitForURL(/\/signup\/check-email(?:\?|$)/, { timeout: 30_000 });
   await signupPage.getByText('We sent a verification link', { exact: false }).waitFor();

--- a/web/src/http.mjs
+++ b/web/src/http.mjs
@@ -60,6 +60,9 @@ export function userFacingSSOError(error) {
 
 export function userFacingSignupError(error) {
   const message = String(error?.message || error || '');
+  if (error?.status === 409 || /already exists|conflict|duplicate/i.test(message)) {
+    return 'An account already exists for this email. Log in or reset your password.';
+  }
   if (/validation|email|password|captcha|terms|400|422/i.test(message)) {
     return 'Check the signup fields and try again.';
   }

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -186,6 +186,16 @@ test('userFacingSSOError maps auth and malformed redirect failures to operator-s
 });
 
 test('public signup errors use evaluation-tier safe copy', () => {
+  const conflict = new Error('Account Manager request failed');
+  conflict.status = 409;
+  assert.equal(
+    userFacingSignupError(conflict),
+    'An account already exists for this email. Log in or reset your password.',
+  );
+  assert.equal(
+    userFacingSignupError(new Error('duplicate email conflict')),
+    'An account already exists for this email. Log in or reset your password.',
+  );
   assert.equal(
     userFacingSignupError(new Error('email validation failed with 400')),
     'Check the signup fields and try again.',

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -953,16 +953,11 @@ function App() {
 
   async function handleSignup(payload) {
     setError('');
-    try {
-      const result = await postJSON('/api/auth/customer/signup', payload);
-      window.history.pushState({}, '', `/signup/check-email?email=${encodeURIComponent(payload.email)}`);
-      setActive('signup-check-email');
-      setRefreshTick((tick) => tick + 1);
-      return result;
-    } catch (err) {
-      setError(userFacingSignupError(err));
-      throw err;
-    }
+    const result = await postJSON('/api/auth/customer/signup', payload);
+    window.history.pushState({}, '', `/signup/check-email?email=${encodeURIComponent(payload.email)}`);
+    setActive('signup-check-email');
+    setRefreshTick((tick) => tick + 1);
+    return result;
   }
 
   async function handleVerify(payload) {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import { createP256CSR, downloadExportableBundle } from './certificateBundle.mjs';
 import {
@@ -197,6 +197,9 @@ function App() {
   const [error, setError] = useState('');
   const [refreshTick, setRefreshTick] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
+  const mobileNavRef = useRef(null);
+  const mobileMenuButtonRef = useRef(null);
   const isPublicRoute = isPublicRouteId(active);
   const isLoginRoute = active === 'login';
   const isAuthEntryRoute = active === 'login' || active === 'login-check-email' || active === 'login-activate' || active === 'brand-cloud-activate' || active === 'forgot-password' || active === 'reset-password';
@@ -636,11 +639,46 @@ function App() {
     setDeviceDrawerOpen(Boolean(deviceId));
   }, [active]);
 
+  useEffect(() => {
+    if (!mobileNavOpen) return undefined;
+    const drawer = mobileNavRef.current;
+    const focusable = () => [...(drawer?.querySelectorAll('button, select, a[href], [tabindex]:not([tabindex="-1"])') || [])]
+      .filter((element) => !element.disabled && element.getAttribute('aria-hidden') !== 'true');
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    focusable()[0]?.focus();
+    const onKeyDown = (event) => {
+      if (event.key === 'Escape') {
+        setMobileNavOpen(false);
+        return;
+      }
+      if (event.key !== 'Tab') return;
+      const items = focusable();
+      if (!items.length) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener('keydown', onKeyDown);
+      mobileMenuButtonRef.current?.focus();
+    };
+  }, [mobileNavOpen]);
+
   function navigate(item) {
     const cloudId = me?.kind === 'customer' ? me.active_org_id : '';
     const path = cloudId && item.path.startsWith('/console/') ? `/console/${encodeURIComponent(cloudId)}/${item.path.slice('/console/'.length)}` : item.path;
     window.history.pushState({}, '', path);
     setActive(item.id);
+    setMobileNavOpen(false);
   }
 
   function switchView(targetActive) {
@@ -983,6 +1021,7 @@ function App() {
   }
 
   async function handleLogout() {
+    setMobileNavOpen(false);
     setError('');
     const response = await fetch('/api/auth/logout', { method: 'POST' });
     if (!response.ok) {
@@ -1034,10 +1073,40 @@ function App() {
 
   return (
     <div className={`app-shell ${isPlatformView ? 'platform-shell' : ''}`}>
-      <aside className="sidebar">
+      <header className="mobile-appbar">
+        <button
+          ref={mobileMenuButtonRef}
+          type="button"
+          className="mobile-menu-button"
+          aria-label="Open navigation"
+          aria-controls="primary-navigation"
+          aria-expanded={mobileNavOpen}
+          onClick={() => setMobileNavOpen(true)}
+        >
+          <Icon name="bars" />
+        </button>
+        <strong>{titleFor(active)}</strong>
+        <span className="mobile-appbar-mark" aria-hidden="true">C+</span>
+      </header>
+      <button
+        type="button"
+        className={`mobile-nav-overlay ${mobileNavOpen ? 'open' : ''}`}
+        aria-label="Close navigation"
+        tabIndex={mobileNavOpen ? 0 : -1}
+        onClick={() => setMobileNavOpen(false)}
+      />
+      <aside
+        id="primary-navigation"
+        ref={mobileNavRef}
+        className={`sidebar ${mobileNavOpen ? 'mobile-open' : ''}`}
+        aria-label="Primary navigation"
+      >
         <div className="brand">
           <span className="brand-mark" aria-hidden="true">{isPlatformView ? <Icon name="cloud" /> : 'C+'}</span>
           <strong>{isPlatformView ? 'RTK cloud' : 'Connect+ Ops'}</strong>
+          <button type="button" className="mobile-nav-close" aria-label="Close navigation" onClick={() => setMobileNavOpen(false)}>
+            <Icon name="xmark" />
+          </button>
         </div>
         <p className="sidebar-section-label">{isPlatformView ? 'Platform View' : 'Customer View'}</p>
         <nav>
@@ -1067,6 +1136,7 @@ function App() {
             <strong>{sessionLabel(me)}</strong>
             <small>{me?.authenticated ? me.email : 'Sign in required'}</small>
           </div>
+          {me?.authenticated ? <button type="button" className="sidebar-logout" onClick={handleLogout}><Icon name="right-from-bracket" />Logout</button> : null}
         </div>
       </aside>
 
@@ -1748,6 +1818,12 @@ function Overview({
       {!telemetryAvailable ? <SourceBlockedState title={telemetryState.title} message={telemetryReason} /> : null}
 
       <section className="overview-grid">
+        <HealthDistributionPanel
+          loading={loading}
+          current={fleetHealth?.current}
+          onFilter={onHealthFilter}
+          source={fleetHealth}
+        />
         <FleetHealthTrendPanel
           loading={loading}
           trend={fleetHealth?.trend || []}
@@ -1755,20 +1831,13 @@ function Overview({
           onWindowChange={setOverviewWindow}
           source={fleetHealth}
         />
-        <HealthDistributionPanel
-          loading={loading}
-          current={fleetHealth?.current}
-          onFilter={onHealthFilter}
-          source={fleetHealth}
-        />
+      </section>
+
+      <section className="overview-attention">
+        <AttentionQueuePanel loading={loading} items={attentionDevices} onOpenDevice={(deviceId) => updateDevicesLocation({ deviceId })} />
       </section>
 
       <RegionFleetPanel summary={fleetSummary} loading={loading} />
-
-      <section className="overview-lower-grid">
-        <RecentAlertsPanel loading={loading} alerts={recentAlerts} source={fleetHealth} onOpenDevice={(deviceId) => updateDevicesLocation({ deviceId })} />
-        <AttentionQueuePanel loading={loading} items={attentionDevices} onOpenDevice={(deviceId) => updateDevicesLocation({ deviceId })} />
-      </section>
 
       {me?.authenticated && isEvaluation && nearQuota ? (
         <section className="panel quota-callout">
@@ -1805,17 +1874,6 @@ function RegionFleetPanel({ summary, loading }) {
       {!loading && unavailable ? <p className="empty-state">區域資料暫時無法取得。</p> : null}
       {!loading && !unavailable ? (
         <div className="region-fleet-grid">
-          <div className="region-map-vector" aria-label="區域設備分布圖">
-            <svg viewBox="0 0 520 260" role="img" aria-label="設備區域分布">
-              <path d="M38 150 92 118 138 128 166 92 230 106 274 78 334 96 390 72 476 112 450 178 390 184 350 220 275 202 220 232 164 214 100 232 52 202Z" />
-              {regions.slice(0, 8).map(([region, count], index) => {
-                const x = 70 + ((index * 71) % 390);
-                const y = 112 + ((index * 43) % 100);
-                return <g key={region}><circle cx={x} cy={y} r={Math.max(5, Math.min(14, 5 + count / max * 10))} /><text x={x + 10} y={y + 4}>{region}</text></g>;
-              })}
-            </svg>
-            <small>區域示意圖 · 資料依設備回報的區域分類</small>
-          </div>
           <div className="region-bars">
             {regions.slice(0, 8).map(([region, count]) => <div className="region-bar-row" key={region}>
               <div><strong>{region}</strong><span>{count.toLocaleString()} 台</span></div>
@@ -1823,10 +1881,29 @@ function RegionFleetPanel({ summary, loading }) {
             </div>)}
             {!regions.length ? <p className="empty-state">目前沒有區域資料。</p> : null}
           </div>
+          <div className="region-map-desktop"><RegionMap regions={regions} max={max} /></div>
+          <details className="region-map-mobile">
+            <summary>View map</summary>
+            <RegionMap regions={regions} max={max} />
+          </details>
         </div>
       ) : null}
     </section>
   );
+}
+
+function RegionMap({ regions, max }) {
+  return <div className="region-map-vector" aria-label="區域設備分布圖">
+    <svg viewBox="0 0 520 260" role="img" aria-label="設備區域分布">
+      <path d="M38 150 92 118 138 128 166 92 230 106 274 78 334 96 390 72 476 112 450 178 390 184 350 220 275 202 220 232 164 214 100 232 52 202Z" />
+      {regions.slice(0, 8).map(([region, count], index) => {
+        const x = 70 + ((index * 71) % 390);
+        const y = 112 + ((index * 43) % 100);
+        return <g key={region}><circle cx={x} cy={y} r={Math.max(5, Math.min(14, 5 + count / max * 10))} /><text x={x + 10} y={y + 4}>{region}</text></g>;
+      })}
+    </svg>
+    <small>區域示意圖 · 資料依設備回報的區域分類</small>
+  </div>;
 }
 
 function PlatformChipsetProviders({ data, loading, capabilities, onRefresh }) {
@@ -4666,51 +4743,13 @@ function HealthDistributionPanel({ loading, current, onFilter, source }) {
   );
 }
 
-function RecentAlertsPanel({ loading, alerts, source, onOpenDevice }) {
-  const available = sourceAvailable(source);
-  return (
-    <section className="panel overview-panel alerts-panel">
-      <div className="panel-head">
-        <div>
-          <h2>Recent alerts</h2>
-          <p>Last 10 telemetry events that resulted in a health change.</p>
-        </div>
-      </div>
-      {!available ? (
-        <p className="empty-state">{sourceMessage(source, 'No telemetry source configured.')}</p>
-      ) : loading && !alerts.length ? (
-        <p className="empty-state">Loading recent alerts.</p>
-      ) : alerts.length ? (
-        <div className="alerts-table">
-          <div className="alerts-table-head">
-            <span>Time</span>
-            <span>Device</span>
-            <span>Signal</span>
-            <span>Health</span>
-          </div>
-          {alerts.map((alert) => (
-            <button type="button" className="alerts-table-row" key={alert.id} onClick={() => onOpenDevice(alert.device_id)}>
-              <time title={alert.occurred_at}>{formatRelativeTime(alert.occurred_at)}</time>
-              <strong>{alert.device_name}</strong>
-              <span>{alert.signal}</span>
-              <StatusBadge value={normalizeStatusKey(alert.health)} label={toTitleCase(alert.health)} />
-            </button>
-          ))}
-        </div>
-      ) : (
-        <p className="empty-state">No alerts in selected window.</p>
-      )}
-    </section>
-  );
-}
-
 function AttentionQueuePanel({ loading, items, onOpenDevice }) {
   return (
     <section className="panel overview-panel attention-panel">
       <div className="panel-head">
         <div>
-          <h2>Attention Queue ({items.length})</h2>
-          <p>Devices sorted by current health, signal, and alert impact.</p>
+          <h2>Devices that need attention ({items.length})</h2>
+          <p>Prioritized by current health, signal quality, and recent alerts.</p>
         </div>
       </div>
       {loading && !items.length ? (

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1581,9 +1581,8 @@ function CheckEmailInterstitial({ email, onResendVerification }) {
 }
 
 function VerifyForm({ token, onVerify }) {
-  const [value, setValue] = useState(token);
   const [password, setPassword] = useState('');
-  const [status, setStatus] = useState('Create your password to finish verification.');
+  const [status, setStatus] = useState(token ? 'Create your password to finish verification.' : 'This verification link is invalid.');
   const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
 
@@ -1592,7 +1591,7 @@ function VerifyForm({ token, onVerify }) {
     setBusy(true);
     setLocalError('');
     try {
-      const result = await onVerify({ token: value, new_password: password });
+      const result = await onVerify({ token, new_password: password });
       if (!result) {
         setLocalError('Verification failed. Check the token and try again.');
       } else if (result.tokens?.access_token) {
@@ -1612,14 +1611,10 @@ function VerifyForm({ token, onVerify }) {
       <p>Verify your email and create the password you will use to log in.</p>
       <form className="auth-form" onSubmit={submit}>
         <label>
-          Verification token
-          <input value={value} onChange={(event) => setValue(event.target.value)} placeholder="Verification token" required />
-        </label>
-        <label>
           New password
           <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
         </label>
-        <button type="submit" disabled={busy}>{busy ? 'Verifying' : 'Verify and continue'}</button>
+        <button type="submit" disabled={busy || !token}>{busy ? 'Verifying' : 'Verify and continue'}</button>
       </form>
       <p className="auth-status">{status}</p>
       {error ? <p className="error">{error}</p> : null}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -976,6 +976,16 @@ function App() {
     }
   }
 
+  async function handleVerificationStatus(token) {
+    setError('');
+    const result = await postJSON('/api/auth/customer/verification-status', { token });
+    if (result?.status === 'expired') {
+      window.history.replaceState({}, '', '/signup/verification-expired');
+      setActive('signup-verification-expired');
+    }
+    return result;
+  }
+
   async function handleResendVerification(email) {
     setError('');
     try {
@@ -1056,6 +1066,7 @@ function App() {
         active={active}
         error={error}
         onSignup={handleSignup}
+        onCheckVerification={handleVerificationStatus}
         onVerify={handleVerify}
         onResendVerification={handleResendVerification}
       />
@@ -1544,7 +1555,7 @@ function ResetPasswordView({ token, onResetPassword }) {
   );
 }
 
-function PublicAuthPage({ active, error, onSignup, onVerify, onResendVerification }) {
+function PublicAuthPage({ active, error, onSignup, onCheckVerification, onVerify, onResendVerification }) {
   const params = new URLSearchParams(window.location.search);
   const email = params.get('email') || '';
   const token = params.get('token') || '';
@@ -1561,8 +1572,10 @@ function PublicAuthPage({ active, error, onSignup, onVerify, onResendVerificatio
           <SignupForm onSignup={onSignup} />
         ) : active === 'signup-check-email' ? (
           <CheckEmailInterstitial email={email} onResendVerification={onResendVerification} />
+        ) : active === 'signup-verification-expired' ? (
+          <ExpiredVerificationPage />
         ) : (
-          <VerifyForm token={token} onVerify={onVerify} />
+          <VerifyForm token={token} onCheckVerification={onCheckVerification} onVerify={onVerify} />
         )}
         {error ? <div className="error">{error}</div> : null}
       </section>
@@ -1645,11 +1658,41 @@ function CheckEmailInterstitial({ email, onResendVerification }) {
   );
 }
 
-function VerifyForm({ token, onVerify }) {
+function ExpiredVerificationPage() {
+  return (
+    <div className="auth-stack expired-verification-page">
+      <h2>Verification link expired</h2>
+      <p>Your account was not verified. Start Sign Up again to receive a new verification email.</p>
+      <a className="primary-button auth-primary-link" href="/signup">Sign up again</a>
+      <a className="auth-link" href="/login">Back to Login</a>
+    </div>
+  );
+}
+
+function VerifyForm({ token, onCheckVerification, onVerify }) {
   const [password, setPassword] = useState('');
-  const [status, setStatus] = useState(token ? 'Create your password to finish verification.' : 'This verification link is invalid.');
+  const [linkStatus, setLinkStatus] = useState(token ? 'checking' : 'invalid');
+  const [status, setStatus] = useState(token ? 'Checking verification link…' : 'This verification link is invalid.');
   const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    if (!token) return undefined;
+    let active = true;
+    onCheckVerification(token)
+      .then((result) => {
+        if (!active || result?.status === 'expired') return;
+        const nextStatus = result?.status === 'valid' ? 'valid' : 'invalid';
+        setLinkStatus(nextStatus);
+        setStatus(nextStatus === 'valid' ? 'Create your password to finish verification.' : 'This verification link is invalid.');
+      })
+      .catch((err) => {
+        if (!active) return;
+        setLinkStatus('error');
+        setLocalError(userFacingVerificationError(err));
+      });
+    return () => { active = false; };
+  }, [onCheckVerification, token]);
 
   async function submit(event) {
     event.preventDefault();
@@ -1674,15 +1717,16 @@ function VerifyForm({ token, onVerify }) {
   return (
     <div className="auth-stack">
       <p>Verify your email and create the password you will use to log in.</p>
-      <form className="auth-form" onSubmit={submit}>
+      {linkStatus === 'valid' ? <form className="auth-form" onSubmit={submit}>
         <label>
           New password
           <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
         </label>
         <button type="submit" disabled={busy || !token}>{busy ? 'Verifying' : 'Verify and continue'}</button>
-      </form>
+      </form> : null}
       <p className="auth-status">{status}</p>
       {error ? <p className="error">{error}</p> : null}
+      {linkStatus === 'invalid' ? <a className="auth-link" href="/signup">Sign up again</a> : null}
     </div>
   );
 }

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -865,20 +865,6 @@ function App() {
     throw new Error(nextError);
   }
 
-  async function handleEmailSignIn(email) {
-    setError('');
-    try {
-      await postJSON('/api/auth/sign-in', { email });
-      window.history.pushState({}, '', `/login/check-email?email=${encodeURIComponent(email)}`);
-      setActive('login-check-email');
-      return true;
-    } catch (err) {
-      const nextError = userFacingLoginActivationError(err);
-      setError(nextError);
-      throw new Error(nextError);
-    }
-  }
-
   async function handleLoginActivate(token) {
     setError('');
     try {
@@ -1022,7 +1008,7 @@ function App() {
           active={active}
           error={error}
           loading={loading}
-          onEmailSignIn={handleEmailSignIn}
+          onSignup={handleSignup}
           onLoginActivate={handleLoginActivate}
           onBrandCloudActivate={handleBrandCloudActivate}
           onPasswordLogin={handlePasswordLogin}
@@ -1236,7 +1222,7 @@ function App() {
   );
 }
 
-function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onBrandCloudActivate, onPasswordLogin, onForgotPassword, onResetPassword }) {
+function LoginPage({ active, error, loading, onSignup, onLoginActivate, onBrandCloudActivate, onPasswordLogin, onForgotPassword, onResetPassword }) {
   const params = new URLSearchParams(window.location.search);
   const email = params.get('email') || '';
   const token = params.get('token') || '';
@@ -1251,7 +1237,7 @@ function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onB
   ) : active === 'reset-password' ? (
     <ResetPasswordView token={token} onResetPassword={onResetPassword} />
   ) : (
-    <LoginEntryForm onEmailSignIn={onEmailSignIn} onPasswordLogin={onPasswordLogin} disabled={loading} />
+    <LoginEntryForm onSignup={onSignup} onPasswordLogin={onPasswordLogin} disabled={loading} />
   );
   return (
     <div className="login-shell">
@@ -1262,7 +1248,7 @@ function LoginPage({ active, error, loading, onEmailSignIn, onLoginActivate, onB
             <strong>Connect+ Ops</strong>
           </div>
           <h1 id="login-title">Admin Console</h1>
-          <p className="login-copy">Login with your password or sign in with an email activation link.</p>
+          <p className="login-copy">Login to an existing account or create a new evaluation account.</p>
           {content}
           {error ? <div className="error">{error}</div> : null}
         </section>
@@ -1301,7 +1287,7 @@ function BrandCloudActivateView({ token, tenant, onActivate }) {
   );
 }
 
-function LoginEntryForm({ onEmailSignIn, onPasswordLogin, disabled }) {
+function LoginEntryForm({ onSignup, onPasswordLogin, disabled }) {
   const [mode, setMode] = useState('login');
   return (
     <div className="auth-stack">
@@ -1317,49 +1303,20 @@ function LoginEntryForm({ onEmailSignIn, onPasswordLogin, disabled }) {
         </button>
         <button
           type="button"
-          className={mode === 'signin' ? 'active' : ''}
+          className={mode === 'signup' ? 'active' : ''}
           role="tab"
-          aria-selected={mode === 'signin'}
-          onClick={() => setMode('signin')}
+          aria-selected={mode === 'signup'}
+          onClick={() => setMode('signup')}
         >
-          Sign-in
+          Sign Up
         </button>
       </div>
-      {mode === 'signin' ? (
-        <LoginEmailForm onEmailSignIn={onEmailSignIn} disabled={disabled} />
+      {mode === 'signup' ? (
+        <SignupForm onSignup={onSignup} disabled={disabled} />
       ) : (
         <LoginPasswordForm onPasswordLogin={onPasswordLogin} disabled={disabled} />
       )}
     </div>
-  );
-}
-
-function LoginEmailForm({ onEmailSignIn, disabled }) {
-  const [email, setEmail] = useState('');
-  const [busy, setBusy] = useState(false);
-  const [localError, setLocalError] = useState('');
-  async function submit(event) {
-    event.preventDefault();
-    setBusy(true);
-    setLocalError('');
-    try {
-      await onEmailSignIn(email);
-    } catch (err) {
-      setLocalError(err?.message || 'Sign-in is temporarily unavailable. Please try again later.');
-    } finally {
-      setBusy(false);
-    }
-  }
-  return (
-    <form className="login-form" onSubmit={submit}>
-      <p className="auth-status">Send an activation link to continue without a password.</p>
-      <label>
-        Email
-        <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="name@company.com" required />
-      </label>
-      <button type="submit" disabled={busy || disabled}>{busy ? 'Sending' : 'Continue'}</button>
-      {localError ? <p className="error">{localError}</p> : null}
-    </form>
   );
 }
 
@@ -1548,13 +1505,9 @@ function PublicAuthPage({ active, error, onSignup, onVerify, onResendVerificatio
   );
 }
 
-function SignupForm({ onSignup }) {
+function SignupForm({ onSignup, disabled = false }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
-  const [organizationName, setOrganizationName] = useState('');
-  const [displayName, setDisplayName] = useState('');
-  const [captchaToken, setCaptchaToken] = useState('');
-  const [acceptTerms, setAcceptTerms] = useState(false);
   const [honeypot, setHoneypot] = useState('');
   const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
@@ -1562,16 +1515,13 @@ function SignupForm({ onSignup }) {
 
   async function submit(event) {
     event.preventDefault();
-    if (!acceptTerms || honeypot) return;
+    if (honeypot) return;
     setBusy(true);
     setLocalError('');
     try {
       await onSignup({
         email,
         password,
-        display_name: displayName,
-        organization_name: organizationName,
-        captcha_token: captchaToken,
       });
     } catch (err) {
       setLocalError(userFacingSignupError(err));
@@ -1590,31 +1540,15 @@ function SignupForm({ onSignup }) {
         Password
         <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
       </label>
-      <label>
-        Organization name
-        <input value={organizationName} onChange={(event) => setOrganizationName(event.target.value)} placeholder="Acme Camera Fleet" required />
-      </label>
-      <label>
-        Display name
-        <input value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Optional contact name" />
-      </label>
       <label className="auth-honeypot">
         Leave this field empty
         <input value={honeypot} onChange={(event) => setHoneypot(event.target.value)} tabIndex={-1} autoComplete="off" />
-      </label>
-      <label>
-        CAPTCHA token
-        <input value={captchaToken} onChange={(event) => setCaptchaToken(event.target.value)} placeholder="Optional if enabled" />
       </label>
       <div className="auth-strength">
         <span>Password strength</span>
         <strong>{strength}</strong>
       </div>
-      <label className="auth-terms">
-        <input type="checkbox" checked={acceptTerms} onChange={(event) => setAcceptTerms(event.target.checked)} />
-        I accept the evaluation-tier terms.
-      </label>
-      <button type="submit" disabled={busy || !acceptTerms || !!honeypot}>Create account</button>
+      <button type="submit" disabled={busy || disabled || !!honeypot}>Create account</button>
       {error ? <p className="error">{error}</p> : null}
     </form>
   );

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -927,10 +927,10 @@ function App() {
     }
   }
 
-  async function handleVerify(token) {
+  async function handleVerify(payload) {
     setError('');
     try {
-      const result = await postJSON('/api/auth/customer/verify-email', { token });
+      const result = await postJSON('/api/auth/customer/verify-email', payload);
       if (result.tokens?.access_token) {
         window.history.pushState({}, '', '/console/overview');
         setActive('overview');
@@ -1507,11 +1507,9 @@ function PublicAuthPage({ active, error, onSignup, onVerify, onResendVerificatio
 
 function SignupForm({ onSignup, disabled = false }) {
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [honeypot, setHoneypot] = useState('');
   const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
-  const strength = passwordStrength(password);
 
   async function submit(event) {
     event.preventDefault();
@@ -1521,7 +1519,6 @@ function SignupForm({ onSignup, disabled = false }) {
     try {
       await onSignup({
         email,
-        password,
       });
     } catch (err) {
       setLocalError(userFacingSignupError(err));
@@ -1536,18 +1533,10 @@ function SignupForm({ onSignup, disabled = false }) {
         Email
         <input type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="name@company.com" required />
       </label>
-      <label>
-        Password
-        <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
-      </label>
       <label className="auth-honeypot">
         Leave this field empty
         <input value={honeypot} onChange={(event) => setHoneypot(event.target.value)} tabIndex={-1} autoComplete="off" />
       </label>
-      <div className="auth-strength">
-        <span>Password strength</span>
-        <strong>{strength}</strong>
-      </div>
       <button type="submit" disabled={busy || disabled || !!honeypot}>Create account</button>
       {error ? <p className="error">{error}</p> : null}
     </form>
@@ -1593,42 +1582,23 @@ function CheckEmailInterstitial({ email, onResendVerification }) {
 
 function VerifyForm({ token, onVerify }) {
   const [value, setValue] = useState(token);
-  const [status, setStatus] = useState('Waiting for verification link.');
+  const [password, setPassword] = useState('');
+  const [status, setStatus] = useState('Create your password to finish verification.');
   const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
-  const [attempted, setAttempted] = useState(false);
-
-  useEffect(() => {
-    if (!value || attempted) return;
-    setAttempted(true);
-    setBusy(true);
-    setLocalError('');
-    onVerify(value)
-      .then((result) => {
-        if (!result) {
-          setLocalError('Verification failed. Check the token and try again.');
-        } else if (result.tokens?.access_token) {
-          setStatus('Verification completed. Redirecting to the dashboard.');
-        } else {
-          setStatus('Email verified. Sign in to continue.');
-        }
-      })
-      .catch((err) => setLocalError(userFacingVerificationError(err)))
-      .finally(() => setBusy(false));
-  }, [attempted, onVerify, value]);
 
   async function submit(event) {
     event.preventDefault();
     setBusy(true);
     setLocalError('');
     try {
-      const result = await onVerify(value);
+      const result = await onVerify({ token: value, new_password: password });
       if (!result) {
         setLocalError('Verification failed. Check the token and try again.');
       } else if (result.tokens?.access_token) {
         setStatus('Verification completed. Redirecting to the dashboard.');
       } else {
-        setStatus('Email verified. Sign in to continue.');
+        setStatus('Email verified. You can now sign in.');
       }
     } catch (err) {
       setLocalError(userFacingVerificationError(err));
@@ -1639,10 +1609,17 @@ function VerifyForm({ token, onVerify }) {
 
   return (
     <div className="auth-stack">
-      <p>Paste the email verification token from your inbox link.</p>
-      <form className="auth-inline" onSubmit={submit}>
-        <input value={value} onChange={(event) => setValue(event.target.value)} placeholder="Verification token" required />
-        <button type="submit" disabled={busy}>Verify</button>
+      <p>Verify your email and create the password you will use to log in.</p>
+      <form className="auth-form" onSubmit={submit}>
+        <label>
+          Verification token
+          <input value={value} onChange={(event) => setValue(event.target.value)} placeholder="Verification token" required />
+        </label>
+        <label>
+          New password
+          <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
+        </label>
+        <button type="submit" disabled={busy}>{busy ? 'Verifying' : 'Verify and continue'}</button>
       </form>
       <p className="auth-status">{status}</p>
       {error ? <p className="error">{error}</p> : null}
@@ -6038,17 +6015,6 @@ function formatTierLabel(tier) {
   if (tier === 'evaluation') return 'Evaluation';
   if (tier === 'commercial') return 'Commercial';
   return toTitleCase(String(tier).replaceAll('_', ' '));
-}
-
-function passwordStrength(password) {
-  if (!password) return 'Empty';
-  let score = 0;
-  if (password.length >= 8) score += 1;
-  if (password.length >= 12) score += 1;
-  if (/[A-Z]/.test(password)) score += 1;
-  if (/[0-9]/.test(password)) score += 1;
-  if (/[^A-Za-z0-9]/.test(password)) score += 1;
-  return ['Weak', 'Fair', 'Good', 'Strong', 'Excellent'][Math.min(score, 4)];
 }
 
 function normalizeStatusKey(value) {

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -33,7 +33,7 @@ export const platformNavItems = [
   { id: 'platform-audit', label: 'Audit Log', path: '/admin/audit', icon: 'shield-halved' },
 ];
 
-const publicRouteIds = new Set(['login', 'login-check-email', 'login-activate', 'brand-cloud-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'verify']);
+const publicRouteIds = new Set(['login', 'login-check-email', 'login-activate', 'brand-cloud-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'signup-verification-expired', 'verify']);
 
 export function isPublicRouteId(route) {
   return publicRouteIds.has(route);
@@ -64,6 +64,7 @@ export function titleFor(active) {
     'reset-password': 'Reset password',
     signup: 'Sign up',
     'signup-check-email': 'Check your email',
+    'signup-verification-expired': 'Verification link expired',
     verify: 'Verify email',
     'brand-cloud-member-invitation-accept': 'Accept Brand Cloud invitation',
     overview: '設備總覽',
@@ -99,6 +100,7 @@ export function routeFromPath(path) {
   if (path === '/reset-password' || path.startsWith('/reset-password/')) return 'reset-password';
   if (path === '/signup' || path === '/signup/') return 'signup';
   if (path === '/signup/check-email' || path.startsWith('/signup/check-email/')) return 'signup-check-email';
+  if (path === '/signup/verification-expired' || path.startsWith('/signup/verification-expired/')) return 'signup-verification-expired';
   if (path === '/signup/verify' || path.startsWith('/signup/verify/')) return 'verify';
   if (path === '/verify' || path.startsWith('/verify/')) return 'verify';
   if (path === '/brand-cloud-member-invitation/accept') return 'brand-cloud-member-invitation-accept';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -40,6 +40,7 @@ test('maps public signup paths to auth routes', () => {
   assert.equal(routeFromPath('/signup'), 'signup');
   assert.equal(routeFromPath('/signup/check-email'), 'signup-check-email');
   assert.equal(routeFromPath('/signup/check-email/inbox'), 'signup-check-email');
+  assert.equal(routeFromPath('/signup/verification-expired'), 'signup-verification-expired');
   assert.equal(routeFromPath('/signup/verify'), 'verify');
   assert.equal(routeFromPath('/signup/verify/'), 'verify');
   assert.equal(routeFromPath('/verify'), 'verify');
@@ -127,7 +128,7 @@ test('platform nav follows the Platform Dashboard landing order', () => {
 });
 
 test('public auth routes stay outside Customer and Platform section navigation', () => {
-  for (const route of ['login', 'login-check-email', 'login-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'verify']) {
+  for (const route of ['login', 'login-check-email', 'login-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'signup-verification-expired', 'verify']) {
     assert.equal(isPublicRouteId(route), true, route);
     assert.equal(isPlatformRouteId(route), false, route);
     assert.deepEqual(navItemsForRoute(route), []);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -306,8 +306,10 @@ body:has(.public-auth-shell) {
     linear-gradient(165deg, rgba(242, 250, 252, 0.98) 0%, rgba(255, 255, 255, 0.98) 44%, #fff 100%);
 }
 
+html:has(.login-shell),
 body:has(.login-shell) {
   background: var(--bg-soft);
+  overflow-x: hidden;
 }
 
 button,
@@ -2654,15 +2656,14 @@ p {
   font-size: 13px;
 }
 
-.auth-terms {
-  align-items: center;
-  display: flex;
-  gap: 10px;
-}
-
 .auth-honeypot {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
   position: absolute;
-  left: -9999px;
+  white-space: nowrap;
+  width: 1px;
 }
 
 .login-shell {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2649,13 +2649,6 @@ p {
   text-decoration: underline;
 }
 
-.auth-strength {
-  display: flex;
-  justify-content: space-between;
-  color: var(--muted);
-  font-size: 13px;
-}
-
 .auth-honeypot {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -921,6 +921,7 @@ main {
   }
 }
 
+
 h1,
 h2,
 p {
@@ -4756,5 +4757,421 @@ th {
 
   .billing-page button {
     width: 100%;
+  }
+}
+/* Responsive console shell and status-first overview. */
+.mobile-appbar,
+.mobile-nav-overlay,
+.mobile-nav-close,
+.sidebar-logout,
+.region-map-mobile {
+  display: none;
+}
+
+.overview-grid {
+  grid-template-columns: minmax(320px, .9fr) minmax(0, 1.45fr);
+}
+
+.overview-grid > *,
+.overview-attention,
+.overview-attention > *,
+.region-fleet-grid > * {
+  min-width: 0;
+}
+
+@media (max-width: 1279px) {
+  .overview-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .overview-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 1023px) {
+  .app-shell,
+  .platform-shell {
+    display: grid;
+    grid-template-columns: 1fr;
+    padding-top: 58px;
+  }
+
+  .app-shell > main,
+  .platform-shell > main {
+    grid-column: 1;
+    grid-row: 1;
+  }
+
+  .mobile-appbar {
+    align-items: center;
+    background: #082944;
+    color: #fff;
+    display: grid;
+    gap: 12px;
+    grid-template-columns: 44px minmax(0, 1fr) 36px;
+    height: 58px;
+    inset: 0 0 auto;
+    padding: 7px 14px;
+    position: fixed;
+    z-index: 390;
+  }
+
+  .mobile-appbar strong {
+    font-size: 17px;
+    overflow: hidden;
+    text-align: center;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .mobile-menu-button,
+  .mobile-nav-close {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 8px;
+    color: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    height: 44px;
+    justify-content: center;
+    width: 44px;
+  }
+
+  .mobile-menu-button:hover,
+  .mobile-menu-button:focus-visible,
+  .mobile-nav-close:hover,
+  .mobile-nav-close:focus-visible {
+    background: rgba(255, 255, 255, .12);
+    outline: 2px solid rgba(255, 255, 255, .75);
+    outline-offset: -2px;
+  }
+
+  .mobile-appbar-mark {
+    align-items: center;
+    background: rgba(255, 255, 255, .14);
+    border-radius: 8px;
+    display: inline-flex;
+    font-size: 12px;
+    font-weight: 800;
+    height: 34px;
+    justify-content: center;
+    width: 34px;
+  }
+
+  .mobile-nav-overlay {
+    background: rgba(3, 17, 29, .58);
+    border: 0;
+    display: block;
+    inset: 0;
+    opacity: 0;
+    pointer-events: none;
+    position: fixed;
+    transition: opacity .2s ease;
+    z-index: 400;
+  }
+
+  .mobile-nav-overlay.open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .sidebar,
+  .platform-shell .sidebar {
+    background: linear-gradient(180deg, #082944 0%, var(--navy) 100%);
+    border: 0;
+    box-shadow: 12px 0 30px rgba(3, 17, 29, .22);
+    color: #fff;
+    height: 100dvh;
+    inset: 0 auto 0 0;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 22px 14px;
+    position: fixed;
+    transform: translateX(-105%);
+    transition: transform .2s ease;
+    width: min(320px, calc(100vw - 40px));
+    z-index: 410;
+  }
+
+  .sidebar.mobile-open,
+  .platform-shell .sidebar.mobile-open {
+    transform: translateX(0);
+  }
+
+  .sidebar .brand,
+  .platform-shell .brand {
+    margin-bottom: 28px;
+    padding: 0 4px 0 8px;
+  }
+
+  .sidebar .brand strong,
+  .platform-shell .brand strong,
+  .sidebar-account strong,
+  .platform-shell .sidebar-account strong {
+    color: #fff;
+  }
+
+  .mobile-nav-close {
+    margin-left: auto;
+  }
+
+  .sidebar nav,
+  .platform-shell nav {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar nav button,
+  .platform-shell nav button {
+    border-radius: 8px;
+    color: rgba(255, 255, 255, .82);
+    min-height: 44px;
+  }
+
+  .sidebar nav button .fa-solid,
+  .platform-shell nav button .fa-solid {
+    color: rgba(255, 255, 255, .76);
+  }
+
+  .sidebar nav button.active,
+  .sidebar nav button:hover,
+  .platform-shell nav button.active,
+  .platform-shell nav button:hover {
+    background: var(--brand);
+    box-shadow: none;
+    color: #fff;
+  }
+
+  .sidebar-section-label,
+  .platform-shell .sidebar-section-label,
+  .sidebar-account small,
+  .platform-shell .sidebar-account small {
+    color: rgba(255, 255, 255, .7);
+  }
+
+  .sidebar-platform-switch {
+    margin-top: 24px;
+  }
+
+  .sidebar-account,
+  .platform-shell .sidebar-account {
+    border-top-color: rgba(255, 255, 255, .16);
+    flex-wrap: wrap;
+    margin-top: 24px;
+  }
+
+  .sidebar-account > div {
+    min-width: 0;
+  }
+
+  .sidebar-account small {
+    overflow-wrap: anywhere;
+  }
+
+  .sidebar-logout {
+    align-items: center;
+    background: rgba(255, 255, 255, .08);
+    border: 1px solid rgba(255, 255, 255, .18);
+    border-radius: 8px;
+    color: #fff;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 8px;
+    justify-content: center;
+    min-height: 44px;
+    width: 100%;
+  }
+
+  main,
+  .platform-shell main {
+    padding: 16px;
+  }
+
+  .platform-shell > main > .error,
+  .platform-shell > main > .platform-dashboard,
+  .platform-shell > main > .panel,
+  .platform-shell > main > .platform-brand-clouds,
+  .platform-shell > main > .platform-sso-page {
+    margin: 0 0 18px;
+  }
+
+  .topbar,
+  .platform-shell .topbar {
+    background: transparent;
+    border: 0;
+    display: block;
+    margin: 0 0 16px;
+    min-height: 0;
+    padding: 0;
+  }
+
+  .topbar-title {
+    display: none;
+  }
+
+  .topbar-controls,
+  .platform-shell .topbar-controls {
+    align-items: stretch;
+    gap: 8px;
+    justify-content: flex-start;
+  }
+
+  .topbar-controls > .ghost-button,
+  .platform-shell .topbar-controls > .ghost-button {
+    display: none;
+  }
+
+  .org-switcher,
+  .window-toggle button {
+    min-height: 44px;
+  }
+
+  .region-fleet-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 767px) {
+  main,
+  .platform-shell main {
+    padding: 14px;
+  }
+
+  .overview-layout {
+    gap: 14px;
+  }
+
+  .overview-metrics {
+    gap: 10px;
+    margin-bottom: 0;
+  }
+
+  .metric-card {
+    align-items: center;
+    gap: 10px;
+    min-height: 126px;
+    padding: 14px;
+  }
+
+  .metric-card .metric-icon {
+    font-size: 18px;
+    height: 44px;
+    width: 44px;
+  }
+
+  .metric-card strong {
+    font-size: 26px;
+    line-height: 1.05;
+    overflow-wrap: anywhere;
+  }
+
+  .metric-card small {
+    line-height: 1.35;
+  }
+
+  .overview-layout .panel {
+    margin-bottom: 0;
+    overflow: hidden;
+    padding: 16px;
+  }
+
+  .overview-layout .panel-head {
+    align-items: stretch;
+    display: grid;
+    gap: 10px;
+  }
+
+  .distribution-segment {
+    min-height: 44px;
+    padding: 0;
+    position: relative;
+  }
+
+  .distribution-segment span,
+  .distribution-segment strong {
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    height: 1px;
+    overflow: hidden;
+    position: absolute;
+    white-space: nowrap;
+    width: 1px;
+  }
+
+  .distribution-row {
+    min-height: 44px;
+  }
+
+  .trend-chart {
+    min-height: 150px;
+  }
+
+  .attention-list-head {
+    display: none;
+  }
+
+  .attention-row {
+    gap: 8px 12px;
+    grid-template-columns: minmax(0, 1fr) auto;
+    padding: 14px;
+  }
+
+  .attention-row strong,
+  .attention-row time {
+    grid-column: 1;
+  }
+
+  .attention-row .attention-issue {
+    grid-column: 2;
+    grid-row: 1 / span 2;
+    text-align: right;
+  }
+
+  .attention-row button {
+    grid-column: 1 / -1;
+    min-height: 44px;
+    width: 100%;
+  }
+
+  .region-map-desktop {
+    display: none;
+  }
+
+  .region-map-mobile {
+    display: block;
+  }
+
+  .region-map-mobile summary {
+    align-items: center;
+    border: 1px solid var(--line);
+    border-radius: 8px;
+    color: var(--brand-dark);
+    cursor: pointer;
+    display: flex;
+    font-weight: 700;
+    min-height: 44px;
+    padding: 0 12px;
+  }
+
+  .region-map-mobile[open] summary {
+    margin-bottom: 10px;
+  }
+
+  .region-map-vector svg {
+    min-height: 0;
+  }
+
+  .quota-callout,
+  .quota-callout .quota-form {
+    display: grid;
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 359px) {
+  .overview-metrics {
+    grid-template-columns: 1fr;
   }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2618,6 +2618,14 @@ p {
   gap: 14px;
 }
 
+.auth-primary-link {
+  align-items: center;
+  display: inline-flex;
+  justify-content: center;
+  justify-self: start;
+  text-decoration: none;
+}
+
 .auth-status {
   color: var(--brand-dark);
   font-size: 14px;


### PR DESCRIPTION
## Summary

- replace the misleading Sign-in account-creation tab with an email-only Sign Up flow
- keep verification tokens out of the rendered UI and create the password only during verification
- add an immediate token-status preflight and a dedicated verification-expired page with Sign up again recovery
- show duplicate-account errors once with actionable Login and password-reset guidance
- make the console overview adaptive across mobile and desktop layouts
- document the complete WebUI signup and verification lifecycle

## Validation

- GOWORK=off go test ./...
- 82 Web unit tests passed
- production Web build passed
- browser smoke passed, including expired-link and responsive layout coverage
- deployed Cloud Admin image sha-0e9bc1a7caa7 to staging
- confirmed the deployment is ready, health checks pass, the live verification-status BFF works, and the expired page route returns HTTP 200

## Related backend PR

The matching Account Manager PR provides token status, expiry enforcement, and expired pending-account recovery.
