### PR TITLE
Reference canonical workspace contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Initialize contracts submodule when token is available
+      - name: Checkout workspace contracts when token is available
         env:
           CONTRACTS_REPO_TOKEN: ${{ secrets.CONTRACTS_REPO_TOKEN }}
         run: |
           set -euo pipefail
           if [ -z "$CONTRACTS_REPO_TOKEN" ]; then
-            echo "::warning::CONTRACTS_REPO_TOKEN is not configured; skipping private contracts submodule checkout"
+            echo "::warning::CONTRACTS_REPO_TOKEN is not configured; skipping private contracts checkout"
             exit 0
           fi
           git config --global \
@@ -35,7 +35,16 @@ jobs:
           git config --global --add \
             url."https://x-access-token:${CONTRACTS_REPO_TOKEN}@github.com/hkt999rtk/rtk_cloud_contracts_doc.git".insteadOf \
             "git@github.com-work:hkt999rtk/rtk_cloud_contracts_doc.git"
-          git submodule update --init --depth=1 docs/rtk_cloud_contracts_doc
+          contracts_repo_dir="../rtk_cloud_contracts_doc"
+          if [ -d "$contracts_repo_dir/.git" ]; then
+            git -C "$contracts_repo_dir" fetch --depth=1 origin main
+            git -C "$contracts_repo_dir" checkout --detach FETCH_HEAD
+          else
+            git clone --depth=1 \
+              "https://x-access-token:${CONTRACTS_REPO_TOKEN}@github.com/hkt999rtk/rtk_cloud_contracts_doc.git" \
+              "$contracts_repo_dir"
+          fi
+          test -f docs/rtk_cloud_contracts_doc/openapi.yaml
 
       - uses: actions/setup-node@v4
         with:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "rtk_cloud_contracts_doc"]
-	path = docs/rtk_cloud_contracts_doc
-	url = git@github-work.com:hkt999rtk/rtk_cloud_contracts_doc.git

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ the React WebUI and BFF surface that operators use to view or administer those
 upstream facts. Realtek Video Cloud owns activation, firmware, telemetry,
 streaming, and media runtime facts.
 
-The product and integration contracts live in the
-`docs/rtk_cloud_contracts_doc` submodule.
+The product and integration contracts live in the workspace's canonical
+`rtk_cloud_contracts_doc` repository. `docs/rtk_cloud_contracts_doc` is a
+symlink to that adjacent checkout.
 
 The service logging migration to `rtk_cloud_logger` zap and central journald
 forwarding is documented in
@@ -80,9 +81,8 @@ Recent completion status:
 - Admin Console local-store access is split behind narrow interfaces so future
   session/projection cache work can be introduced without making Admin Console
   the source of truth for upstream tenant or device facts.
-- The contracts documentation submodule URL and CI rewrite now support the
-  local `github.com-work` SSH alias while preserving token-authenticated CI
-  checkout.
+- CI checks out the contracts repository adjacent to this repository, matching
+  the local workspace layout while preserving token-authenticated CI checkout.
 
 ## WebUI Background
 
@@ -242,7 +242,7 @@ web/                         React frontend
 docs/SPEC.md                 Product and implementation specification
 docs/openapi.yaml            OpenAPI contract for the Admin Console BFF API
 docs/assets/webui-design/    WebUI visual concepts and static GUI mocks
-docs/rtk_cloud_contracts_doc/ Shared contracts submodule
+docs/rtk_cloud_contracts_doc/ Shared workspace contracts repository
 ```
 
 ## Configuration
@@ -310,8 +310,8 @@ in GitHub repository secrets and variables, not local `.env` files.
 
 ## CI
 
-`.github/workflows/ci.yml` runs on GitHub-hosted `ubuntu-latest`, initializes
-the contracts submodule when `CONTRACTS_REPO_TOKEN` is configured, and runs
+`.github/workflows/ci.yml` runs on GitHub-hosted `ubuntu-latest`, checks out
+the workspace contracts repository when `CONTRACTS_REPO_TOKEN` is configured, and runs
 `go test ./...`, `go build ./cmd/server`, `npm ci`, `npm test`,
 `npm run build`, and a native server smoke test.
 
@@ -325,17 +325,16 @@ CI environment notes live in [`docs/ci-runner.md`](docs/ci-runner.md).
 
 ## Contracts
 
-Initialize submodules after clone:
+Keep the canonical contracts repository next to this repository in the workspace:
 
 ```sh
