### PR TITLE
test: normalize auth E2E catalog ID

### DIFF
--- a/web/e2e/auth-errors.spec.mjs
+++ b/web/e2e/auth-errors.spec.mjs
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('[UI-AUTH-001] failed login renders its error once', async ({ page }) => {
+test('[UI-CA-AUTH-003] failed login renders its error once', async ({ page }) => {
   await page.goto('/login');
   await page.getByLabel('Email').fill('nobody@example.com');
   await page.getByLabel('Password').fill('incorrect-password');


### PR DESCRIPTION
## Summary
- rename the legacy auth error Playwright ID to the governed Cloud Admin ID format
- unblock workspace test-catalog validation

## Test
- npm test