### PR TITLE
Add OTA rollout dashboard

### DIFF
--- a/web/e2e/brand-fleet-workflows.spec.mjs
+++ b/web/e2e/brand-fleet-workflows.spec.mjs
@@ -43,29 +43,47 @@ test.describe('Brandname async workflows', () => {
 
   test('[UI-CA-OTA-002] firmware page shows upgrade progress and device results @brand-fleet @smoke', async ({ page }) => {
     await login(page, 'developer');
+    const requestedActions = [];
+    await page.route('**/api/update-plans/*/*', async (route) => {
+      if (route.request().method() !== 'POST') return route.continue();
+      requestedActions.push(new URL(route.request().url()).pathname);
+      return route.fulfill({ json: { update_plan: { state: 'accepted' } } });
+    });
     await page.route('**/api/fleet/firmware-distribution?*', async (route) => {
       await route.fulfill({ json: {
         source_status: 'available',
         versions: [{ version: 'v1.2.4', count: 2, pct: 100, is_latest: true }],
         campaigns: [{
-          campaign_id: 'upgrade-e2e-1', target_version: 'v1.2.4', policy: 'normal', state: 'completed',
-          applied: 1, pending: 0, failed: 1, skipped: 0, total: 2,
-          started_at: '2026-08-28T01:00:00Z', updated_at: '2026-08-28T01:05:00Z',
+          campaign_id: 'upgrade-newest', target_version: 'v1.2.4', policy: 'normal', state: 'active',
+          applied: 5, pending: 3, failed: 1, skipped: 1, total: 10,
+          started_at: '2026-08-29T01:00:00Z', updated_at: '2026-08-29T01:05:00Z',
           rollouts: [
             { device_id: 'dev-ok', device_name: 'Camera OK', current_version: 'v1.2.4', target_version: 'v1.2.4', rollout_status: 'applied', last_updated: '2026-08-28T01:04:00Z' },
             { device_id: 'dev-failed', device_name: 'Camera Failed', current_version: 'v1.2.3', target_version: 'v1.2.4', rollout_status: 'failed', failure_reason: 'checksum mismatch', last_updated: '2026-08-28T01:05:00Z' },
           ],
+        }, {
+          campaign_id: 'upgrade-older', target_version: 'v1.2.3', policy: 'normal', state: 'paused',
+          applied: 0, pending: 4, failed: 0, skipped: 0, total: 4,
+          started_at: '2026-08-28T01:00:00Z', updated_at: '2026-08-28T01:05:00Z', rollouts: [],
         }],
       } });
     });
     await page.goto('/console/brand-e2e-01/firmware-ota?product_id=product-alpha');
-    await expect(page.getByRole('heading', { name: 'Firmware update status' })).toBeVisible();
-    await expect(page.getByText('upgrade-e2e-1').first()).toBeVisible();
-    await expect(page.getByText('Completed', { exact: true }).first()).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'OTA Dashboard' })).toBeVisible();
+    const dashboardRows = page.locator('.ota-dashboard-row');
+    await expect(dashboardRows).toHaveCount(2);
+    await expect(dashboardRows.nth(0)).toContainText('upgrade-newest');
+    await expect(dashboardRows.nth(1)).toContainText('upgrade-older');
+    await expect(dashboardRows.nth(0)).toContainText('3 / 10');
+    await expect(dashboardRows.nth(0).getByRole('progressbar', { name: 'Waiting devices for upgrade-newest' })).toHaveAttribute('aria-valuenow', '3');
+    await expect(dashboardRows.nth(0).getByRole('progressbar', { name: 'Waiting devices for upgrade-newest' })).toHaveAttribute('aria-valuemax', '10');
+    await expect(page.getByText('Updating', { exact: true }).first()).toBeVisible();
+    await dashboardRows.nth(0).getByRole('button', { name: 'Stop OTA' }).click();
+    await dashboardRows.nth(1).getByRole('button', { name: 'Start OTA' }).click();
+    await expect.poll(() => requestedActions).toEqual(['/api/update-plans/upgrade-newest/pause', '/api/update-plans/upgrade-older/resume']);
     await expect(page.getByText('Camera Failed', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('Update failed', { exact: true }).first()).toBeVisible();
     await expect(page.getByText('checksum mismatch')).toBeVisible();
-    await expect(page.getByRole('button', { name: 'Retry failed device' })).toBeVisible();
   });
 
   test('[UI-CA-OTA-003] firmware binary calculates release metadata before upload @brand-fleet @smoke', async ({ page }) => {

--- a/web/src/firmware.mjs
+++ b/web/src/firmware.mjs
@@ -63,6 +63,30 @@ export function firmwareCampaignProgress(campaign = {}) {
   return { total, completed, pct: total ? completed / total * 100 : 0 };
 }
 
+export function firmwareCampaignWaitingProgress(campaign = {}) {
+  const total = Math.max(Number(campaign.total || 0), 0);
+  const waiting = Math.max(Number(campaign.pending || 0), 0);
+  return { total, waiting, pct: total ? Math.min(waiting / total * 100, 100) : 0 };
+}
+
+export function sortFirmwareCampaignsByStartTime(campaigns = []) {
+  return [...campaigns].sort((left, right) => {
+    const leftStartedAt = Date.parse(left.started_at || '') || 0;
+    const rightStartedAt = Date.parse(right.started_at || '') || 0;
+    if (leftStartedAt !== rightStartedAt) return rightStartedAt - leftStartedAt;
+    return String(right.campaign_id || '').localeCompare(String(left.campaign_id || ''));
+  });
+}
+
+export function firmwareDashboardAction(campaign = {}, canManage = true) {
+  if (!canManage) return null;
+  const state = String(campaign.state || '').trim().toLowerCase();
+  if (state === 'draft') return { action: 'start', label: 'Start OTA' };
+  if (state === 'paused') return { action: 'resume', label: 'Start OTA' };
+  if (state === 'scheduled' || state === 'active') return { action: 'pause', label: 'Stop OTA' };
+  return null;
+}
+
 export function firmwareCampaignActions(campaign = {}, canManage = true) {
   if (!canManage) return [];
   const state = String(campaign.state || '').trim().toLowerCase();

--- a/web/src/firmware.test.mjs
+++ b/web/src/firmware.test.mjs
@@ -5,11 +5,14 @@ import {
   firmwareCampaignDetailRows,
   firmwareCampaignNeedsPolling,
   firmwareCampaignProgress,
+  firmwareCampaignWaitingProgress,
   firmwareCampaignStatusLabel,
+  firmwareDashboardAction,
   firmwarePolicyLabel,
   firmwareRiskRows,
   firmwareRolloutStatusLabel,
   firmwareVersionFilterValue,
+  sortFirmwareCampaignsByStartTime,
 } from './firmware.mjs';
 
 const campaign = {
@@ -69,6 +72,28 @@ test('firmware status helpers use upgrade-specific English labels', () => {
 test('firmware campaign progress counts terminal device outcomes', () => {
   assert.deepEqual(firmwareCampaignProgress({ total: 10, applied: 6, failed: 1, skipped: 1 }), { total: 10, completed: 8, pct: 80 });
   assert.deepEqual(firmwareCampaignProgress({}), { total: 0, completed: 0, pct: 0 });
+});
+
+test('firmware dashboard reports waiting devices against the campaign total', () => {
+  assert.deepEqual(firmwareCampaignWaitingProgress({ total: 10, pending: 3 }), { total: 10, waiting: 3, pct: 30 });
+  assert.deepEqual(firmwareCampaignWaitingProgress({ total: 0, pending: 2 }), { total: 0, waiting: 2, pct: 0 });
+});
+
+test('firmware dashboard orders campaigns by newest start time', () => {
+  const sorted = sortFirmwareCampaignsByStartTime([
+    { campaign_id: 'older', started_at: '2026-08-28T01:00:00Z' },
+    { campaign_id: 'not-started', started_at: '' },
+    { campaign_id: 'newer', started_at: '2026-08-29T01:00:00Z' },
+  ]);
+  assert.deepEqual(sorted.map((item) => item.campaign_id), ['newer', 'older', 'not-started']);
+});
+
+test('firmware dashboard exposes reversible start and stop controls', () => {
+  assert.deepEqual(firmwareDashboardAction({ state: 'draft' }), { action: 'start', label: 'Start OTA' });
+  assert.deepEqual(firmwareDashboardAction({ state: 'paused' }), { action: 'resume', label: 'Start OTA' });
+  assert.deepEqual(firmwareDashboardAction({ state: 'active' }), { action: 'pause', label: 'Stop OTA' });
+  assert.equal(firmwareDashboardAction({ state: 'completed' }), null);
+  assert.equal(firmwareDashboardAction({ state: 'active' }, false), null);
 });
 
 test('firmware campaign actions follow campaign state and permission', () => {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -56,11 +56,14 @@ import {
   firmwareCampaignDetailRows,
   firmwareCampaignNeedsPolling,
   firmwareCampaignProgress,
+  firmwareCampaignWaitingProgress,
   firmwareCampaignStatusLabel,
+  firmwareDashboardAction,
   firmwarePolicyLabel,
   firmwareRiskRows,
   firmwareRolloutStatusLabel,
   firmwareVersionFilterValue,
+  sortFirmwareCampaignsByStartTime,
 } from './firmware.mjs';
 import {
   auditCoverageCopy,
@@ -108,7 +111,7 @@ import {
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import '@fontsource-variable/noto-sans-tc';
 import './styles.css';
-import i18n, { FORMAT_LOCALE, formatNumber, translate } from './i18n/index.mjs';
+import i18n, { FORMAT_LOCALE, formatDateTime, formatNumber, translate } from './i18n/index.mjs';
 
 const DEFAULT_PAGE_SIZE = 8;
 
@@ -3194,7 +3197,7 @@ function batchJobStateLabel(state) {
 
 function FirmwareOTAPage({ loading, distribution, selectedProductId, products, releases, onViewDevices, onCampaignAction, onStatusRefresh, canRelease, canManageOTA, onSelectProduct, onRefresh }) {
   const versions = distribution?.versions || [];
-  const campaigns = distribution?.campaigns || [];
+  const campaigns = sortFirmwareCampaignsByStartTime(distribution?.campaigns || []);
   const selectedProduct = products.find((product) => product.id === selectedProductId) || null;
   const hasSelection = Boolean(selectedProductId && selectedProduct);
   const [selectedCampaignId, setSelectedCampaignId] = useState('');
@@ -3213,6 +3216,7 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
   const [scopePreview, setScopePreview] = useState(null);
   const [scopeLoading, setScopeLoading] = useState(false);
   const [statusRefreshing, setStatusRefreshing] = useState(false);
+  const [campaignActionBusy, setCampaignActionBusy] = useState('');
   function selectProduct(event) {
     const productID = event.target.value;
     setSelectedCampaignId('');
@@ -3245,6 +3249,15 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
     setStatusRefreshing(true);
     await onStatusRefresh?.();
     setStatusRefreshing(false);
+  }
+  async function runCampaignAction(campaignId, action) {
+    const key = `${campaignId}:${action}`;
+    setCampaignActionBusy(key);
+    try {
+      await onCampaignAction?.(campaignId, action);
+    } finally {
+      setCampaignActionBusy('');
+    }
   }
   async function selectReleaseArtifact(event) {
     const file = event.target.files?.[0] || null;
@@ -3357,7 +3370,7 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
       <div className="panel-head">
         <div>
           <h2>Firmware Update</h2>
-          <p>Publish firmware versions, create update plans, and track upgrade status for each device on the same page.</p>
+          <p>Start and stop OTA rollouts, publish firmware versions, and track device progress for the selected Product.</p>
         </div>
         <button type="button" className="ghost-button" disabled={!hasSelection || statusRefreshing} onClick={refreshStatus}>{statusRefreshing ? 'Updating status…' : 'Refresh status'}</button>
       </div>
@@ -3381,6 +3394,17 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
         <MetricCard icon="cloud-arrow-up" label="Recent updates" value={primaryCampaign ? formatPercent(primaryProgress.pct) : '—'} hint={primaryCampaign ? `${formatNumber(primaryProgress.completed)} of ${formatNumber(primaryProgress.total)} devices processed` : 'No updates are currently running'} tone="info" />
         <MetricCard icon="circle-exclamation" label="Update failed" value={failedRollout} hint={primaryCampaign ? `${formatPercent(primaryCampaign.total ? failedRollout / primaryCampaign.total * 100 : 0)} of target devices` : 'No updates are currently running'} tone={failedRollout ? 'danger' : 'good'} />
       </section> : null}
+
+      {hasSelection && distribution && available ? (
+        <FirmwareOTADashboard
+          campaigns={campaigns}
+          selectedCampaignId={selectedCampaignId}
+          onSelect={setSelectedCampaignId}
+          onAction={runCampaignAction}
+          canManage={canManageOTA}
+          busyAction={campaignActionBusy}
+        />
+      ) : null}
 
       {hasSelection && canRelease && selectedProduct.allowed_actions?.includes('manage_updates') ? <section className="panel firmware-panel"><div className="panel-head"><div><h3>Add firmware version</h3><p>The version will be registered to {selectedProduct.name}. You can then create an update plan for the same Product.</p></div></div><form className="inline-form" onSubmit={publishRelease}><input required placeholder="Version, e.g. 1.4.3" value={releaseVersion} onChange={(event) => setReleaseVersion(event.target.value)} /><input ref={releaseFileInput} name="artifact" required type="file" accept="application/octet-stream,.bin" aria-label="Firmware binary" onChange={selectReleaseArtifact} /><input required placeholder="Hardware versions (comma separated)" value={releaseHardware} onChange={(event) => setReleaseHardware(event.target.value)} />{releaseArtifactLoading ? <div className="firmware-artifact-metadata" role="status">Calculating firmware metadata…</div> : null}{releaseArtifact ? <dl className="firmware-artifact-metadata" aria-label="Firmware binary metadata"><div><dt>File</dt><dd>{releaseArtifact.name}</dd></div><div><dt>Size</dt><dd>{formatFirmwareSize(releaseArtifact.size)}{releaseArtifact.size >= 1024 ? ` (${releaseArtifact.size.toLocaleString('en-US')} bytes)` : ''}</dd></div><div><dt>SHA-256</dt><dd><code>{releaseArtifact.sha256}</code></dd></div></dl> : null}<button type="submit" className="primary-button" disabled={releaseArtifactLoading || !releaseArtifact}>Create version</button></form>{releaseMessage ? <p className="notice">{releaseMessage}</p> : null}</section> : null}
       {hasSelection && canManageOTA && releases.some((release) => String(release.state || '').toLowerCase() === 'published') ? <section className="panel firmware-panel"><div className="panel-head"><div><h3>Create an update plan</h3><p>Obtain the server scope preview before creating the immutable OTA plan; the browser does not determine the target count.</p></div></div><form className="inline-form" onSubmit={createUpdatePlan}><select className="select-control" required value={planRelease} onChange={(event) => { setPlanRelease(event.target.value); setScopePreview(null); }}><option value="">Select firmware version</option>{releases.filter((release) => String(release.state || '').toLowerCase() === 'published').map((release) => <option value={release.id || release.release_id} key={release.id || release.release_id}>{release.version}</option>)}</select><input placeholder="Plan name (optional)" value={planName} onChange={(event) => setPlanName(event.target.value)} /><input placeholder="Regions (comma separated)" value={scopeQuery.region} onChange={(event) => { setScopeQuery({ ...scopeQuery, region: event.target.value }); setScopePreview(null); }} /><input placeholder="Group IDs (comma separated)" value={scopeQuery.group_ids} onChange={(event) => { setScopeQuery({ ...scopeQuery, group_ids: event.target.value }); setScopePreview(null); }} /><input placeholder="Firmware versions (comma separated)" value={scopeQuery.firmware} onChange={(event) => { setScopeQuery({ ...scopeQuery, firmware: event.target.value }); setScopePreview(null); }} /><input placeholder="Health statuses (comma separated)" value={scopeQuery.health} onChange={(event) => { setScopeQuery({ ...scopeQuery, health: event.target.value }); setScopePreview(null); }} /><input className="wide-input" placeholder="Exclude device IDs (comma or space separated)" value={excludedDeviceText} onChange={(event) => { setExcludedDeviceText(event.target.value); setScopePreview(null); }} /><button type="button" className="ghost-button" disabled={scopeLoading || !planRelease} onClick={previewScope}>{scopeLoading ? 'Calculating scope…' : 'Preview server scope'}</button><button type="submit" className="primary-button" disabled={!scopePreview?.scope}>Create update plan</button></form>{scopePreview?.scope ? <div className="scope-preview-grid"><span>Target <strong>{formatNumber(scopePreview.target_count || 0)}</strong></span><span>Excluded <strong>{formatNumber(scopePreview.excluded_count || 0)}</strong></span><span>Scope <code>{scopePreview.scope.scope_hash}</code></span><span>Expires <strong>{scopePreview.scope.expires_at || '—'}</strong></span></div> : null}{planMessage ? <p className="notice">{planMessage}</p> : null}</section> : null}
@@ -3431,60 +3455,86 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
         </div>
 
         <div className="firmware-lower-grid">
-          <section className="panel firmware-panel">
-            <div className="panel-head">
-              <div>
-                <h3>Firmware update status</h3>
-                <p>See the overall progress, device results, and final report time for each upgrade.</p>
-              </div>
-            </div>
-            {campaigns.length ? (
-              <div className="campaign-table">
-                <div className="campaign-table-head">
-                  <span>Update ID</span>
-                  <span>Target Version</span>
-                  <span>Status</span>
-                  <span>Overall progress</span>
-                  <span>Done</span>
-                  <span>Wait</span>
-                  <span>Failed/Skipped</span>
-                  <span>Start time</span>
-                  <span>Last Updated</span>
-                </div>
-                {campaigns.map((campaign) => {
-                  const progress = firmwareCampaignProgress(campaign);
-                  return (
-                    <button
-                      key={campaign.campaign_id}
-                      type="button"
-                      className={`campaign-table-row${selectedCampaign?.campaign_id === campaign.campaign_id ? ' is-selected' : ''}`}
-                      onClick={() => setSelectedCampaignId(campaign.campaign_id)}
-                    >
-                      <strong>{campaign.campaign_id}</strong>
-                      <span>{campaign.target_version}</span>
-                      <StatusBadge value={normalizeStatusKey(campaign.state)} label={firmwareCampaignStatusLabel(campaign.state)} />
-                      <span>{formatPercent(progress.pct)}</span>
-                      <span>{formatNumber(campaign.applied || 0)}</span>
-                      <span>{formatNumber(campaign.pending || 0)}</span>
-                      <span>{formatNumber(campaign.failed || 0)} / {formatNumber(campaign.skipped || 0)}</span>
-                      <time>{campaign.started_at ? formatRelativeTime(campaign.started_at) : '—'}</time>
-                      <time>{campaign.updated_at ? formatRelativeTime(campaign.updated_at) : '—'}</time>
-                    </button>
-                  );
-                })}
-              </div>
-            ) : (
-              <p className="empty-state">There are currently no firmware updates.</p>
-            )}
-          </section>
-
-          <FirmwareCampaignDetail campaign={selectedCampaign} onAction={canManageOTA ? onCampaignAction : null} canManage={canManageOTA} />
+          <FirmwareCampaignDetail campaign={selectedCampaign} onAction={canManageOTA ? runCampaignAction : null} canManage={canManageOTA} />
           <FirmwareRiskQueue campaigns={campaigns} onViewDevices={(version) => onViewDevices(version, selectedProductId)} />
         </div>
         </>
       ) : null}
     </section>
   );
+}
+
+function FirmwareOTADashboard({ campaigns, selectedCampaignId, onSelect, onAction, canManage, busyAction }) {
+  return (
+    <section className="panel firmware-panel ota-dashboard" aria-label="OTA Dashboard">
+      <div className="panel-head">
+        <div>
+          <h3>OTA Dashboard</h3>
+          <p>OTA rollouts are ordered by start time, newest first. Stop pauses an active rollout so it can be started again.</p>
+        </div>
+      </div>
+      {campaigns.length ? (
+        <div className="ota-dashboard-list">
+          {campaigns.map((campaign) => {
+            const waiting = firmwareCampaignWaitingProgress(campaign);
+            const control = firmwareDashboardAction(campaign, canManage);
+            const controlBusy = control && busyAction === `${campaign.campaign_id}:${control.action}`;
+            return (
+              <article className={`ota-dashboard-row${selectedCampaignId === campaign.campaign_id ? ' is-selected' : ''}`} key={campaign.campaign_id}>
+                <button
+                  type="button"
+                  className="ota-dashboard-row__details"
+                  aria-pressed={selectedCampaignId === campaign.campaign_id}
+                  onClick={() => onSelect(campaign.campaign_id)}
+                >
+                  <span className="ota-dashboard-row__heading">
+                    <strong>{campaign.campaign_id}</strong>
+                    <StatusBadge value={normalizeStatusKey(campaign.state)} label={firmwareCampaignStatusLabel(campaign.state)} />
+                  </span>
+                  <span className="ota-dashboard-row__meta">
+                    <span>Target {campaign.target_version || '—'}</span>
+                    <time dateTime={campaign.started_at || undefined}>Started {formatFirmwareStartTime(campaign.started_at)}</time>
+                  </span>
+                  <span className="ota-dashboard-waiting-copy">
+                    <span>Waiting devices</span>
+                    <strong>{formatNumber(waiting.waiting)} / {formatNumber(waiting.total)}</strong>
+                  </span>
+                  <span
+                    className="ota-dashboard-progress"
+                    role="progressbar"
+                    aria-label={`Waiting devices for ${campaign.campaign_id}`}
+                    aria-valuemin="0"
+                    aria-valuemax={Math.max(waiting.total, 1)}
+                    aria-valuenow={Math.min(waiting.waiting, waiting.total || 0)}
+                    aria-valuetext={`${waiting.waiting} waiting of ${waiting.total} total devices`}
+                  >
+                    <span style={{ width: `${waiting.pct}%` }} />
+                  </span>
+                </button>
+                <div className="ota-dashboard-row__actions">
+                  {control ? (
+                    <button
+                      type="button"
+                      className={control.action === 'pause' ? 'danger-button' : 'primary-button'}
+                      disabled={Boolean(busyAction)}
+                      onClick={() => onAction(campaign.campaign_id, control.action)}
+                    >
+                      {controlBusy ? `${control.label.replace(' OTA', '')}…` : control.label}
+                    </button>
+                  ) : <span className="muted">{canManage ? 'No action available' : 'Read-only'}</span>}
+                </div>
+              </article>
+            );
+          })}
+        </div>
+      ) : <p className="empty-state">There are currently no OTA rollouts for this Product.</p>}
+    </section>
+  );
+}
+
+function formatFirmwareStartTime(value) {
+  if (Number.isNaN(Date.parse(value || ''))) return 'not started';
+  return formatDateTime(value, { dateStyle: 'medium', timeStyle: 'short' });
 }
 
 function FirmwareCampaignDetail({ campaign, onAction, canManage }) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2484,26 +2484,88 @@ p {
   background: #cbd5e1;
 }
 
-.campaign-table,
 .risk-table {
   display: grid;
   gap: 8px;
 }
 
-.campaign-table {
-  overflow-x: auto;
+.ota-dashboard-list {
+  display: grid;
+  gap: 12px;
 }
 
-.campaign-table-head,
-.campaign-table-row {
+.ota-dashboard-row {
   align-items: center;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr) auto;
+  padding: 14px;
+  transition: border-color 120ms ease, box-shadow 120ms ease;
+}
+
+.ota-dashboard-row:hover,
+.ota-dashboard-row.is-selected {
+  border-color: rgba(0, 104, 183, 0.36);
+  box-shadow: 0 14px 28px rgba(3, 83, 144, 0.08);
+}
+
+.ota-dashboard-row__details {
+  background: transparent;
+  border: 0;
+  cursor: pointer;
   display: grid;
   gap: 10px;
-  grid-template-columns: minmax(140px, 1fr) 90px 110px 90px 72px 72px 96px 110px 110px;
-  min-width: 1040px;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
 }
 
-.campaign-table-head,
+.ota-dashboard-row__heading,
+.ota-dashboard-row__meta,
+.ota-dashboard-waiting-copy {
+  align-items: center;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.ota-dashboard-row__heading > strong {
+  color: var(--navy);
+  overflow-wrap: anywhere;
+}
+
+.ota-dashboard-row__meta,
+.ota-dashboard-waiting-copy > span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.ota-dashboard-waiting-copy > strong {
+  color: var(--navy);
+}
+
+.ota-dashboard-progress {
+  background: rgba(37, 56, 76, 0.12);
+  border-radius: 999px;
+  display: block;
+  height: 12px;
+  overflow: hidden;
+}
+
+.ota-dashboard-progress > span {
+  background: var(--brand);
+  display: block;
+  height: 100%;
+}
+
+.ota-dashboard-row__actions,
+.ota-dashboard-row__actions button {
+  min-width: 104px;
+}
+
 .risk-table-head {
   color: var(--muted);
   font-size: 12px;
@@ -2511,7 +2573,6 @@ p {
   text-transform: uppercase;
 }
 
-.campaign-table-row,
 .risk-table-row {
   background: #fff;
   border: 1px solid var(--line);
@@ -2519,25 +2580,10 @@ p {
   padding: 10px;
 }
 
-.campaign-table-row {
-  cursor: pointer;
-  text-align: left;
-  width: 100%;
-}
-
-.campaign-table-row:hover,
-.campaign-table-row.is-selected {
-  border-color: rgba(0, 104, 183, 0.32);
-  box-shadow: 0 16px 30px rgba(3, 83, 144, 0.08);
-}
-
-.campaign-table-row strong,
 .risk-table-row strong {
   color: var(--brand);
 }
 
-.campaign-table-row span,
-.campaign-table-row time,
 .risk-table-row span,
 .risk-table-row time {
   color: var(--muted);
@@ -5355,6 +5401,19 @@ th {
   .firmware-rollout-table__head,
   .firmware-rollout-table__row {
     grid-template-columns: 1fr;
+  }
+
+  .ota-dashboard-row {
+    grid-template-columns: 1fr;
+  }
+
+  .ota-dashboard-row__meta {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .ota-dashboard-row__actions button {
+    width: 100%;
   }
 
   .stream-device-table__head,


### PR DESCRIPTION
## Summary
- add an OTA dashboard ordered by rollout start time
- show waiting devices versus total devices with accessible progress bars
- provide reversible Start OTA and Stop OTA controls
- cover ordering, progress, and control endpoints in unit and browser tests

## Validation
- npm test
- npm run build
- npm run e2e:smoke
- GOWORK=off go test ./...