### PR TITLE
Hide groups and tags from customer navigation

### DIFF
--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -3,7 +3,6 @@ export const customerNavItems = [
   { id: 'devices', label: '設備', path: '/console/devices', icon: 'video', capabilities: ['fleet.read', 'customer.devices.read'] },
   { id: 'sku-services', label: 'SKU 與服務', path: '/console/sku-services', icon: 'boxes-stacked', capabilities: ['sku.read', 'registry_device.read'] },
   { id: 'chipset-sdk', label: 'ChipSet & SDK', path: '/console/chipset-sdk', icon: 'code-branch' },
-  { id: 'groups', label: '群組與標籤', path: '/console/groups', icon: 'layer-group', capabilities: ['fleet.read', 'device_group.read', 'device_group.manage'] },
   { id: 'access', label: '團隊與權限', path: '/console/access', icon: 'user-shield', capabilities: ['team.read', 'role_assignment.read'] },
   { id: 'firmware-ota', label: '韌體更新', path: '/console/firmware-ota', icon: 'microchip', capabilities: ['firmware.release.read', 'ota.plan.read', 'customer.firmware.read'] },
   { id: 'stream-health', label: '影像播放狀況', path: '/console/stream-health', icon: 'tower-broadcast', capabilities: ['customer.stream.read'] },

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -94,7 +94,7 @@ test('billing subpaths remain addressable inside the tenant billing section', ()
 test('customer nav follows the approved Customer View design order', () => {
   assert.deepEqual(
     customerNavItems.map((item) => item.label),
-    ['設備總覽', '設備', 'SKU 與服務', 'ChipSet & SDK', '群組與標籤', '團隊與權限', '韌體更新', '影像播放狀況', '批次工作', '報表', '設備註冊', '帳務與自動加值'],
+    ['設備總覽', '設備', 'SKU 與服務', 'ChipSet & SDK', '團隊與權限', '韌體更新', '影像播放狀況', '批次工作', '報表', '設備註冊', '帳務與自動加值'],
   );
 });
 
@@ -104,7 +104,7 @@ test('customer nav is derived from active membership capabilities', () => {
     'customer.devices.read',
     'customer.stream.read',
   ]).map((item) => item.label);
-  assert.deepEqual(labels, ['設備總覽', '設備', 'ChipSet & SDK', '群組與標籤', '影像播放狀況', '批次工作']);
+  assert.deepEqual(labels, ['設備總覽', '設備', 'ChipSet & SDK', '影像播放狀況', '批次工作']);
   assert.equal(navItemsForCapabilities('overview', ['team.read']).some((item) => item.id === 'access'), true);
   assert.equal(navItemsForCapabilities('overview', ['team.read']).some((item) => item.id === 'sku-services'), false);
   assert.equal(navItemsForCapabilities('overview', ['billing_account.read']).some((item) => item.id === 'billing'), true);


### PR DESCRIPTION
## Summary
- hide the 群組與標籤 entry from Brand Fleet navigation
- keep the existing route, page implementation, and backend APIs unchanged
- update navigation expectations in unit tests

## Verification
- `node --test web/src/routes.test.mjs` (17 passed)