### PR TITLE
fix: avoid duplicate login errors

### DIFF
--- a/web/e2e/auth-errors.spec.mjs
+++ b/web/e2e/auth-errors.spec.mjs
@@ -1,0 +1,10 @@
+import { expect, test } from '@playwright/test';
+
+test('[UI-AUTH-001] failed login renders its error once', async ({ page }) => {
+  await page.goto('/login');
+  await page.getByLabel('Email').fill('nobody@example.com');
+  await page.getByLabel('Password').fill('incorrect-password');
+  await page.getByRole('button', { name: 'Login', exact: true }).click();
+
+  await expect(page.getByText('Email or password is incorrect.')).toHaveCount(1);
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -884,23 +884,19 @@ function App() {
     const message = `${errors.customer?.message || ''}\n${errors.platform?.message || ''}`;
     if (order[0] === 'platform' && message.includes('platform password sign-in is disabled')) {
       const nextError = 'Platform password sign-in is not enabled for this environment.';
-      setError(nextError);
       throw new Error(nextError);
     }
     if (order[0] === 'customer' && message.includes('customer password sign-in is disabled')) {
       const nextError = 'Password sign-in is not enabled for this environment.';
-      setError(nextError);
       throw new Error(nextError);
     }
     if (((errors.customer?.status === 401 || errors.customer?.status === 403) &&
       (errors.platform?.status === 401 || errors.platform?.status === 403)) ||
       /invalid credentials/i.test(message)) {
       const nextError = 'Email or password is incorrect.';
-      setError(nextError);
       throw new Error(nextError);
     }
     const nextError = 'Sign-in is temporarily unavailable. Please try again later.';
-    setError(nextError);
     throw new Error(nextError);
   }
 
@@ -912,7 +908,6 @@ function App() {
       return result;
     } catch (err) {
       const nextError = userFacingLoginActivationError(err);
-      setError(nextError);
       throw new Error(nextError);
     }
   }
@@ -923,7 +918,6 @@ function App() {
       return await postJSON('/api/auth/brand-cloud/activate', payload);
     } catch (err) {
       const nextError = userFacingLoginActivationError(err);
-      setError(nextError);
       throw new Error(nextError);
     }
   }
@@ -935,7 +929,6 @@ function App() {
       return true;
     } catch (err) {
       const nextError = userFacingPasswordResetError(err);
-      setError(nextError);
       throw new Error(nextError);
     }
   }
@@ -947,7 +940,6 @@ function App() {
       return true;
     } catch (err) {
       const nextError = userFacingPasswordResetError(err);
-      setError(nextError);
       throw new Error(nextError);
     }
   }


### PR DESCRIPTION
## Summary
- keep authentication action failures in the form-level error state only
- prevent login, activation, forgot-password, and reset-password errors from also rendering in the page-level error slot
- add a Playwright regression test asserting invalid credentials render exactly one message

## Verification
- `npm test` (84 passed)
- `npm run build`
- `E2E_FIXTURE_DIR=/Users/kevinhuang/work/rtk_cloud_workspace/repos/rtk_cloud_admin/.artifacts/e2e-fixtures/cloud-admin-e2e npx playwright test e2e/auth-errors.spec.mjs --project=chromium` (1 passed)