### PR TITLE
Fix expired email verification handling

### DIFF
--- a/web/scripts/browser-smoke.mjs
+++ b/web/scripts/browser-smoke.mjs
@@ -573,6 +573,7 @@ async function runAuthSmoke(browserContext) {
   }
   await screenshot(page, 'desktop-verification-expired.png');
   await page.goto(`${baseURL}/verify?token=verification-token`, { waitUntil: 'networkidle' });
+  await page.waitForURL(`${baseURL}/verify`);
   if (await page.getByLabel('Verification token').count()) {
     throw new Error('Verification page must not render the token as a field.');
   }
@@ -641,7 +642,9 @@ async function runDesktopSmoke(page) {
   await expectText(page, 'Create account');
   await gotoAndAssert(page, '/signup/check-email?email=fleet.manager%40example.com', 'Check your email');
   await expectText(page, 'Resend');
-  await gotoAndAssert(page, '/verify?token=visual-check-token', 'Verify email');
+  await page.goto(`${baseURL}/verify?token=visual-check-token`, { waitUntil: 'networkidle' });
+  await page.waitForURL(`${baseURL}/verify`);
+  await expectText(page, 'Verify email');
   await expectText(page, 'Create your password to finish verification');
   if ((await page.locator('body').innerText()).includes('visual-check-token')) {
     throw new Error('Verification page screenshot state must not render the token value.');

--- a/web/src/http.mjs
+++ b/web/src/http.mjs
@@ -74,7 +74,7 @@ export function userFacingSignupError(error) {
 
 export function userFacingVerificationError(error) {
   const message = String(error?.message || error || '');
-  if (/expired/i.test(message)) {
+  if (isExpiredVerificationError(error)) {
     return 'Verification link expired. Request a new verification email.';
   }
   if (/already verified|already_verified/i.test(message)) {
@@ -87,6 +87,10 @@ export function userFacingVerificationError(error) {
     return 'Verification service is temporarily unavailable. Please try again later.';
   }
   return 'Verification could not be completed. Please try again.';
+}
+
+export function isExpiredVerificationError(error) {
+  return /expired/i.test(String(error?.message || error || ''));
 }
 
 export function userFacingLoginActivationError(error) {

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+  isExpiredVerificationError,
   postJSON,
   putJSON,
   startSSOLogin,
@@ -211,6 +212,8 @@ test('public signup errors use evaluation-tier safe copy', () => {
 });
 
 test('verification errors distinguish token and service states without raw payloads', () => {
+  assert.equal(isExpiredVerificationError(new Error('Invalid or expired verification token')), true);
+  assert.equal(isExpiredVerificationError(new Error('invalid verification token')), false);
   assert.equal(
     userFacingVerificationError(new Error('expired verification token')),
     'Verification link expired. Request a new verification email.',

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -15,6 +15,7 @@ import {
   titleFor,
 } from './routes.mjs';
 import {
+  isExpiredVerificationError,
   postJSON,
   putJSON,
   startSSOLogin,
@@ -972,6 +973,11 @@ function App() {
       }
       return result;
     } catch (err) {
+      if (isExpiredVerificationError(err)) {
+        window.history.replaceState({}, '', '/signup/verification-expired');
+        setActive('signup-verification-expired');
+        return null;
+      }
       setError(userFacingVerificationError(err));
       throw err;
     }
@@ -979,12 +985,21 @@ function App() {
 
   async function handleVerificationStatus(token) {
     setError('');
-    const result = await postJSON('/api/auth/customer/verification-status', { token });
-    if (result?.status === 'expired') {
-      window.history.replaceState({}, '', '/signup/verification-expired');
-      setActive('signup-verification-expired');
+    try {
+      const result = await postJSON('/api/auth/customer/verification-status', { token });
+      if (result?.status === 'expired') {
+        window.history.replaceState({}, '', '/signup/verification-expired');
+        setActive('signup-verification-expired');
+      }
+      return result;
+    } catch (err) {
+      if (isExpiredVerificationError(err)) {
+        window.history.replaceState({}, '', '/signup/verification-expired');
+        setActive('signup-verification-expired');
+        return { status: 'expired' };
+      }
+      throw err;
     }
-    return result;
   }
 
   async function handleResendVerification(email) {
@@ -1729,16 +1744,21 @@ function ExpiredVerificationPage() {
 }
 
 function VerifyForm({ token, onCheckVerification, onVerify }) {
+  const [tokenValue] = useState(() => token);
   const [password, setPassword] = useState('');
-  const [linkStatus, setLinkStatus] = useState(token ? 'checking' : 'invalid');
-  const [status, setStatus] = useState(token ? 'Checking verification link…' : 'This verification link is invalid.');
+  const [linkStatus, setLinkStatus] = useState(tokenValue ? 'checking' : 'invalid');
+  const [status, setStatus] = useState(tokenValue ? 'Checking verification link…' : 'This verification link is invalid.');
   const [error, setLocalError] = useState('');
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    if (!token) return undefined;
+    removeQueryParameterFromAddress(window.location, window.history, 'token');
+  }, []);
+
+  useEffect(() => {
+    if (!tokenValue) return undefined;
     let active = true;
-    onCheckVerification(token)
+    onCheckVerification(tokenValue)
       .then((result) => {
         if (!active || result?.status === 'expired') return;
         const nextStatus = result?.status === 'valid' ? 'valid' : 'invalid';
@@ -1751,14 +1771,14 @@ function VerifyForm({ token, onCheckVerification, onVerify }) {
         setLocalError(userFacingVerificationError(err));
       });
     return () => { active = false; };
-  }, [onCheckVerification, token]);
+  }, [onCheckVerification, tokenValue]);
 
   async function submit(event) {
     event.preventDefault();
     setBusy(true);
     setLocalError('');
     try {
-      const result = await onVerify({ token, new_password: password });
+      const result = await onVerify({ token: tokenValue, new_password: password });
       if (!result) {
         setLocalError('Verification failed. Check the token and try again.');
       } else if (result.tokens?.access_token) {
@@ -1781,7 +1801,7 @@ function VerifyForm({ token, onCheckVerification, onVerify }) {
           New password
           <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="At least 8 characters" minLength={8} required />
         </label>
-        <button type="submit" disabled={busy || !token}>{busy ? 'Verifying' : 'Verify and continue'}</button>
+        <button type="submit" disabled={busy || !tokenValue}>{busy ? 'Verifying' : 'Verify and continue'}</button>
       </form> : null}
       <p className="auth-status">{status}</p>
       {error ? <p className="error">{error}</p> : null}


### PR DESCRIPTION
## Summary
- redirect expired verification links directly to the dedicated expired page
- remove the verification token from the browser address after capture
- handle upstream `Invalid or expired verification token` errors without duplicate generic messages
- extend unit and browser smoke coverage

## Validation
- `npm test` (84 passed)
- `npm run build`
- `npm run browser:smoke`