### PR TITLE
fix: restore workspace UI and coverage gates

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 79.7% |
+| Go total coverage | 79.8% |
 | Go coverage gate | >= 65.0% |
 | Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
@@ -35,7 +35,7 @@
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |
 | `rtk_cloud_admin/internal/store` | 80.2% |
-| `rtk_cloud_admin/internal/videoclient` | 85.4% |
+| `rtk_cloud_admin/internal/videoclient` | 86.3% |
 
 ## Artifact Policy
 

--- a/internal/videoclient/client_test.go
+++ b/internal/videoclient/client_test.go
@@ -463,6 +463,36 @@ func TestCanonicalOTAReadMethodsFollowPagesAndDecodeStatus(t *testing.T) {
 	}
 }
 
+func TestGetOTACampaignSummaryRejectsBadResponses(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantStatus bool
+	}{
+		{name: "upstream status", statusCode: http.StatusBadGateway, body: `upstream unavailable`, wantStatus: true},
+		{name: "invalid JSON", statusCode: http.StatusOK, body: `{`},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.statusCode)
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer upstream.Close()
+			_, err := New(upstream.URL).GetOTACampaignSummary(t.Context(), "secret", "brand-1", "campaign-1")
+			if err == nil {
+				t.Fatal("GetOTACampaignSummary returned nil error")
+			}
+			if _, ok := err.(HTTPStatusError); ok != tc.wantStatus {
+				t.Fatalf("HTTPStatusError = %v, want %v: %v", ok, tc.wantStatus, err)
+			}
+		})
+	}
+}
+
 func TestDeviceTelemetry(t *testing.T) {
 	t.Parallel()
 

--- a/web/e2e/brand-fleet-workflows.spec.mjs
+++ b/web/e2e/brand-fleet-workflows.spec.mjs
@@ -53,7 +53,7 @@ test.describe('Brandname async workflows', () => {
 
   test('[UI-CA-OTA-002] firmware page shows upgrade progress and device results @brand-fleet @smoke', async ({ page }) => {
     await login(page, 'developer');
-    await page.route('**/api/fleet/firmware-distribution', async (route) => {
+    await page.route('**/api/fleet/firmware-distribution?*', async (route) => {
       await route.fulfill({ json: {
         source_status: 'available',
         versions: [{ version: 'v1.2.4', count: 2, pct: 100, is_latest: true }],
@@ -68,7 +68,7 @@ test.describe('Brandname async workflows', () => {
         }],
       } });
     });
-    await page.goto('/console/brand-e2e-01/firmware-ota');
+    await page.goto('/console/brand-e2e-01/firmware-ota?sku_id=sku-alpha');
     await expect(page.getByRole('heading', { name: '韌體更新狀態' })).toBeVisible();
     await expect(page.getByText('upgrade-e2e-1').first()).toBeVisible();
     await expect(page.getByText('已完成', { exact: true }).first()).toBeVisible();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -490,7 +490,7 @@ main {
 
 .org-switcher,
 .ghost-button {
-  background: #fff;
+  background-color: #fff;
   border: 1px solid var(--line);
   border-radius: 8px;
   color: var(--navy);
@@ -990,7 +990,7 @@ p {
 .org-switcher {
   font-size: 13px;
   color: var(--brand-dark);
-  background: transparent;
+  background-color: #fff;
   border: 1px solid var(--line);
   border-radius: 4px;
   padding: 2px 6px;
@@ -5670,6 +5670,7 @@ th {
   }
 
   .mobile-appbar h1 {
+    color: inherit;
     font-size: 17px;
     margin: 0;
     overflow: hidden;


### PR DESCRIPTION
## Summary
- require the firmware E2E to select its SKU before asserting campaign status
- restore mobile app-bar title contrast and native organization-switcher affordance
- cover OTA campaign summary error responses to preserve the videoclient package ratchet

## Tests
- GOWORK=off go test ./internal/videoclient -coverprofile=/tmp/rtk-admin-videoclient.cover (86.3%)
- npm test (92 passed)
- targeted mobile Playwright OTA test passes; visual changes verified against the approved baseline