-git submodule update --init --recursive
+git -C ../rtk_cloud_contracts_doc status --short --branch
 ```
 
-Update the contracts submodule:
+Update the canonical workspace contracts repository:
 
 ```sh
-git -C docs/rtk_cloud_contracts_doc pull --ff-only
-git add docs/rtk_cloud_contracts_doc
+git -C ../rtk_cloud_contracts_doc pull --ff-only
 ```
 
 Frontend color, typography, layout, and status presentation rules are defined in:

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -241,6 +241,12 @@ authorization facts. Video Cloud owns firmware releases, OTA campaigns, and
 deployment results. Cloud Admin presents the effective result and must not
 infer service entitlement or user permissions from model names or runtime
 token scopes.
+
+The Product capability surface uses the canonical codes `video_streaming`,
+`video_storage`, `mqtt`, and `iot_shadow`, displayed as `Live`, `Recording
+Storage`, `MQTT`, and `IoT Shadow`. `iot_shadow` is independently configurable
+and must not be inferred from `mqtt`. Product list capability cells must not
+render human management permissions such as Manage Devices or Edit Product.
 - `GET /api/operations`: lifecycle operation list.
 - `GET /api/service-health`: configured upstream service health.
 - `GET /api/audit`: audit log.

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -6,12 +6,13 @@ checks against the built server binary.
 
 ## Required Secrets
 
-CI initializes the private `docs/rtk_cloud_contracts_doc` submodule over HTTPS
-when `CONTRACTS_REPO_TOKEN` is configured. Configure a repository or
-organization secret named `CONTRACTS_REPO_TOKEN` with read access to
+CI checks out the private `rtk_cloud_contracts_doc` repository adjacent to this
+repository when `CONTRACTS_REPO_TOKEN` is configured. The checked-in
+`docs/rtk_cloud_contracts_doc` symlink resolves to that checkout. Configure a
+repository or organization secret named `CONTRACTS_REPO_TOKEN` with read access to
 `hkt999rtk/rtk_cloud_contracts_doc` when a CI job needs contract file contents.
 
-If `CONTRACTS_REPO_TOKEN` is missing, CI skips the private submodule checkout
+If `CONTRACTS_REPO_TOKEN` is missing, CI skips the private contracts checkout
 and continues with repo-local tests.
 
 ## Quick Health Checks
@@ -20,7 +21,7 @@ Use the GitHub Actions run page to verify:
 
 - the job is assigned to `ubuntu-latest` instead of waiting for a repository
   runner
-- the contracts submodule initialization step either succeeds or is skipped
+- the workspace contracts checkout step either succeeds or is skipped
   with the expected warning
 - the Go, frontend, and native smoke steps finish with the expected checks
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -3827,6 +3827,7 @@ components:
           type: array
           items:
             type: string
+            enum: [video_streaming, video_storage, mqtt, iot_shadow]
         device_policy:
           type: object
           additionalProperties: true
@@ -3861,7 +3862,12 @@ components:
         product_model: { type: string }
         category: { type: string }
         manufacturer: { type: string }
-        service_capabilities: { type: array, items: { type: string } }
+        service_capabilities:
+          type: array
+          uniqueItems: true
+          items:
+            type: string
+            enum: [video_streaming, video_storage, mqtt, iot_shadow]
         device_policy: { type: object, additionalProperties: true }
         firmware_policy: { type: object, additionalProperties: true }
 


### PR DESCRIPTION
## Summary
- replace the nested contracts submodule with a symlink to the workspace contracts repository
- update CI to check out contracts adjacent to Cloud Admin
- align Product capability documentation and OpenAPI with configurable IoT Shadow

## Validation
- `GOWORK=off go test ./...`
- parsed workflow and OpenAPI YAML
- `git diff --check`