### PR TITLE
fix: hide password reset tokens

### DIFF
--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -470,6 +470,17 @@ async function installApiMocks(page, { sessionForPath } = {}) {
       }
       return route.fulfill({ json: { status: payload.token === 'expired-token' ? 'expired' : 'valid' } });
     }
+    if (pathName === '/api/auth/reset-password') {
+      if (request.method() !== 'POST') {
+        throw new Error(`Password reset must use POST, got ${request.method()}`);
+      }
+      const payload = request.postDataJSON();
+      const expected = { token: 'synthetic-reset-token', new_password: 'new-password-123' };
+      if (JSON.stringify(payload) !== JSON.stringify(expected)) {
+        throw new Error('Unexpected password reset payload.');
+      }
+      return route.fulfill({ status: 204, body: '' });
+    }
     if (pathName === '/api/summary' || pathName === '/api/admin/summary') return route.fulfill({ json: summary });
     if (pathName === '/api/developer/brand-clouds') return route.fulfill({ json: { brand_clouds: [] } });
     if (pathName === '/api/customers' || pathName === '/api/admin/customers') return route.fulfill({ json: customers });
@@ -571,6 +582,25 @@ async function runAuthSmoke(browserContext) {
   await page.getByLabel('New password').fill('password123');
   await page.getByRole('button', { name: 'Verify and continue', exact: true }).click();
   await page.waitForURL(`${baseURL}/console/overview`);
+  await page.goto(`${baseURL}/reset-password?token=synthetic-reset-token`, { waitUntil: 'networkidle' });
+  await page.waitForURL(`${baseURL}/reset-password`);
+  await expectText(page, 'Secure reset link recognized');
+  if (await page.getByLabel('Reset token').count()) {
+    throw new Error('Password reset page must not render the token as a field.');
+  }
+  if ((await page.locator('body').innerText()).includes('synthetic-reset-token')) {
+    throw new Error('Password reset page must not render the token value.');
+  }
+  await page.getByLabel('New password', { exact: true }).fill('new-password-123');
+  await page.getByLabel('Confirm new password', { exact: true }).fill('new-password-123');
+  await screenshot(page, 'desktop-reset-password.png');
+  await page.getByRole('button', { name: 'Update password', exact: true }).click();
+  await expectText(page, 'Password updated');
+  await page.goto(`${baseURL}/reset-password`, { waitUntil: 'networkidle' });
+  await expectText(page, 'This reset link is not valid');
+  if (await page.getByLabel('New password', { exact: true }).count()) {
+    throw new Error('Password reset page without a token must not render the password form.');
+  }
   if (consoleIssues.length) {
     throw new Error(`Auth smoke console issues detected:\n${consoleIssues.join('\n')}`);
   }

--- a/web/src/auth-routing.mjs
+++ b/web/src/auth-routing.mjs
@@ -31,6 +31,16 @@ export function protectedPathFromLocation(location) {
   return `${pathname}${search}${hash}`;
 }
 
+export function removeQueryParameterFromAddress(location, history, parameter) {
+  const params = new URLSearchParams(location?.search || '');
+  if (!params.has(parameter)) return false;
+  params.delete(parameter);
+  const search = params.toString();
+  const nextAddress = `${location?.pathname || '/'}${search ? `?${search}` : ''}${location?.hash || ''}`;
+  history.replaceState(history.state, '', nextAddress);
+  return true;
+}
+
 export function loginPathFor(nextPath) {
   const next = normalizeLoginNext(nextPath);
   return next ? `/login?next=${encodeURIComponent(next)}` : '/login';

--- a/web/src/auth-routing.test.mjs
+++ b/web/src/auth-routing.test.mjs
@@ -7,6 +7,7 @@ import {
   loginPathFor,
   normalizeLoginNext,
   passwordLoginOrderForNext,
+  removeQueryParameterFromAddress,
 } from './auth-routing.mjs';
 
 test('login next accepts only admin and console paths', () => {
@@ -53,4 +54,22 @@ test('password login prefers the destination view', () => {
   assert.deepEqual(passwordLoginOrderForNext('/admin/resources'), ['platform', 'customer']);
   assert.deepEqual(passwordLoginOrderForNext('/console/devices'), ['customer', 'platform']);
   assert.deepEqual(passwordLoginOrderForNext('/signup'), ['customer', 'platform']);
+});
+
+test('sensitive query parameters are removed without changing the rest of the address', () => {
+  const calls = [];
+  const history = {
+    state: { source: 'email' },
+    replaceState: (...args) => calls.push(args),
+  };
+  const location = {
+    pathname: '/reset-password',
+    search: '?token=secret&campaign=welcome',
+    hash: '#form',
+  };
+
+  assert.equal(removeQueryParameterFromAddress(location, history, 'token'), true);
+  assert.deepEqual(calls, [[history.state, '', '/reset-password?campaign=welcome#form']]);
+  assert.equal(removeQueryParameterFromAddress({ pathname: '/reset-password', search: '' }, history, 'token'), false);
+  assert.equal(calls.length, 1);
 });

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -41,6 +41,7 @@ import {
   loginPathFor,
   passwordLoginOrderForNext,
   protectedPathFromLocation,
+  removeQueryParameterFromAddress,
 } from './auth-routing.mjs';
 import { quotaRaiseErrorMessage, quotaUsageLabel } from './auth-state.mjs';
 import { canUseCapability, deviceActionState, isReadOnlyRole } from './device-actions.mjs';
@@ -1302,6 +1303,10 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onBrandC
   const params = new URLSearchParams(window.location.search);
   const email = params.get('email') || '';
   const token = params.get('token') || '';
+  const pageHeading = active === 'reset-password' ? 'Reset your password' : 'Admin Console';
+  const pageCopy = active === 'reset-password'
+    ? 'Choose a new password for your Connect+ Ops account.'
+    : 'Login to an existing account or create a new evaluation account.';
   const content = active === 'login-check-email' ? (
     <LoginCheckEmail email={email} />
   ) : active === 'login-activate' ? (
@@ -1323,8 +1328,8 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onBrandC
             <img src="/assets/realtek-logo.png" alt="Realtek" />
             <strong>Connect+ Ops</strong>
           </div>
-          <h1 id="login-title">Admin Console</h1>
-          <p className="login-copy">Login to an existing account or create a new evaluation account.</p>
+          <h1 id="login-title">{pageHeading}</h1>
+          <p className="login-copy">{pageCopy}</p>
           {content}
           {error ? <div className="error">{error}</div> : null}
         </section>
@@ -1519,37 +1524,91 @@ function ForgotPasswordView({ email, onForgotPassword }) {
 }
 
 function ResetPasswordView({ token, onResetPassword }) {
-  const [tokenValue, setTokenValue] = useState(token);
+  const [tokenValue, setTokenValue] = useState(() => token);
   const [password, setPassword] = useState('');
-  const [status, setStatus] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [completed, setCompleted] = useState(false);
   const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    removeQueryParameterFromAddress(window.location, window.history, 'token');
+  }, []);
+
   async function submit(event) {
     event.preventDefault();
+    if (password !== confirmPassword) {
+      setLocalError('Passwords do not match.');
+      return;
+    }
     setBusy(true);
     setLocalError('');
     try {
       await onResetPassword({ token: tokenValue, new_password: password });
-      setStatus('Password reset completed. You can sign in with the new password.');
+      setTokenValue('');
+      setPassword('');
+      setConfirmPassword('');
+      setCompleted(true);
     } catch (err) {
       setLocalError(userFacingPasswordResetError(err));
     } finally {
       setBusy(false);
     }
   }
+
+  if (completed) {
+    return (
+      <div className="auth-stack" role="status">
+        <div className="reset-link-status success">
+          <span className="reset-link-status-icon" aria-hidden="true">✓</span>
+          <div>
+            <strong>Password updated</strong>
+            <p>Your new password is ready. You can now sign in to your account.</p>
+          </div>
+        </div>
+        <a className="auth-primary-action" href="/login">Continue to sign in</a>
+      </div>
+    );
+  }
+
+  if (!tokenValue) {
+    return (
+      <div className="auth-stack">
+        <div className="reset-link-status invalid" role="alert">
+          <span className="reset-link-status-icon" aria-hidden="true">!</span>
+          <div>
+            <strong>This reset link is not valid</strong>
+            <p>Request a new email to continue. Reset links can expire or be used only once.</p>
+          </div>
+        </div>
+        <a className="auth-primary-action" href="/forgot-password">Request a new reset link</a>
+        <a className="auth-link" href="/login">Back to sign in</a>
+      </div>
+    );
+  }
+
+  const passwordsDoNotMatch = Boolean(confirmPassword) && password !== confirmPassword;
   return (
     <form className="login-form" onSubmit={submit}>
-      <label>
-        Reset token
-        <input value={tokenValue} onChange={(event) => setTokenValue(event.target.value)} placeholder="Reset token" required />
-      </label>
+      <div className="reset-link-status">
+        <span className="reset-link-status-icon" aria-hidden="true">✓</span>
+        <div>
+          <strong>Secure reset link recognized</strong>
+          <p>Your reset code is hidden and will be submitted securely.</p>
+        </div>
+      </div>
       <label>
         New password
-        <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
+        <input type="password" autoComplete="new-password" value={password} onChange={(event) => { setPassword(event.target.value); setLocalError(''); }} placeholder="At least 8 characters" minLength={8} required />
       </label>
-      <button type="submit" disabled={busy}>{busy ? 'Resetting' : 'Reset password'}</button>
-      {status ? <p className="auth-status">{status}</p> : null}
-      {error ? <p className="error">{error}</p> : null}
+      <label>
+        Confirm new password
+        <input type="password" autoComplete="new-password" value={confirmPassword} onChange={(event) => { setConfirmPassword(event.target.value); setLocalError(''); }} placeholder="Enter the new password again" minLength={8} aria-invalid={passwordsDoNotMatch} required />
+      </label>
+      <p className="password-requirement">Use at least 8 characters.</p>
+      {passwordsDoNotMatch ? <p className="field-error" role="alert">Passwords do not match.</p> : null}
+      <button type="submit" disabled={busy || passwordsDoNotMatch}>{busy ? 'Updating password' : 'Update password'}</button>
+      {error && !passwordsDoNotMatch ? <p className="error">{error}</p> : null}
       <a className="auth-link" href="/login">Back to sign in</a>
     </form>
   );

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2658,6 +2658,25 @@ p {
   text-decoration: underline;
 }
 
+.auth-primary-action {
+  align-items: center;
+  align-self: start;
+  background: var(--brand);
+  border-radius: 8px;
+  color: #fff;
+  display: inline-flex;
+  font-size: 14px;
+  font-weight: 800;
+  justify-content: center;
+  min-height: 46px;
+  padding: 0 18px;
+  text-decoration: none;
+}
+
+.auth-primary-action:hover {
+  background: var(--brand-dark);
+}
+
 .auth-honeypot {
   clip: rect(0 0 0 0);
   clip-path: inset(50%);
@@ -2818,6 +2837,75 @@ p {
 .login-form button:disabled {
   background: #ccd7e0;
   cursor: not-allowed;
+}
+
+.reset-link-status {
+  align-items: flex-start;
+  background: #f2f8fc;
+  border: 1px solid #c9dfed;
+  border-radius: 8px;
+  color: var(--navy);
+  display: flex;
+  gap: 12px;
+  padding: 14px;
+}
+
+.reset-link-status.success {
+  background: #f0f8f3;
+  border-color: #bcdcc7;
+}
+
+.reset-link-status.invalid {
+  background: #fff7ed;
+  border-color: #fed7aa;
+}
+
+.reset-link-status-icon {
+  align-items: center;
+  background: var(--brand);
+  border-radius: 999px;
+  color: #fff;
+  display: inline-flex;
+  flex: 0 0 24px;
+  font-size: 13px;
+  font-weight: 900;
+  height: 24px;
+  justify-content: center;
+}
+
+.reset-link-status.success .reset-link-status-icon {
+  background: #21804b;
+}
+
+.reset-link-status.invalid .reset-link-status-icon {
+  background: #b45309;
+}
+
+.reset-link-status strong,
+.reset-link-status p {
+  margin: 0;
+}
+
+.reset-link-status p,
+.password-requirement {
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.reset-link-status p {
+  margin-top: 3px;
+}
+
+.password-requirement,
+.field-error {
+  margin: -3px 0 0;
+}
+
+.field-error {
+  color: #b42318;
+  font-size: 13px;
+  font-weight: 700;
 }
 
 .login-form .secondary-button {


### PR DESCRIPTION
## Summary\n- remove password reset tokens from the rendered UI and scrub them from the address bar\n- redesign the reset flow with password confirmation, valid/missing-link states, and a completion state\n- add unit and browser regression coverage for token redaction and internal API submission\n\n## Validation\n- npm test\n- npm run build\n- npm run browser:smoke