### PR TITLE
Add SKU collaborator management UI

### DIFF
--- a/docs/ROLES.md
+++ b/docs/ROLES.md
@@ -180,6 +180,22 @@ explicitly granted the developer capability.
 
 ### Capability contract
 
+### SKU project collaboration
+
+Brand Cloud membership is not SKU visibility. The Brand Cloud owner has audited
+governance access and is the only actor allowed to create a SKU. Each SKU has
+one explicit, transferable owner plus Editors and Viewers:
+
+| SKU role | Project access | Collaboration authority |
+|---|---|---|
+| Owner | Full SKU, device, firmware, OTA, provisioning, batch, and report access | Invite, change, remove, disable, and transfer ownership |
+| Editor | Read/write project operations | None |
+| Viewer | Read-only project resources | None |
+
+Unassigned SKUs are omitted from lists and direct access fails without revealing
+whether the SKU exists. Organization-wide admin/member roles do not override
+this rule.
+
 The active membership must project these machine-readable capabilities. Display
 roles are only labels:
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 79.3% |
+| Go total coverage | 77.5% |
 | Go coverage gate | >= 65.0% |
 | Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
@@ -28,8 +28,8 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 88.2% |
-| `rtk_cloud_admin/internal/app` | 80.0% |
+| `rtk_cloud_admin/internal/accountclient` | 82.0% |
+| `rtk_cloud_admin/internal/app` | 78.1% |
 | `rtk_cloud_admin/internal/billingclient` | 24.4% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |

--- a/docs/admin-dashboard-redesign.md
+++ b/docs/admin-dashboard-redesign.md
@@ -174,6 +174,14 @@ cover the whole organization, one SKU, a region, a device group, or a single
 device. The page shows role names and readable scope labels; raw permission
 names and internal actor identifiers stay out of the primary workflow.
 
+SKU collaboration is managed from `SKU 與服務`, not from the tenant-wide team
+table. The Brand Cloud owner alone creates a SKU and becomes its initial owner.
+The SKU owner invites registered developers as Editor or Viewer, changes or
+removes collaborators, and may explicitly transfer ownership. Cards and tables
+show the current user's effective SKU role and only render server-projected
+`allowed_actions`. A developer with a valid Brand Cloud identity but no SKU
+assignment sees an empty project state rather than the tenant's full catalog.
+
 The `SKU 與服務` surface is the source of truth for the operator-facing
 relationship between a SKU, its product/device specification, enabled service
 capabilities, user permissions, device policy, and firmware policy. A SKU is

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -597,6 +597,83 @@ paths:
         "401": { $ref: "#/components/responses/PlainTextError" }
         "403": { $ref: "#/components/responses/PlainTextError" }
 
+  /api/skus/{skuID}/collaborators:
+    get:
+      operationId: getApiSKUCollaborators
+      x-rtk-requirement-ids: [REQ-CONTRACT-SKU-COLLAB-001]
+      tags: [Developer]
+      summary: List collaborators and pending invitations for one SKU project
+      parameters: [{ name: skuID, in: path, required: true, schema: { type: string, format: uuid } }]
+      responses:
+        "200": { description: SKU collaborator state. }
+        "404": { $ref: "#/components/responses/PlainTextError" }
+
+  /api/skus/{skuID}/collaborator-invitations:
+    post:
+      operationId: postApiSKUCollaboratorInvitation
+      x-rtk-requirement-ids: [REQ-CONTRACT-SKU-COLLAB-001]
+      tags: [Developer]
+      summary: Invite a registered developer as Editor or Viewer
+      parameters:
+        - { name: skuID, in: path, required: true, schema: { type: string, format: uuid } }
+        - $ref: "#/components/parameters/IdempotencyKey"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [email, role]
+              properties:
+                email: { type: string, format: email }
+                role: { type: string, enum: [sku_editor, sku_viewer] }
+      responses:
+        "202": { description: Invitation created. }
+        "404": { $ref: "#/components/responses/PlainTextError" }
+        "409": { $ref: "#/components/responses/PlainTextError" }
+
+  /api/skus/{skuID}/collaborators/{userID}:
+    patch:
+      operationId: patchApiSKUCollaborator
+      x-rtk-requirement-ids: [REQ-CONTRACT-SKU-COLLAB-001]
+      tags: [Developer]
+      summary: Change an Editor or Viewer role
+      parameters:
+        - { name: skuID, in: path, required: true, schema: { type: string, format: uuid } }
+        - { name: userID, in: path, required: true, schema: { type: string, format: uuid } }
+        - $ref: "#/components/parameters/IdempotencyKey"
+      responses: { "200": { description: Collaborator updated. }, "404": { $ref: "#/components/responses/PlainTextError" } }
+    delete:
+      operationId: deleteApiSKUCollaborator
+      x-rtk-requirement-ids: [REQ-CONTRACT-SKU-COLLAB-001]
+      tags: [Developer]
+      summary: Remove a non-owner collaborator
+      parameters:
+        - { name: skuID, in: path, required: true, schema: { type: string, format: uuid } }
+        - { name: userID, in: path, required: true, schema: { type: string, format: uuid } }
+        - $ref: "#/components/parameters/IdempotencyKey"
+      responses: { "204": { description: Collaborator removed. }, "404": { $ref: "#/components/responses/PlainTextError" } }
+
+  /api/skus/{skuID}/owner-transfer:
+    post:
+      operationId: postApiSKUOwnerTransfer
+      x-rtk-requirement-ids: [REQ-CONTRACT-SKU-COLLAB-001]
+      tags: [Developer]
+      summary: Atomically transfer explicit SKU ownership
+      parameters:
+        - { name: skuID, in: path, required: true, schema: { type: string, format: uuid } }
+        - $ref: "#/components/parameters/IdempotencyKey"
+      responses: { "200": { description: Ownership transferred. }, "404": { $ref: "#/components/responses/PlainTextError" } }
+
+  /api/developer/sku-collaborator-invitations/accept:
+    post:
+      operationId: postApiDeveloperSKUCollaboratorInvitationsAccept
+      x-rtk-requirement-ids: [REQ-CONTRACT-SKU-COLLAB-001]
+      tags: [Developer]
+      summary: Accept a SKU invitation and atomically activate membership and assignment
+      parameters: [{ $ref: "#/components/parameters/IdempotencyKey" }]
+      responses: { "200": { description: SKU assignment activated. }, "404": { $ref: "#/components/responses/PlainTextError" } }
+
   /api/developer/brand-clouds/{brandCloudID}/members/{userID}:
     patch:
       operationId: patchApiDeveloperBrandCloudsByBrandCloudIDMembersByUserID

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -165,6 +165,26 @@ type BrandCloudMemberInvitation struct {
 	UpdatedAt       string `json:"updated_at"`
 }
 
