### PR TITLE
fix: stabilize mobile navigation E2E

### DIFF
--- a/web/e2e/brand-cloud.spec.mjs
+++ b/web/e2e/brand-cloud.spec.mjs
@@ -1,18 +1,17 @@
 import { test, expect } from '@playwright/test';
-import { enterPlatform, login } from './fixtures/session.mjs';
+import { expectPageTitle, login } from './fixtures/session.mjs';
 
 test.describe('Brand Clouds', () => {
   test.describe.configure({ mode: 'serial' });
 
   test.beforeEach(async ({ page }) => {
     await login(page, 'platform_admin');
-    await enterPlatform(page);
-    await page.getByRole('button', { name: 'Brand Clouds', exact: true }).click();
-    await expect(page.getByRole('heading', { name: 'Brand Clouds' }).first()).toBeVisible();
+    await page.goto('/admin/brand-clouds');
+    await expectPageTitle(page, 'Brand Clouds');
   });
 
   test('[UI-CA-CLOUD-001] list filters and detail reload show Account Manager data @smoke', async ({ page }) => {
-    await expect(page.getByRole('heading', { name: 'Brand Clouds', level: 1 })).toBeVisible();
+    await expectPageTitle(page, 'Brand Clouds');
     await expect(page.getByText('E2E Alpha Cloud', { exact: true })).toBeVisible();
     await page.getByRole('button', { name: 'View', exact: true }).first().click();
     await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();

--- a/web/e2e/brand-fleet-cloud.spec.mjs
+++ b/web/e2e/brand-fleet-cloud.spec.mjs
@@ -1,12 +1,12 @@
 import { test, expect } from '@playwright/test';
-import { login } from './fixtures/session.mjs';
+import { expectPageTitle, login } from './fixtures/session.mjs';
 import { assertForbiddenRoute } from './fixtures/brand-fleet.mjs';
 
 test.describe('Brandname cloud scope', () => {
   test('[UI-CA-SCOPE-001] developer can switch Brand Clouds and keep URL/data scope aligned @brand-fleet @smoke', async ({ page }) => {
     await login(page, 'developer');
     await page.goto('/console/brand-e2e-01/overview');
-    await expect(page.getByRole('heading', { name: '設備總覽' }).first()).toBeVisible();
+    await expectPageTitle(page, '設備總覽');
     const selector = page.getByLabel('Active organization');
     await expect(selector).toHaveValue('brand-e2e-01');
     await expect(selector.locator('option[value="brand-e2e-02"]')).toHaveCount(1);
@@ -17,7 +17,7 @@ test.describe('Brandname cloud scope', () => {
 
     await selector.selectOption('brand-e2e-02');
     await expect(page).toHaveURL(/\/console\/brand-e2e-02\/overview$/);
-    await expect(page.getByRole('heading', { name: '設備總覽' }).first()).toBeVisible();
+    await expectPageTitle(page, '設備總覽');
     const betaDevices = await page.request.get('/api/fleet/devices?limit=100');
     expect(betaDevices.ok()).toBeTruthy();
     const beta = await betaDevices.json();

--- a/web/e2e/brand-fleet-pages.spec.mjs
+++ b/web/e2e/brand-fleet-pages.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from './fixtures/session.mjs';
+import { expectPageTitle, login } from './fixtures/session.mjs';
 
 const pages = [
   ['overview', '設備總覽'],
@@ -16,7 +16,7 @@ test('[UI-CA-FLEETPAGE-001] Brandname customer pages load through the real BFF @
   await login(page, 'developer');
   for (const [route, heading] of pages) {
     await page.goto(`/console/brand-e2e-01/${route}`);
-    await expect(page.getByRole('heading', { name: heading }).first()).toBeVisible();
+    await expectPageTitle(page, heading);
   }
 });
 

--- a/web/e2e/brand-fleet-workflows.spec.mjs
+++ b/web/e2e/brand-fleet-workflows.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { login } from './fixtures/session.mjs';
+import { expectPageTitle, login } from './fixtures/session.mjs';
 import { assertServerScope, waitForJob } from './fixtures/brand-fleet.mjs';
 
 test.describe('Brandname async workflows', () => {
@@ -29,7 +29,7 @@ test.describe('Brandname async workflows', () => {
   test('[UI-CA-OTA-001] OTA scope preview is server calculated and immutable @brand-fleet @smoke', async ({ page }) => {
     await login(page, 'developer');
     await page.goto('/console/brand-e2e-01/firmware-ota');
-    await expect(page.getByRole('heading', { name: '韌體更新' }).first()).toBeVisible();
+    await expectPageTitle(page, '韌體更新');
     const preview = await page.request.post('/api/update-plans/scope-preview', {
       headers: { 'Content-Type': 'application/json' },
       data: { sku_id: 'sku-alpha', query: { region: ['na'], firmware: ['v3.8.0'] }, excluded_device_ids: ['dev-e2e-001'] },

--- a/web/e2e/fixtures/session.mjs
+++ b/web/e2e/fixtures/session.mjs
@@ -23,6 +23,15 @@ export async function enterCustomer(page, cloudId = 'brand-e2e-01') {
   await expect(page.getByText('Brand Fleet', { exact: true })).toBeVisible();
 }
 
+export async function expectPageTitle(page, title) {
+  const mobileTitle = page.locator('.mobile-appbar strong');
+  if (await mobileTitle.isVisible()) {
+    await expect(mobileTitle).toHaveText(title);
+    return;
+  }
+  await expect(page.getByRole('heading', { name: title }).first()).toBeVisible();
+}
+
 export async function waitForJobState(page, jobId, states = ['completed'], timeout = 15_000) {
   const pattern = new RegExp(`^(?:${states.join('|')})$`);
   await expect.poll(async () => {
@@ -45,8 +54,6 @@ export async function enterPlatform(page) {
   try {
     await switchButton.waitFor({ state: 'visible', timeout: 10_000 });
     await switchButton.click();
-    await page.getByRole('heading', { name: 'Platform Dashboard' }).waitFor();
-  } catch {
-    await page.getByRole('heading', { name: 'Platform Dashboard' }).waitFor();
-  }
+  } catch {}
+  await expectPageTitle(page, 'Platform Dashboard');
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3154,7 +3154,7 @@ dd {
   position: fixed;
   right: 0;
   top: 0;
-  z-index: 30;
+  z-index: 420;
 }
 
 .drawer-panel {


### PR DESCRIPTION
## Summary
- assert the responsive app-bar title on mobile and the content heading on desktop
- navigate the Brand Clouds smoke directly so a collapsed mobile sidebar is not treated as interactive
- place drawers above the fixed mobile app bar so close controls remain clickable

## Validation
- targeted mobile smoke: all 8 previously failing scenarios pass after rebuilding assets
- `npm test`: 84 passed
- `npm run build`