### PR TITLE
Use runner Go 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,6 @@ jobs:
             "git@github.com-work:hkt999rtk/rtk_cloud_contracts_doc.git"
           git submodule update --init --depth=1 docs/rtk_cloud_contracts_doc
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-          cache: true
-
       - name: Set up Node
         uses: actions/setup-node@v4
         with:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module rtk_cloud_admin
 
-go 1.26.3
+go 1.25.13
 
 require (
 	github.com/hkt999rtk/rtk_cloud_logger v0.0.0-20260724133957-e03921322662


### PR DESCRIPTION
## Summary
- lower the module requirement to Go 1.25.13
- use the Go toolchain already installed on the Linux X64 runner
- remove setup-go cache post-steps from CI and release packaging

The repository Object Storage bucket variable was also corrected to rtk-cloud-client-artifacts.

## Validation
- GOTOOLCHAIN=go1.25.13 go test ./...
- go mod tidy -diff
- actionlint