+type SKUCollaborator struct {
+	AssignmentID string `json:"assignment_id"`
+	SKUID        string `json:"sku_id"`
+	UserID       string `json:"user_id"`
+	Email        string `json:"email"`
+	DisplayName  string `json:"display_name,omitempty"`
+	Role         string `json:"role"`
+	DisabledAt   string `json:"disabled_at,omitempty"`
+	CreatedAt    string `json:"created_at"`
+}
+
+type SKUCollaboratorInvitation struct {
+	ID          string `json:"id"`
+	SKUID       string `json:"sku_id"`
+	TargetEmail string `json:"target_email"`
+	Role        string `json:"role"`
+	Status      string `json:"status"`
+	ExpiresAt   string `json:"expires_at"`
+}
+
 type BrandCloudUserResult struct {
 	Action           string         `json:"action"`
 	BrandCloudUser   BrandCloudUser `json:"brand_cloud_user"`
@@ -229,6 +249,7 @@ type DeviceItemProfile struct {
 	ProvisioningPolicy map[string]any `json:"provisioning_policy"`
 	CreatedAt          string         `json:"created_at"`
 	UpdatedAt          string         `json:"updated_at"`
+	CurrentUserRole    string         `json:"current_user_role,omitempty"`
 }
 
 type DeviceItemProfileRequest struct {
@@ -843,6 +864,81 @@ func (c *Client) SetDeveloperBrandCloudMemberStatus(ctx context.Context, accessT
 	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/members/" + url.PathEscape(userID) + "/" + action
 	err := c.doJSON(ctx, http.MethodPatch, path, accessToken, nil, &body)
 	return body.Member, err
+}
+
+func (c *Client) SKUCollaborators(ctx context.Context, accessToken, brandCloudID, skuID string) ([]SKUCollaborator, error) {
+	var body struct {
+		Collaborators []SKUCollaborator `json:"collaborators"`
+	}
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/skus/" + url.PathEscape(skuID) + "/collaborators"
+	if err := c.doJSON(ctx, http.MethodGet, path, accessToken, nil, &body); err != nil {
+		return nil, err
+	}
+	return body.Collaborators, nil
+}
+
+func (c *Client) SKUCollaboratorInvitations(ctx context.Context, accessToken, brandCloudID, skuID string) ([]SKUCollaboratorInvitation, error) {
+	var body struct {
+		Invitations []SKUCollaboratorInvitation `json:"invitations"`
+	}
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/skus/" + url.PathEscape(skuID) + "/collaborator-invitations"
+	if err := c.doJSON(ctx, http.MethodGet, path, accessToken, nil, &body); err != nil {
+		return nil, err
+	}
+	return body.Invitations, nil
+}
+
+func (c *Client) InviteSKUCollaborator(ctx context.Context, accessToken, brandCloudID, skuID, email, role string) (SKUCollaboratorInvitation, error) {
+	var body struct {
+		Invitation SKUCollaboratorInvitation `json:"invitation"`
+	}
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/skus/" + url.PathEscape(skuID) + "/collaborator-invitations"
+	if err := c.doJSON(ctx, http.MethodPost, path, accessToken, map[string]string{"email": email, "role": role}, &body); err != nil {
+		return SKUCollaboratorInvitation{}, err
+	}
+	return body.Invitation, nil
+}
+
+func (c *Client) ActOnSKUCollaboratorInvitation(ctx context.Context, accessToken, brandCloudID, skuID, invitationID, action string) (SKUCollaboratorInvitation, error) {
+	var body struct {
+		Invitation SKUCollaboratorInvitation `json:"invitation"`
+	}
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/skus/" + url.PathEscape(skuID) + "/collaborator-invitations/" + url.PathEscape(invitationID) + "/" + url.PathEscape(action)
+	if err := c.doJSON(ctx, http.MethodPost, path, accessToken, nil, &body); err != nil {
+		return SKUCollaboratorInvitation{}, err
+	}
+	return body.Invitation, nil
+}
+
+func (c *Client) UpdateSKUCollaborator(ctx context.Context, accessToken, brandCloudID, skuID, userID, role string) (SKUCollaborator, error) {
+	var body struct {
+		Collaborator SKUCollaborator `json:"collaborator"`
+	}
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/skus/" + url.PathEscape(skuID) + "/collaborators/" + url.PathEscape(userID)
+	if err := c.doJSON(ctx, http.MethodPatch, path, accessToken, map[string]string{"role": role}, &body); err != nil {
+		return SKUCollaborator{}, err
+	}
+	return body.Collaborator, nil
+}
+
+func (c *Client) RemoveSKUCollaborator(ctx context.Context, accessToken, brandCloudID, skuID, userID string) error {
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/skus/" + url.PathEscape(skuID) + "/collaborators/" + url.PathEscape(userID)
+	return c.doJSON(ctx, http.MethodDelete, path, accessToken, nil, nil)
+}
+
+func (c *Client) TransferSKUOwnership(ctx context.Context, accessToken, brandCloudID, skuID, targetUserID string) error {
+	path := "/v1/developer/brand-clouds/" + url.PathEscape(brandCloudID) + "/skus/" + url.PathEscape(skuID) + "/owner-transfer"
+	return c.doJSON(ctx, http.MethodPost, path, accessToken, map[string]string{"target_user_id": targetUserID}, nil)
+}
+
+func (c *Client) AcceptSKUCollaboratorInvitation(ctx context.Context, accessToken, token string) (SKUCollaboratorInvitation, error) {
+	var body struct {
+		Invitation SKUCollaboratorInvitation `json:"invitation"`
+	}
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/developer/sku-collaborator-invitations/accept", accessToken, map[string]string{"token": token}, &body); err != nil {
+		return SKUCollaboratorInvitation{}, err
+	}
+	return body.Invitation, nil
 }
 
 func (c *Client) RequestDeveloperOwnerTransfer(ctx context.Context, accessToken, brandCloudID, targetEmail string) (OwnerTransfer, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -274,6 +274,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/developer/brand-clouds/{brandCloudID}/owner-transfer/{transferID}/cancel", s.apiDeveloperOwnerTransfer)
 	s.mux.HandleFunc("POST /api/developer/brand-cloud-owner-transfers/accept", s.apiDeveloperOwnerTransferAccept)
 	s.mux.HandleFunc("POST /api/developer/brand-cloud-member-invitations/accept", s.apiDeveloperBrandCloudInvitationAccept)
+	s.mux.HandleFunc("POST /api/developer/sku-collaborator-invitations/accept", s.apiSKUCollaboratorInvitationAccept)
 	s.mux.HandleFunc("POST /api/developer/pki/test-bundles/app", s.apiDeveloperPKITestAppBundle)
 	s.mux.HandleFunc("POST /api/developer/pki/test-bundles/device", s.apiDeveloperPKITestDeviceBundle)
 	s.mux.HandleFunc("POST /api/auth/customer/signup", s.apiCustomerSignup)
@@ -351,6 +352,12 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/skus/{id}/disable", s.apiSKUWrite)
 	s.mux.HandleFunc("GET /api/skus/{id}/permissions", s.apiSKUPermissions)
 	s.mux.HandleFunc("POST /api/skus/{id}/impact-preview", s.apiSKUImpactPreview)
+	s.mux.HandleFunc("GET /api/skus/{id}/collaborators", s.apiSKUCollaborators)
+	s.mux.HandleFunc("PATCH /api/skus/{id}/collaborators/{userId}", s.apiSKUCollaborator)
+	s.mux.HandleFunc("DELETE /api/skus/{id}/collaborators/{userId}", s.apiSKUCollaborator)
+	s.mux.HandleFunc("POST /api/skus/{id}/collaborator-invitations", s.apiSKUCollaboratorInvitations)
+	s.mux.HandleFunc("POST /api/skus/{id}/collaborator-invitations/{invitationId}/{action}", s.apiSKUCollaboratorInvitationAction)
+	s.mux.HandleFunc("POST /api/skus/{id}/owner-transfer", s.apiSKUOwnerTransfer)
 	s.mux.HandleFunc("GET /api/admin/devices", s.apiAdminDevices)
 	s.mux.HandleFunc("GET /api/admin/brand-clouds", s.apiAdminBrandClouds)
 	s.mux.HandleFunc("POST /api/admin/brand-clouds", s.apiAdminBrandClouds)
@@ -861,6 +868,30 @@ func (s *Server) apiDeveloperBrandCloudInvitationAccept(w http.ResponseWriter, r
 		return
 	}
 	writeJSON(w, map[string]any{"invitation": invitation, "member": member, "source_status": "available"})
+}
+
+func (s *Server) apiSKUCollaboratorInvitationAccept(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requestSession(r)
+	if !ok || strings.TrimSpace(session.AccessToken) == "" {
+		http.Error(w, "developer authentication required", http.StatusUnauthorized)
+		return
+	}
+	if _, ok := requireIdempotencyKey(w, r); !ok {
+		return
+	}
+	var body struct {
+		Token string `json:"token"`
+	}
+	if json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body) != nil || strings.TrimSpace(body.Token) == "" {
+		http.Error(w, "token is required", http.StatusBadRequest)
+		return
+	}
+	invitation, err := s.accountClient.AcceptSKUCollaboratorInvitation(r.Context(), session.AccessToken, strings.TrimSpace(body.Token))
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	writeJSON(w, map[string]any{"invitation": invitation, "source_status": "available"})
 }
 
 func (s *Server) apiDeveloperBrandCloudMember(w http.ResponseWriter, r *http.Request) {
@@ -2960,6 +2991,11 @@ func (s *Server) apiSKUs(w http.ResponseWriter, r *http.Request) {
 	capabilities := capabilitiesForOrganization(org)
 	for _, profile := range profiles {
 		item := customerSKUWithActionsAndSummary(profile, capabilities, &fleetSummary)
+		if profile.CurrentUserRole == "sku_owner" {
+			if collaborators, collaboratorErr := s.accountClient.SKUCollaborators(r.Context(), tokens.AccessToken, org.ID, profile.ID); collaboratorErr == nil {
+				item.CollaboratorCount = len(collaborators)
+			}
+		}
 		var runs []accountclient.ProductionRun
 		var runErr error
 		tokens, runErr = s.customerCall(r.Context(), tokens, func(token string) error {
@@ -2971,7 +3007,133 @@ func (s *Server) apiSKUs(w http.ResponseWriter, r *http.Request) {
 		}
 		items = append(items, item)
 	}
-	writeJSON(w, map[string]any{"skus": items, "can_manage": hasCapability(capabilities, "registry_device.manage") || hasCapability(capabilities, capabilityCustomerFirmwareManage), "source_status": "available"})
+	writeJSON(w, map[string]any{"skus": items, "can_manage": org.Role == "owner", "source_status": "available"})
+}
+
+func (s *Server) skuCollaborationContext(w http.ResponseWriter, r *http.Request) (store.Session, accountclient.Organization, accountclient.Tokens, bool) {
+	session, ok := s.customerSession(r)
+	if !ok {
+		http.Error(w, "developer authentication required", http.StatusUnauthorized)
+		return store.Session{}, accountclient.Organization{}, accountclient.Tokens{}, false
+	}
+	org, tokens, err := s.activeCustomerOrg(r.Context(), session)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return store.Session{}, accountclient.Organization{}, accountclient.Tokens{}, false
+	}
+	return session, org, tokens, true
+}
+
+func (s *Server) apiSKUCollaborators(w http.ResponseWriter, r *http.Request) {
+	session, org, tokens, ok := s.skuCollaborationContext(w, r)
+	if !ok {
+		return
+	}
+	items, err := s.accountClient.SKUCollaborators(r.Context(), tokens.AccessToken, org.ID, r.PathValue("id"))
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	invitations, _ := s.accountClient.SKUCollaboratorInvitations(r.Context(), tokens.AccessToken, org.ID, r.PathValue("id"))
+	writeJSON(w, map[string]any{"collaborators": items, "invitations": invitations, "source_status": "available"})
+}
+
+func (s *Server) apiSKUCollaboratorInvitations(w http.ResponseWriter, r *http.Request) {
+	session, org, tokens, ok := s.skuCollaborationContext(w, r)
+	if !ok {
+		return
+	}
+	if _, ok := requireIdempotencyKey(w, r); !ok {
+		return
+	}
+	var body struct {
+		Email string `json:"email"`
+		Role  string `json:"role"`
+	}
+	if json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body) != nil || strings.TrimSpace(body.Email) == "" {
+		http.Error(w, "email is required", http.StatusBadRequest)
+		return
+	}
+	invitation, err := s.accountClient.InviteSKUCollaborator(r.Context(), tokens.AccessToken, org.ID, r.PathValue("id"), strings.TrimSpace(body.Email), strings.TrimSpace(body.Role))
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	writeJSONStatus(w, http.StatusAccepted, map[string]any{"invitation": invitation, "source_status": "available"})
+}
+
+func (s *Server) apiSKUCollaboratorInvitationAction(w http.ResponseWriter, r *http.Request) {
+	session, org, tokens, ok := s.skuCollaborationContext(w, r)
+	if !ok {
+		return
+	}
+	if _, ok := requireIdempotencyKey(w, r); !ok {
+		return
+	}
+	action := r.PathValue("action")
+	if action != "resend" && action != "cancel" {
+		http.NotFound(w, r)
+		return
+	}
+	item, err := s.accountClient.ActOnSKUCollaboratorInvitation(r.Context(), tokens.AccessToken, org.ID, r.PathValue("id"), r.PathValue("invitationId"), action)
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	writeJSON(w, map[string]any{"invitation": item, "source_status": "available"})
+}
+
+func (s *Server) apiSKUCollaborator(w http.ResponseWriter, r *http.Request) {
+	session, org, tokens, ok := s.skuCollaborationContext(w, r)
+	if !ok {
+		return
+	}
+	if _, ok := requireIdempotencyKey(w, r); !ok {
+		return
+	}
+	if r.Method == http.MethodDelete {
+		if err := s.accountClient.RemoveSKUCollaborator(r.Context(), tokens.AccessToken, org.ID, r.PathValue("id"), r.PathValue("userId")); err != nil {
+			s.writeCustomerErrorForSession(w, session.ID, err)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	var body struct {
+		Role string `json:"role"`
+	}
+	if json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body) != nil {
+		http.Error(w, "role is required", http.StatusBadRequest)
+		return
+	}
+	item, err := s.accountClient.UpdateSKUCollaborator(r.Context(), tokens.AccessToken, org.ID, r.PathValue("id"), r.PathValue("userId"), strings.TrimSpace(body.Role))
+	if err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	writeJSON(w, map[string]any{"collaborator": item, "source_status": "available"})
+}
+
+func (s *Server) apiSKUOwnerTransfer(w http.ResponseWriter, r *http.Request) {
+	session, org, tokens, ok := s.skuCollaborationContext(w, r)
+	if !ok {
+		return
+	}
+	if _, ok := requireIdempotencyKey(w, r); !ok {
+		return
+	}
+	var body struct {
+		TargetUserID string `json:"target_user_id"`
+	}
+	if json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&body) != nil || strings.TrimSpace(body.TargetUserID) == "" {
+		http.Error(w, "target_user_id is required", http.StatusBadRequest)
+		return
+	}
+	if err := s.accountClient.TransferSKUOwnership(r.Context(), tokens.AccessToken, org.ID, r.PathValue("id"), strings.TrimSpace(body.TargetUserID)); err != nil {
+		s.writeCustomerErrorForSession(w, session.ID, err)
+		return
+	}
+	writeJSON(w, map[string]any{"sku_id": r.PathValue("id"), "owner_user_id": strings.TrimSpace(body.TargetUserID), "source_status": "available"})
 }
 
 func (s *Server) apiSKU(w http.ResponseWriter, r *http.Request) {
@@ -3037,8 +3199,21 @@ func (s *Server) apiSKUWrite(w http.ResponseWriter, r *http.Request) {
 		s.writeCustomerErrorForSession(w, session.ID, err)
 		return
 	}
-	if !requireCustomerCapability(w, org, capabilitySKUPolicyManage, "sku.manage", "registry_device.manage") {
-		return
+	if r.PathValue("id") == "" {
+		if org.Role != "owner" {
+			writeJSONStatus(w, http.StatusForbidden, map[string]any{"code": "BRAND_OWNER_REQUIRED", "message": "Only the Brand Cloud owner can create a SKU."})
+			return
+		}
+	} else {
+		allowed, checkErr := s.accountClient.CheckAccess(r.Context(), tokens.AccessToken, org.ID, "registry_device.manage", "sku", r.PathValue("id"))
+		if checkErr != nil {
+			s.writeCustomerErrorForSession(w, session.ID, checkErr)
+			return
+		}
+		if !allowed {
+			writeJSONStatus(w, http.StatusNotFound, map[string]any{"code": "SKU_NOT_FOUND", "message": "SKU not found."})
+			return
+		}
 	}
 	if _, ok := requireIdempotencyKey(w, r); !ok {
 		return
@@ -3069,11 +3244,6 @@ func (s *Server) apiSKUWrite(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	request := accountclient.DeviceItemProfileRequest{ProfileKey: strings.TrimSpace(input.ProfileKey), DisplayName: strings.TrimSpace(input.Name), Category: strings.TrimSpace(input.Category), Manufacturer: strings.TrimSpace(input.Manufacturer), Model: strings.TrimSpace(input.ProductModel), ServiceOptions: customerServiceOptions(input.ServiceCapabilities), ClaimPolicy: input.DevicePolicy, ProvisioningPolicy: input.DevicePolicy}
-	if input.ServiceCapabilities != nil || input.DevicePolicy != nil || input.FirmwarePolicy != nil {
-		if !requireCustomerCapability(w, org, capabilitySKUPolicyManage) {
-			return
-		}
-	}
 	if request.ProfileKey == "" && request.DisplayName != "" {
 		request.ProfileKey = "sku-" + strings.ToLower(strings.NewReplacer(" ", "-", "/", "-", "_", "-").Replace(request.DisplayName))
 	}
@@ -3162,7 +3332,13 @@ func (s *Server) apiSKUImpactPreview(w http.ResponseWriter, r *http.Request) {
 		s.writeCustomerErrorForSession(w, session.ID, err)
 		return
 	}
-	if !requireCustomerCapability(w, org, capabilitySKUPolicyManage) {
+	allowed, checkErr := s.accountClient.CheckAccess(r.Context(), tokens.AccessToken, org.ID, "registry_device.manage", "sku", r.PathValue("id"))
+	if checkErr != nil {
+		s.writeCustomerErrorForSession(w, session.ID, checkErr)
+		return
+	}
+	if !allowed {
+		http.NotFound(w, r)
 		return
 	}
 	if _, ok := requireIdempotencyKey(w, r); !ok {
@@ -3274,7 +3450,8 @@ func customerSKUWithActionsAndSummary(profile accountclient.DeviceItemProfile, c
 		FirmwarePolicy: map[string]any{
 			"ota_enabled": hasOTA,
 		},
-		AllowedActions:     skuAllowedActions(capabilities),
+		AllowedActions:     skuAllowedActionsForRole(profile.CurrentUserRole, capabilities),
+		CurrentUserRole:    profile.CurrentUserRole,
 		UpdatedAt:          profile.UpdatedAt,
 		DeviceCount:        deviceCount,
 		RegionDistribution: regionDistribution,
@@ -3284,6 +3461,21 @@ func customerSKUWithActionsAndSummary(profile accountclient.DeviceItemProfile, c
 			}
 			return summary.BySKUFirmware[profile.ID]
 		}(),
+	}
+}
+
+func skuAllowedActionsForRole(role string, capabilities []string) []string {
+	switch role {
+	case "sku_owner":
+		return []string{"read", "manage_devices", "manage_updates", "view_reports", "edit_sku", "manage_collaborators", "disable_sku"}
+	case "brand_owner":
+		return []string{"read", "manage_devices", "manage_updates", "view_reports", "edit_sku", "disable_sku"}
+	case "sku_editor":
+		return []string{"read", "manage_devices", "manage_updates", "view_reports", "edit_sku"}
+	case "sku_viewer":
+		return []string{"read", "view_reports"}
+	default:
+		return skuAllowedActions(capabilities)
 	}
 }
 
@@ -3444,6 +3636,7 @@ func (s *Server) apiSKUOTA(w http.ResponseWriter, r *http.Request) {
 	}
 	orgID := strings.TrimSpace(session.ActiveOrgID)
 	capabilities := fleetManagerCapabilities()
+	resourceAllowed := false
 	if s.accountClient.Enabled() {
 		org, tokens, err := s.activeCustomerOrg(r.Context(), session)
 		if err != nil {
@@ -3467,6 +3660,7 @@ func (s *Server) apiSKUOTA(w http.ResponseWriter, r *http.Request) {
 				writeJSONStatus(w, http.StatusForbidden, map[string]any{"code": "RESOURCE_SCOPE_FORBIDDEN", "resource": "sku", "message": "Current membership does not allow this SKU scope."})
 				return
 			}
+			resourceAllowed = true
 		}
 	}
 	required := capabilityCustomerFirmwareRead
@@ -3486,7 +3680,7 @@ func (s *Server) apiSKUOTA(w http.ResponseWriter, r *http.Request) {
 			required = capabilityCustomerFirmwareManage
 		}
 	}
-	if !hasCapability(capabilities, required) && !(required == capabilityFirmwareReleaseRead && hasCapability(capabilities, capabilityCustomerFirmwareRead)) && !(required == capabilityOTAPlanRead && hasCapability(capabilities, capabilityCustomerFirmwareRead)) {
+	if !resourceAllowed && !hasCapability(capabilities, required) && !(required == capabilityFirmwareReleaseRead && hasCapability(capabilities, capabilityCustomerFirmwareRead)) && !(required == capabilityOTAPlanRead && hasCapability(capabilities, capabilityCustomerFirmwareRead)) {
 		writeJSONStatus(w, http.StatusForbidden, map[string]any{"code": "CAPABILITY_REQUIRED", "required_capability": required, "message": "Current membership does not allow this action."})
 		return
 	}

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -79,6 +79,8 @@ type SKU struct {
 	RegionDistribution   map[string]int `json:"region_distribution,omitempty"`
 	FirmwareDistribution map[string]int `json:"firmware_distribution,omitempty"`
 	ProductionRunCount   int            `json:"production_run_count"`
+	CurrentUserRole      string         `json:"current_user_role,omitempty"`
+	CollaboratorCount    int            `json:"collaborator_count"`
 }
 
 type FleetSummary struct {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -204,7 +204,7 @@ function App() {
   const isLoginRoute = active === 'login';
   const isAuthEntryRoute = active === 'login' || active === 'login-check-email' || active === 'login-activate' || active === 'brand-cloud-activate' || active === 'forgot-password' || active === 'reset-password';
   const isPlatformView = isPlatformRouteId(active);
-  const isMemberInvitationAccept = active === 'brand-cloud-member-invitation-accept';
+  const isMemberInvitationAccept = active === 'brand-cloud-member-invitation-accept' || active === 'sku-collaborator-invitation-accept';
   const visibleNavItems = navItemsForCapabilities(active, me?.capabilities).filter((item) => item.id !== 'platform-brand-clouds' || me?.upstream_account_manager);
   const needsPlatformAccess = isPlatformView && me?.kind !== 'platform_admin';
   const brandCloudsBlocked = active === 'platform-brand-clouds' && me?.kind === 'platform_admin' && !me?.upstream_account_manager;
@@ -2101,7 +2101,37 @@ function SKUsPage({ loading, data, onRefresh }) {
   const [preview, setPreview] = useState(null);
   const [form, setForm] = useState({ name: '', product_model: '', category: 'ip_camera', service_capabilities: ['即時觀看'] });
   const [message, setMessage] = useState('');
-  const canManage = data?.can_manage || items.some((sku) => sku.allowed_actions?.includes('manage_devices'));
+  const [collaborationSKU, setCollaborationSKU] = useState(null);
+  const [collaboration, setCollaboration] = useState(null);
+  const [invite, setInvite] = useState({ email: '', role: 'sku_editor' });
+  const canManage = Boolean(data?.can_manage);
+  async function loadCollaborators(sku) {
+    setCollaborationSKU(sku); setCollaboration(null);
+    const response = await fetch(`/api/skus/${encodeURIComponent(sku.id)}/collaborators`);
+    setCollaboration(response.ok ? await response.json() : { source_status: 'unavailable' });
+  }
+  async function inviteCollaborator(event) {
+    event.preventDefault();
+    const response = await fetch(`/api/skus/${encodeURIComponent(collaborationSKU.id)}/collaborator-invitations`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `sku-invite-${collaborationSKU.id}-${invite.email}` }, body: JSON.stringify(invite) });
+    setMessage(response.ok ? 'SKU 協作者邀請已寄出。' : '無法邀請；請確認此 Email 已註冊且尚未加入這個 SKU。');
+    if (response.ok) { setInvite({ email: '', role: 'sku_editor' }); await loadCollaborators(collaborationSKU); }
+  }
+  async function updateCollaborator(userId, role) {
+    const response = await fetch(`/api/skus/${encodeURIComponent(collaborationSKU.id)}/collaborators/${encodeURIComponent(userId)}`, { method: 'PATCH', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `sku-role-${collaborationSKU.id}-${userId}-${role}` }, body: JSON.stringify({ role }) });
+    setMessage(response.ok ? '協作者角色已更新。' : '無法更新協作者角色。'); if (response.ok) await loadCollaborators(collaborationSKU);
+  }
+  async function removeCollaborator(userId) {
+    const response = await fetch(`/api/skus/${encodeURIComponent(collaborationSKU.id)}/collaborators/${encodeURIComponent(userId)}`, { method: 'DELETE', headers: { 'Idempotency-Key': `sku-remove-${collaborationSKU.id}-${userId}` } });
+    setMessage(response.ok ? '協作者已移除。' : '無法移除協作者。'); if (response.ok) await loadCollaborators(collaborationSKU);
+  }
+  async function transferOwner(userId) {
+    const response = await fetch(`/api/skus/${encodeURIComponent(collaborationSKU.id)}/owner-transfer`, { method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `sku-owner-${collaborationSKU.id}-${userId}` }, body: JSON.stringify({ target_user_id: userId }) });
+    setMessage(response.ok ? 'SKU ownership 已轉移。' : '無法轉移 SKU ownership。'); if (response.ok) { await loadCollaborators(collaborationSKU); onRefresh(); }
+  }
+  async function invitationAction(invitationId, action) {
+    const response = await fetch(`/api/skus/${encodeURIComponent(collaborationSKU.id)}/collaborator-invitations/${encodeURIComponent(invitationId)}/${action}`, { method: 'POST', headers: { 'Idempotency-Key': `sku-invite-${action}-${invitationId}-${Date.now()}` } });
+    setMessage(response.ok ? (action === 'resend' ? '邀請已重寄。' : '邀請已取消。') : '無法更新邀請。'); if (response.ok) await loadCollaborators(collaborationSKU);
+  }
   async function createSKU(event) {
     event.preventDefault();
     const response = await fetch(editingSKU ? `/api/skus/${encodeURIComponent(editingSKU.id)}` : '/api/skus', { method: editingSKU ? 'PATCH' : 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `sku-write-${editingSKU?.id || form.name}` }, body: JSON.stringify(form) });
@@ -2133,22 +2163,24 @@ function SKUsPage({ loading, data, onRefresh }) {
         <section className="panel">
           <div className="table-wrap">
             <table className="data-table">
-              <thead><tr><th>SKU</th><th>產品型號</th><th>設備數量</th><th>生產批次</th><th>可用服務</th><th>設備政策</th><th>韌體政策</th><th>可執行操作</th><th>狀態</th></tr></thead>
+              <thead><tr><th>SKU</th><th>我的角色</th><th>產品型號</th><th>設備數量</th><th>生產批次</th><th>可用服務</th><th>設備政策</th><th>韌體政策</th><th>可執行操作</th><th>狀態</th></tr></thead>
               <tbody>{items.map((sku) => <tr key={sku.id}>
                 <td><strong>{sku.name}</strong><small>{sku.id}</small></td>
+                <td><span className="status-badge neutral">{sku.current_user_role === 'brand_owner' ? 'Brand Owner' : sku.current_user_role === 'sku_owner' ? 'Owner' : sku.current_user_role === 'sku_editor' ? 'Editor' : 'Viewer'}</span>{sku.allowed_actions?.includes('manage_collaborators') ? <button type="button" className="link-button" onClick={() => loadCollaborators(sku)}>協作者 ({sku.collaborator_count || 0})</button> : null}</td>
                 <td>{sku.product_model || sku.category || '—'}</td>
                 <td>{sku.device_count?.toLocaleString?.() || '0'}</td>
                 <td>{(sku.production_run_count || 0).toLocaleString()} 批</td>
                 <td>{sku.service_capabilities?.length ? sku.service_capabilities.join('、') : '未啟用'}</td>
                 <td>{sku.device_policy?.setup_available || sku.device_policy?.binding_available ? '已設定' : '未設定'}</td>
                 <td>{sku.firmware_policy?.ota_enabled ? '允許韌體更新' : '未啟用'}</td>
-                <td>{sku.allowed_actions?.length ? sku.allowed_actions.map((action) => action === 'manage_devices' ? '管理設備' : action === 'manage_updates' ? '管理更新' : action === 'view_reports' ? '查看報表' : '查看').join('、') : '需要聯絡管理者'}{canManage ? <button type="button" className="link-button" onClick={() => { setEditingSKU(sku); setForm({ name: sku.name, product_model: sku.product_model || '', category: sku.category || 'generic', service_capabilities: sku.service_capabilities || [] }); setPreview(null); setShowCreate(true); }}>編輯</button> : null}</td>
-                <td><span className={sku.status === 'active' ? 'status-badge good' : 'status-badge neutral'}>{sku.status === 'active' ? '啟用' : '停用'}</span>{sku.status === 'active' && canManage ? <button type="button" className="link-button" onClick={async () => { await fetch(`/api/skus/${encodeURIComponent(sku.id)}/disable`, { method: 'POST', headers: { 'Idempotency-Key': `sku-disable-${sku.id}` } }); onRefresh(); }}>停用</button> : null}</td>
+                <td>{sku.allowed_actions?.length ? sku.allowed_actions.map((action) => action === 'manage_devices' ? '管理設備' : action === 'manage_updates' ? '管理更新' : action === 'view_reports' ? '查看報表' : action === 'manage_collaborators' ? '管理協作者' : action === 'edit_sku' ? '編輯 SKU' : '查看').join('、') : '需要聯絡管理者'}{sku.allowed_actions?.includes('edit_sku') ? <button type="button" className="link-button" onClick={() => { setEditingSKU(sku); setForm({ name: sku.name, product_model: sku.product_model || '', category: sku.category || 'generic', service_capabilities: sku.service_capabilities || [] }); setPreview(null); setShowCreate(true); }}>編輯</button> : null}</td>
+                <td><span className={sku.status === 'active' ? 'status-badge good' : 'status-badge neutral'}>{sku.status === 'active' ? '啟用' : '停用'}</span>{sku.status === 'active' && sku.allowed_actions?.includes('disable_sku') ? <button type="button" className="link-button" onClick={async () => { await fetch(`/api/skus/${encodeURIComponent(sku.id)}/disable`, { method: 'POST', headers: { 'Idempotency-Key': `sku-disable-${sku.id}` } }); onRefresh(); }}>停用</button> : null}</td>
               </tr>)}</tbody>
             </table>
           </div>
         </section>
       ) : null}
+      {collaborationSKU ? <section className="panel" data-testid="sku-collaborators"><div className="panel-head"><div><h3>{collaborationSKU.name} 協作者</h3><p>協作者只會看到被指派的 SKU；Editor 可執行專案工作，Viewer 為唯讀。</p></div><button type="button" className="link-button" onClick={() => { setCollaborationSKU(null); setCollaboration(null); }}>關閉</button></div>{collaboration?.source_status === 'unavailable' ? <p className="notice">協作者資料目前無法取得。</p> : <><form className="inline-form" onSubmit={inviteCollaborator}><input required type="email" placeholder="已註冊的 Developer Email" value={invite.email} onChange={(event) => setInvite({ ...invite, email: event.target.value })} /><select value={invite.role} onChange={(event) => setInvite({ ...invite, role: event.target.value })}><option value="sku_editor">Editor</option><option value="sku_viewer">Viewer</option></select><button type="submit" className="primary">邀請到此 SKU</button></form><div className="table-wrap"><table className="data-table"><thead><tr><th>Developer</th><th>角色</th><th>操作</th></tr></thead><tbody>{(collaboration?.collaborators || []).map((person) => <tr key={person.user_id}><td><strong>{person.display_name || person.email}</strong><small>{person.email}</small></td><td>{person.role === 'sku_owner' ? 'Owner' : <select value={person.role} onChange={(event) => updateCollaborator(person.user_id, event.target.value)}><option value="sku_editor">Editor</option><option value="sku_viewer">Viewer</option></select>}</td><td>{person.role === 'sku_owner' ? 'Ownership transfer required' : <><button type="button" className="link-button" onClick={() => transferOwner(person.user_id)}>轉移 Owner</button><button type="button" className="link-button" onClick={() => removeCollaborator(person.user_id)}>移除</button></>}</td></tr>)}</tbody></table></div>{(collaboration?.invitations || []).some((item) => item.status === 'pending') ? <div className="chip-list">{collaboration.invitations.filter((item) => item.status === 'pending').map((item) => <span className="status-badge neutral" key={item.id}>{item.target_email} · {item.role === 'sku_editor' ? 'Editor' : 'Viewer'} · 待接受 <button type="button" className="link-button" onClick={() => invitationAction(item.id, 'resend')}>重寄</button><button type="button" className="link-button" onClick={() => invitationAction(item.id, 'cancel')}>取消</button></span>)}</div> : null}</>}</section> : null}
     </section>
   );
 }
@@ -2206,6 +2238,7 @@ function GroupsPage({ data, loading, onRefresh }) {
 }
 
 function BrandCloudMemberInvitationAcceptPage() {
+	const isSKUInvitation = window.location.pathname === '/sku-collaborator-invitation/accept';
   const [token] = useState(() => new URLSearchParams(window.location.search).get('token') || '');
   const [requestKey] = useState(() => globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`);
   const [result, setResult] = useState(null);
@@ -2213,13 +2246,13 @@ function BrandCloudMemberInvitationAcceptPage() {
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    window.history.replaceState({}, '', '/brand-cloud-member-invitation/accept');
+    window.history.replaceState({}, '', isSKUInvitation ? '/sku-collaborator-invitation/accept' : '/brand-cloud-member-invitation/accept');
   }, []);
 
   async function acceptInvitation() {
     setBusy(true);
     setMessage('正在驗證邀請…');
-    const response = await fetch('/api/developer/brand-cloud-member-invitations/accept', {
+    const response = await fetch(isSKUInvitation ? '/api/developer/sku-collaborator-invitations/accept' : '/api/developer/brand-cloud-member-invitations/accept', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `member-invitation-accept-${requestKey}` },
       body: JSON.stringify({ token }),
@@ -2227,7 +2260,7 @@ function BrandCloudMemberInvitationAcceptPage() {
     const body = await response.json().catch(() => ({}));
     if (response.ok) {
       setResult(body);
-      setMessage('邀請已接受，Brand Cloud membership 已建立。');
+      setMessage(isSKUInvitation ? '邀請已接受，SKU project access 已建立。' : '邀請已接受，Brand Cloud membership 已建立。');
     } else if (response.status === 404) {
       setMessage('邀請無效、已過期、已使用，或登入帳號不是受邀者。');
     } else if (response.status === 409) {
@@ -2239,7 +2272,7 @@ function BrandCloudMemberInvitationAcceptPage() {
   }
 
   const cloudID = result?.invitation?.brand_cloud_id || '';
-  return <div className="public-auth-shell"><section className="auth-hero"><p className="eyebrow">Brand Cloud invitation</p><h1>接受團隊邀請</h1><p>系統會同時驗證 Email invitation token 與目前登入的 Developer 帳號。</p></section><section className="panel auth-panel"><p className="auth-status">{message}</p>{!result ? <button type="button" className="primary" disabled={!token || busy} onClick={acceptInvitation}>{busy ? '驗證中…' : '接受邀請'}</button> : <a className="inline-action" href={`/console/${encodeURIComponent(cloudID)}/access`}>前往 Brand Cloud 團隊頁面</a>}</section></div>;
+  return <div className="public-auth-shell"><section className="auth-hero"><p className="eyebrow">{isSKUInvitation ? 'SKU project invitation' : 'Brand Cloud invitation'}</p><h1>{isSKUInvitation ? '接受 SKU 協作邀請' : '接受團隊邀請'}</h1><p>系統會同時驗證 Email invitation token 與目前登入的 Developer 帳號。</p></section><section className="panel auth-panel"><p className="auth-status">{message}</p>{!result ? <button type="button" className="primary" disabled={!token || busy} onClick={acceptInvitation}>{busy ? '驗證中…' : '接受邀請'}</button> : <a className="inline-action" href={`/console/${encodeURIComponent(cloudID)}/sku-services`}>前往 SKU project</a>}</section></div>;
 }
 
 function AccessPage({ data, loading, activeCloudId, canManage, canIssuePKITest, onRefresh }) {

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -67,6 +67,7 @@ export function titleFor(active) {
     'signup-verification-expired': 'Verification link expired',
     verify: 'Verify email',
     'brand-cloud-member-invitation-accept': 'Accept Brand Cloud invitation',
+    'sku-collaborator-invitation-accept': 'Accept SKU collaboration invitation',
     overview: '設備總覽',
     devices: '設備',
     'sku-services': 'SKU 與服務',
@@ -104,6 +105,7 @@ export function routeFromPath(path) {
   if (path === '/signup/verify' || path.startsWith('/signup/verify/')) return 'verify';
   if (path === '/verify' || path.startsWith('/verify/')) return 'verify';
   if (path === '/brand-cloud-member-invitation/accept') return 'brand-cloud-member-invitation-accept';
+  if (path === '/sku-collaborator-invitation/accept') return 'sku-collaborator-invitation-accept';
   if (path === '/admin' || path === '/admin/') return 'platform-dashboard';
   if (path === '/admin/grafana' || path.startsWith('/admin/grafana/')) return 'platform-grafana';
   if (path === '/admin/resources' || path.startsWith('/admin/resources/')) return 'platform-dashboard';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -52,6 +52,11 @@ test('maps Brand Cloud membership invitation acceptance outside regular console 
   assert.equal(titleFor('brand-cloud-member-invitation-accept'), 'Accept Brand Cloud invitation');
 });
 
+test('maps SKU collaborator invitation acceptance outside regular console navigation', () => {
+  assert.equal(routeFromPath('/sku-collaborator-invitation/accept'), 'sku-collaborator-invitation-accept');
+  assert.equal(titleFor('sku-collaborator-invitation-accept'), 'Accept SKU collaboration invitation');
+});
+
 test('maps customer shell paths to customer routes', () => {
   assert.equal(routeFromPath('/console'), 'overview');
   assert.equal(routeFromPath('/console/overview'), 'overview');


### PR DESCRIPTION
## Summary
- expose SKU collaborator and invitation BFF endpoints
- show each developer’s effective SKU role and allowed actions
- add invite, resend, cancel, role-change, removal, and owner-transfer controls
- add SKU invitation acceptance routing
- restrict SKU creation to the Brand Cloud owner while enforcing per-SKU operations server-side
- update role, dashboard, and OpenAPI documentation

## Validation
- Cloud Admin Go tests passed
- frontend test suite passed (83 tests)
- Vite production build passed
- diff and OpenAPI checks passed

## Dependencies
- stacked on #255 (`codex/managed-cloud-billing`)
- backend API: hkt999rtk/rtk_account_manager#270
- shared authorization contract: hkt999rtk/rtk_cloud_contracts_doc#119