### PR TITLE
Restore Cloud Admin CI to the registered self-hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, rtk-cloud-admin-ci]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Route the Cloud Admin validation job back to the original Linux/X64 rtk-cloud-admin-ci self-hosted runner labels while preserving the current validation steps.

Validation:
- git diff --check
- YAML parse

Runner status: no matching repository runner is currently registered, so checks remain queued until a runner is registered and started with the rtk-cloud-admin-ci label.