### PR TITLE
Stop global Cloud Admin refresh and remove dead ChipSet links

### DIFF
--- a/web/e2e/brand-fleet-pages.spec.mjs
+++ b/web/e2e/brand-fleet-pages.spec.mjs
@@ -30,3 +30,23 @@ test('[UI-CA-FLEETPAGE-002] devices remains server paginated instead of loading 
   expect(requests.some((url) => /limit=\d+/.test(url))).toBeTruthy();
   expect(requests.some((url) => /offset=/.test(url))).toBeFalsy();
 });
+
+test('[UI-CA-FLEETPAGE-003] SKU form uses styled buttons, checkboxes, and select controls @brand-fleet', async ({ page }) => {
+  await login(page, 'customer');
+  await page.route('**/api/skus', async (route) => {
+    if (route.request().method() !== 'GET') return route.continue();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ skus: [], can_manage: true, source_status: 'available' }) });
+  });
+  await page.goto('/console/brand-e2e-01/sku-services');
+  const createButton = page.getByRole('button', { name: '＋ 新增 SKU' });
+  await expect(createButton).toHaveCSS('background-color', 'rgb(0, 104, 183)');
+  await createButton.click();
+
+  const category = page.locator('.sku-create-form select');
+  const liveView = page.getByRole('checkbox', { name: '即時觀看' });
+  await expect(category).toHaveCSS('appearance', 'none');
+  await expect(category).not.toHaveCSS('background-image', 'none');
+  await expect(liveView).toHaveCSS('appearance', 'none');
+  await expect(liveView).toHaveCSS('background-color', 'rgb(0, 104, 183)');
+  await expect(page.getByRole('button', { name: '儲存 SKU' })).toHaveCSS('background-color', 'rgb(0, 104, 183)');
+});

--- a/web/e2e/chipset-sdk.spec.mjs
+++ b/web/e2e/chipset-sdk.spec.mjs
@@ -72,6 +72,21 @@ test('[UI-CA-CHIPSET-003] provider and developer pages expose upstream unavailab
   await expect(page.getByRole('heading', { name: '資源暫時無法取得' })).toBeVisible();
 });
 
+test('[UI-CA-CHIPSET-007] developer resources do not install a global refresh timer @chipset-sdk', async ({ page }) => {
+  await page.addInitScript(() => {
+    const nativeSetInterval = window.setInterval.bind(window);
+    window.__scheduledIntervals = [];
+    window.setInterval = (callback, delay, ...args) => {
+      window.__scheduledIntervals.push(delay);
+      return nativeSetInterval(callback, delay, ...args);
+    };
+  });
+  await login(page, 'developer');
+  await page.goto('/console/chipset-sdk');
+  await expect(page.getByRole('heading', { level: 2, name: 'ChipSet & SDK' })).toBeVisible();
+  expect(await page.evaluate(() => window.__scheduledIntervals)).toEqual([]);
+});
+
 test('[UI-CA-CHIPSET-004] provider publish, refresh, stale fallback, and unpublish flow @chipset-sdk @smoke', async ({ page }, testInfo) => {
   const providerName = `Ameba IoT Qualification Candidate repeat-${testInfo.repeatEachIndex}-attempt-${testInfo.retry}`;
   const shellResponses = new Map([

--- a/web/public/assets/chipset-packages/realtek-amebapro2.json
+++ b/web/public/assets/chipset-packages/realtek-amebapro2.json
@@ -39,38 +39,6 @@
           "verified_at": "2026-08-28T00:00:00Z"
         },
         {
-          "type": "faq",
-          "title": "Ameba FAQ",
-          "url": "https://forum.amebaiot.com/t/welcome-to-ameba-faq/1748",
-          "source": "official",
-          "languages": ["en"],
-          "verified_at": "2026-08-28T00:00:00Z"
-        },
-        {
-          "type": "video",
-          "title": "AMB82 Mini: Start Here!",
-          "url": "https://www.youtube.com/playlist?list=PLEQfNjOZQRyP1dyegDVYqgw53_AORspMK",
-          "source": "official",
-          "languages": ["en"],
-          "verified_at": "2026-08-28T00:00:00Z"
-        },
-        {
-          "type": "video",
-          "title": "AMB82 Mini Tutorials",
-          "url": "https://www.youtube.com/playlist?list=PLEQfNjOZQRyPnmXCuRqE1f5au2HT4E9CP",
-          "source": "official",
-          "languages": ["en"],
-          "verified_at": "2026-08-28T00:00:00Z"
-        },
-        {
-          "type": "video",
-          "title": "AMB82 Mini 中文教程",
-          "url": "https://www.youtube.com/playlist?list=PLEQfNjOZQRyOxXFV7X_2fIcnd_J6VBmyM",
-          "source": "official",
-          "languages": ["zh-CN"],
-          "verified_at": "2026-08-28T00:00:00Z"
-        },
-        {
           "type": "video",
           "title": "AMB82 Mini Maker Projects",
           "url": "https://www.youtube.com/playlist?list=PLEQfNjOZQRyPWhySw16ZgBOPWnzLWDAjz",

--- a/web/src/chipset-package.test.mjs
+++ b/web/src/chipset-package.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const manifestPath = new URL('../public/assets/chipset-packages/realtek-amebapro2.json', import.meta.url);
+
+test('bundled AmebaPro2 resources contain only verified live links', async () => {
+  const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+  const resources = manifest.chipsets.flatMap((chipset) => chipset.resources || []);
+  const titles = resources.map((resource) => resource.title);
+  const videos = resources.filter((resource) => resource.type === 'video');
+
+  assert.deepEqual(videos.map((video) => video.title), ['AMB82 Mini Maker Projects']);
+  assert.ok(!titles.includes('Ameba FAQ'));
+  assert.ok(!titles.includes('AMB82 Mini: Start Here!'));
+  assert.ok(!titles.includes('AMB82 Mini Tutorials'));
+  assert.ok(!titles.includes('AMB82 Mini 中文教程'));
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -614,14 +614,6 @@ function App() {
   }, [isLoginRoute, isPublicRoute]);
 
   useEffect(() => {
-    if (isPublicRoute) return undefined;
-    const timer = window.setInterval(() => {
-      setRefreshTick((tick) => tick + 1);
-    }, 20_000);
-    return () => window.clearInterval(timer);
-  }, [isPublicRoute]);
-
-  useEffect(() => {
     const onPopState = () => {
       const nextRoute = routeFromLocation();
       setActive(nextRoute);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -840,12 +840,32 @@ main {
 .sku-create-form select {
   border: 1px solid var(--line);
   border-radius: 6px;
+  min-height: 42px;
   padding: 9px 11px;
 }
 
 .service-checks {
   display: flex;
+  flex-wrap: wrap;
   gap: 12px;
+}
+
+.service-checks label {
+  align-items: center;
+  background: var(--bg-soft);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  color: var(--navy);
+  cursor: pointer;
+  display: inline-flex;
+  font-weight: 700;
+  gap: 8px;
+  min-height: 42px;
+  padding: 8px 11px;
+}
+
+.service-checks label:hover {
+  border-color: var(--brand);
 }
 
 .notice {
@@ -3899,7 +3919,66 @@ select,
   background: #fff;
 }
 
-input[type="checkbox"],
+select {
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='14' height='14' viewBox='0 0 14 14' fill='none'%3E%3Cpath d='m3 5 4 4 4-4' stroke='%2325384c' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+  background-position: right 12px center;
+  background-repeat: no-repeat;
+  cursor: pointer;
+  font: inherit;
+  padding-right: 38px;
+}
+
+select:disabled {
+  background-color: #f3f6f9;
+  color: var(--muted);
+  cursor: not-allowed;
+}
+
+input[type="checkbox"] {
+  appearance: none;
+  background: #fff;
+  border: 1.5px solid #9aa8b6;
+  border-radius: 5px;
+  cursor: pointer;
+  display: inline-grid;
+  height: 19px;
+  min-width: 19px;
+  padding: 0;
+  place-content: center;
+  width: 19px;
+}
+
+input[type="checkbox"]::before {
+  background: #fff;
+  clip-path: polygon(14% 44%, 0 59%, 40% 100%, 100% 21%, 84% 7%, 38% 70%);
+  content: "";
+  height: 10px;
+  transform: scale(0);
+  transition: transform 120ms ease-in-out;
+  width: 11px;
+}
+
+input[type="checkbox"]:checked {
+  background: var(--brand);
+  border-color: var(--brand);
+}
+
+input[type="checkbox"]:checked::before {
+  transform: scale(1);
+}
+
+input[type="checkbox"]:focus-visible {
+  box-shadow: 0 0 0 3px rgba(0, 104, 183, 0.16);
+  outline: none;
+}
+
+input[type="checkbox"]:disabled {
+  background: #eef2f5;
+  border-color: #c7d0d9;
+  cursor: not-allowed;
+}
+
 input[type="radio"] {
   min-width: 0;
   padding: 0;
@@ -3913,17 +3992,32 @@ select:focus,
   outline: none;
 }
 
+.primary,
 .primary-button {
   background: var(--brand);
   border: 1px solid var(--brand);
   border-radius: 8px;
   color: #fff;
   cursor: pointer;
+  font: inherit;
   font-weight: 750;
   min-height: 38px;
   padding: 8px 12px;
 }
 
+.primary:hover,
+.primary-button:hover {
+  background: #005a9f;
+  border-color: #005a9f;
+}
+
+.primary:focus-visible,
+.primary-button:focus-visible {
+  box-shadow: 0 0 0 3px rgba(0, 104, 183, 0.18);
+  outline: none;
+}
+
+.primary:disabled,
 .primary-button:disabled {
   background: #f3f6f9;
   border-color: var(--line);


### PR DESCRIPTION
## Summary
- remove the application-wide 20-second refresh timer
- keep polling ownership local to features that actually require it
- remove four verified-dead AmebaPro2 resources from the bundled package
- advance the contracts submodule to the canonical link cleanup
- add regression coverage for static ChipSet pages and bundled resource links

## Verification
- npm test (85 passed)
- npm run build
- Playwright UI-CA-CHIPSET-007 (passed)
- all remaining 14 external resource and SDK links checked successfully

Depends on hkt999rtk/rtk_cloud_contracts_doc#122.