### PR TITLE
Add OTA job rate controls

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3561,6 +3561,11 @@ func (s *Server) apiUpdatePlans(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "OTA plan requires a server-calculated immutable scope", http.StatusBadRequest)
 			return
 		}
+		rate, ok := payload["rate_limit_per_minute"].(float64)
+		if !ok || rate != float64(int(rate)) || rate < 1 || rate > 10000 {
+			http.Error(w, "OTA plan rate_limit_per_minute must be an integer from 1 to 10000", http.StatusUnprocessableEntity)
+			return
+		}
 		delete(payload, "product_id")
 		body, _ = json.Marshal(payload)
 		upstreamPath = "/api/ota/products/" + url.PathEscape(strings.TrimSpace(productID)) + "/campaigns"
@@ -3570,6 +3575,8 @@ func (s *Server) apiUpdatePlans(w http.ResponseWriter, r *http.Request) {
 		if action := strings.TrimSpace(r.PathValue("action")); action != "" {
 			if action == "start" {
 				action = "activate"
+			} else if action == "rate-limit" {
+				action = "set-rate-limit"
 			}
 			upstreamPath += ":" + url.PathEscape(action)
 		}
@@ -3979,14 +3986,17 @@ func (s *Server) canonicalFirmwareCampaigns(ctx context.Context, devices []contr
 
 func summarizeCanonicalFirmwareCampaign(campaign videoclient.OTACampaignRecord, targetVersion string, deployments []videoclient.OTADeploymentRecord, summary videoclient.OTACampaignSummary, deviceByID map[string]contracts.Device) contracts.FirmwareDistributionCampaign {
 	result := contracts.FirmwareDistributionCampaign{
-		CampaignID:    strings.TrimSpace(campaign.ID),
-		TargetVersion: strings.TrimSpace(targetVersion),
-		Policy:        "normal",
-		State:         strings.TrimSpace(campaign.State),
-		StartedAt:     firstNonEmpty(strings.TrimSpace(campaign.ActivatedAt), strings.TrimSpace(campaign.CreatedAt)),
-		UpdatedAt:     firstNonEmpty(strings.TrimSpace(summary.UpdatedAt), strings.TrimSpace(campaign.UpdatedAt)),
-		Total:         summary.Total,
-		Rollouts:      make([]contracts.FirmwareDistributionRollout, 0, len(deployments)),
+		CampaignID:         strings.TrimSpace(campaign.ID),
+		TargetVersion:      strings.TrimSpace(targetVersion),
+		Policy:             "normal",
+		State:              strings.TrimSpace(campaign.State),
+		StartedAt:          firstNonEmpty(strings.TrimSpace(campaign.ActivatedAt), strings.TrimSpace(campaign.CreatedAt)),
+		UpdatedAt:          firstNonEmpty(strings.TrimSpace(summary.UpdatedAt), strings.TrimSpace(campaign.UpdatedAt)),
+		RateLimitPerMinute: campaign.RateLimitPerMinute,
+		EffectiveRateLimit: campaign.EffectiveRateLimit,
+		SystemMaxRateLimit: campaign.SystemMaxRateLimit,
+		Total:              summary.Total,
+		Rollouts:           make([]contracts.FirmwareDistributionRollout, 0, len(deployments)),
 	}
 	if result.Total == 0 {
 		result.Total = campaign.TargetSnapshotCount

--- a/internal/app/batch_job_coverage_test.go
+++ b/internal/app/batch_job_coverage_test.go
@@ -427,6 +427,9 @@ func TestOTAUpdatePlanProxyAndFirmwareRetry(t *testing.T) {
 	if rec := request(http.MethodPost, "/api/update-plans/campaign-1/start", `{}`, "plan-start"); rec.Code != http.StatusOK {
 		t.Fatalf("plan start status = %d, body=%s", rec.Code, rec.Body.String())
 	}
+	if rec := request(http.MethodPost, "/api/update-plans/campaign-1/rate-limit", `{"rate_limit_per_minute":10000,"reason":"capacity change"}`, "plan-rate"); rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), ":set-rate-limit") {
+		t.Fatalf("plan rate status = %d, body=%s", rec.Code, rec.Body.String())
+	}
 	if rec := request(http.MethodPost, "/api/update-plans/reject/cancel", `{}`, "plan-reject"); rec.Code != http.StatusConflict {
 		t.Fatalf("plan reject status = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -440,7 +443,7 @@ func TestOTAUpdatePlanProxyAndFirmwareRetry(t *testing.T) {
 		"target_count":        0,
 	}
 	scope["scope_hash"] = batchScopeHash(map[string]any{"query": query, "excluded_device_ids": excluded})
-	payload, err := json.Marshal(map[string]any{"product_id": "product-1", "name": "Qualification", "scope": scope})
+	payload, err := json.Marshal(map[string]any{"product_id": "product-1", "name": "Qualification", "scope": scope, "rate_limit_per_minute": 100})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -455,6 +458,7 @@ func TestOTAUpdatePlanProxyAndFirmwareRetry(t *testing.T) {
 		{`{`, "plan-json", http.StatusBadRequest},
 		{`{"name":"missing product"}`, "plan-product", http.StatusBadRequest},
 		{`{"product_id":"product-1"}`, "plan-scope", http.StatusBadRequest},
+		{strings.Replace(string(payload), `"rate_limit_per_minute":100`, `"rate_limit_per_minute":10001`, 1), "plan-rate-high", http.StatusUnprocessableEntity},
 		{string(payload), "", http.StatusPreconditionRequired},
 	} {
 		rec := request(http.MethodPost, "/api/update-plans", tc.body, tc.key)

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -545,18 +545,21 @@ type FirmwareDistributionRollout struct {
 }
 
 type FirmwareDistributionCampaign struct {
-	CampaignID    string                        `json:"campaign_id"`
-	TargetVersion string                        `json:"target_version"`
-	Policy        string                        `json:"policy"`
-	State         string                        `json:"state"`
-	Applied       int                           `json:"applied"`
-	Pending       int                           `json:"pending"`
-	Failed        int                           `json:"failed"`
-	Skipped       int                           `json:"skipped"`
-	Total         int                           `json:"total"`
-	StartedAt     string                        `json:"started_at"`
-	UpdatedAt     string                        `json:"updated_at,omitempty"`
-	Rollouts      []FirmwareDistributionRollout `json:"rollouts,omitempty"`
+	CampaignID         string                        `json:"campaign_id"`
+	TargetVersion      string                        `json:"target_version"`
+	Policy             string                        `json:"policy"`
+	State              string                        `json:"state"`
+	Applied            int                           `json:"applied"`
+	Pending            int                           `json:"pending"`
+	Failed             int                           `json:"failed"`
+	Skipped            int                           `json:"skipped"`
+	Total              int                           `json:"total"`
+	StartedAt          string                        `json:"started_at"`
+	UpdatedAt          string                        `json:"updated_at,omitempty"`
+	RateLimitPerMinute int                           `json:"rate_limit_per_minute,omitempty"`
+	EffectiveRateLimit int                           `json:"effective_rate_limit_per_minute,omitempty"`
+	SystemMaxRateLimit int                           `json:"system_max_rate_limit_per_minute,omitempty"`
+	Rollouts           []FirmwareDistributionRollout `json:"rollouts,omitempty"`
 }
 
 type FirmwareDistribution struct {

--- a/internal/videoclient/client.go
+++ b/internal/videoclient/client.go
@@ -40,6 +40,9 @@ type OTACampaignRecord struct {
 	CreatedAt           string `json:"created_at"`
 	UpdatedAt           string `json:"updated_at"`
 	ActivatedAt         string `json:"activated_at,omitempty"`
+	RateLimitPerMinute  int    `json:"rate_limit_per_minute"`
+	EffectiveRateLimit  int    `json:"effective_rate_limit_per_minute"`
+	SystemMaxRateLimit  int    `json:"system_max_rate_limit_per_minute"`
 }
 
 type OTAReleaseRecord struct {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -833,18 +833,19 @@ function App() {
     setActive('devices');
   }
 
-  async function runUpdatePlanAction(campaignId, action) {
+  async function runUpdatePlanAction(campaignId, action, payload = {}) {
     setError('');
     const response = await fetch(`/api/update-plans/${encodeURIComponent(campaignId)}/${action}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `ui-${campaignId}-${action}-${Date.now()}` },
-      body: JSON.stringify({ reason: 'Executed by an operator in Fleet Management' }),
+      body: JSON.stringify({ reason: 'Executed by an operator in Fleet Management', ...payload }),
     });
     if (!response.ok) {
       setError(`${action} failed with ${response.status}`);
-      return;
+      return false;
     }
     setRefreshTick((tick) => tick + 1);
+    return true;
   }
 
   async function handleSSOProviderSave(orgID, config) {
@@ -3210,6 +3211,7 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
   const releaseFileInput = useRef(null);
   const [planRelease, setPlanRelease] = useState('');
   const [planName, setPlanName] = useState('');
+  const [planRate, setPlanRate] = useState(100);
   const [planMessage, setPlanMessage] = useState('');
   const [scopeQuery, setScopeQuery] = useState({ region: '', group_ids: '', firmware: '', health: '' });
   const [excludedDeviceText, setExcludedDeviceText] = useState('');
@@ -3250,11 +3252,11 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
     await onStatusRefresh?.();
     setStatusRefreshing(false);
   }
-  async function runCampaignAction(campaignId, action) {
+  async function runCampaignAction(campaignId, action, payload = {}) {
     const key = `${campaignId}:${action}`;
     setCampaignActionBusy(key);
     try {
-      await onCampaignAction?.(campaignId, action);
+      return await onCampaignAction?.(campaignId, action, payload);
     } finally {
       setCampaignActionBusy('');
     }
@@ -3315,10 +3317,10 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
     if (!release || !scopePreview?.scope) { setPlanMessage('Please get a valid server scope preview first.'); return; }
     const response = await fetch('/api/update-plans', {
       method: 'POST', headers: { 'Content-Type': 'application/json', 'Idempotency-Key': `plan-${release.product_id}-${release.id || release.release_id}-${Date.now()}` },
-      body: JSON.stringify({ product_id: release.product_id, release_id: release.id || release.release_id, name: planName.trim() || `Update ${release.version}`, scope: scopePreview.scope, selector: scopePreview.scope.query, phases: [{ phase: 0, cumulative_percentage: 100, soak_seconds: 0 }], failure_policy: { minimum_sample_size: 10, failure_percentage: 10, timeout_percentage: 10 } }),
+      body: JSON.stringify({ product_id: release.product_id, release_id: release.id || release.release_id, name: planName.trim() || `Update ${release.version}`, scope: scopePreview.scope, selector: scopePreview.scope.query, phases: [{ phase: 0, cumulative_percentage: 100, soak_seconds: 0 }], failure_policy: { minimum_sample_size: 10, failure_percentage: 10, timeout_percentage: 10 }, rate_limit_per_minute: Number(planRate) }),
     });
     setPlanMessage(response.ok ? 'The update protocol has been created, please activate it below.' : 'The update plan could not be created at this time.');
-    if (response.ok) { setPlanName(''); setPlanRelease(''); setScopePreview(null); onRefresh(); }
+    if (response.ok) { setPlanName(''); setPlanRelease(''); setPlanRate(100); setScopePreview(null); onRefresh(); }
   }
   async function previewScope() {
     const release = releases.find((item) => item.id === planRelease || item.release_id === planRelease);
@@ -3369,7 +3371,7 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
     <section className="panel firmware-ota-page">
       <div className="panel-head">
         <div>
-          <h2>Firmware Update</h2>
+          <h2>Firmware OTA</h2>
           <p>Start and stop OTA rollouts, publish firmware versions, and track device progress for the selected Product.</p>
         </div>
         <button type="button" className="ghost-button" disabled={!hasSelection || statusRefreshing} onClick={refreshStatus}>{statusRefreshing ? 'Updating status…' : 'Refresh status'}</button>
@@ -3407,7 +3409,7 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
       ) : null}
 
       {hasSelection && canRelease && selectedProduct.allowed_actions?.includes('manage_updates') ? <section className="panel firmware-panel"><div className="panel-head"><div><h3>Add firmware version</h3><p>The version will be registered to {selectedProduct.name}. You can then create an update plan for the same Product.</p></div></div><form className="inline-form" onSubmit={publishRelease}><input required placeholder="Version, e.g. 1.4.3" value={releaseVersion} onChange={(event) => setReleaseVersion(event.target.value)} /><input ref={releaseFileInput} name="artifact" required type="file" accept="application/octet-stream,.bin" aria-label="Firmware binary" onChange={selectReleaseArtifact} /><input required placeholder="Hardware versions (comma separated)" value={releaseHardware} onChange={(event) => setReleaseHardware(event.target.value)} />{releaseArtifactLoading ? <div className="firmware-artifact-metadata" role="status">Calculating firmware metadata…</div> : null}{releaseArtifact ? <dl className="firmware-artifact-metadata" aria-label="Firmware binary metadata"><div><dt>File</dt><dd>{releaseArtifact.name}</dd></div><div><dt>Size</dt><dd>{formatFirmwareSize(releaseArtifact.size)}{releaseArtifact.size >= 1024 ? ` (${releaseArtifact.size.toLocaleString('en-US')} bytes)` : ''}</dd></div><div><dt>SHA-256</dt><dd><code>{releaseArtifact.sha256}</code></dd></div></dl> : null}<button type="submit" className="primary-button" disabled={releaseArtifactLoading || !releaseArtifact}>Create version</button></form>{releaseMessage ? <p className="notice">{releaseMessage}</p> : null}</section> : null}
-      {hasSelection && canManageOTA && releases.some((release) => String(release.state || '').toLowerCase() === 'published') ? <section className="panel firmware-panel"><div className="panel-head"><div><h3>Create an update plan</h3><p>Obtain the server scope preview before creating the immutable OTA plan; the browser does not determine the target count.</p></div></div><form className="inline-form" onSubmit={createUpdatePlan}><select className="select-control" required value={planRelease} onChange={(event) => { setPlanRelease(event.target.value); setScopePreview(null); }}><option value="">Select firmware version</option>{releases.filter((release) => String(release.state || '').toLowerCase() === 'published').map((release) => <option value={release.id || release.release_id} key={release.id || release.release_id}>{release.version}</option>)}</select><input placeholder="Plan name (optional)" value={planName} onChange={(event) => setPlanName(event.target.value)} /><input placeholder="Regions (comma separated)" value={scopeQuery.region} onChange={(event) => { setScopeQuery({ ...scopeQuery, region: event.target.value }); setScopePreview(null); }} /><input placeholder="Group IDs (comma separated)" value={scopeQuery.group_ids} onChange={(event) => { setScopeQuery({ ...scopeQuery, group_ids: event.target.value }); setScopePreview(null); }} /><input placeholder="Firmware versions (comma separated)" value={scopeQuery.firmware} onChange={(event) => { setScopeQuery({ ...scopeQuery, firmware: event.target.value }); setScopePreview(null); }} /><input placeholder="Health statuses (comma separated)" value={scopeQuery.health} onChange={(event) => { setScopeQuery({ ...scopeQuery, health: event.target.value }); setScopePreview(null); }} /><input className="wide-input" placeholder="Exclude device IDs (comma or space separated)" value={excludedDeviceText} onChange={(event) => { setExcludedDeviceText(event.target.value); setScopePreview(null); }} /><button type="button" className="ghost-button" disabled={scopeLoading || !planRelease} onClick={previewScope}>{scopeLoading ? 'Calculating scope…' : 'Preview server scope'}</button><button type="submit" className="primary-button" disabled={!scopePreview?.scope}>Create update plan</button></form>{scopePreview?.scope ? <div className="scope-preview-grid"><span>Target <strong>{formatNumber(scopePreview.target_count || 0)}</strong></span><span>Excluded <strong>{formatNumber(scopePreview.excluded_count || 0)}</strong></span><span>Scope <code>{scopePreview.scope.scope_hash}</code></span><span>Expires <strong>{scopePreview.scope.expires_at || '—'}</strong></span></div> : null}{planMessage ? <p className="notice">{planMessage}</p> : null}</section> : null}
+      {hasSelection && canManageOTA && releases.some((release) => String(release.state || '').toLowerCase() === 'published') ? <section className="panel firmware-panel"><div className="panel-head"><div><h3>Create an update plan</h3><p>Obtain the server scope preview before creating the immutable OTA plan; the browser does not determine the target count.</p></div></div><form className="inline-form" onSubmit={createUpdatePlan}><select className="select-control" required value={planRelease} onChange={(event) => { setPlanRelease(event.target.value); setScopePreview(null); }}><option value="">Select firmware version</option>{releases.filter((release) => String(release.state || '').toLowerCase() === 'published').map((release) => <option value={release.id || release.release_id} key={release.id || release.release_id}>{release.version}</option>)}</select><input placeholder="Plan name (optional)" value={planName} onChange={(event) => setPlanName(event.target.value)} /><label className="ota-rate-field"><span>Upgrade rate (devices/minute)</span><input required type="number" min="1" max="10000" step="1" value={planRate} onChange={(event) => setPlanRate(event.target.value)} /></label><input placeholder="Regions (comma separated)" value={scopeQuery.region} onChange={(event) => { setScopeQuery({ ...scopeQuery, region: event.target.value }); setScopePreview(null); }} /><input placeholder="Group IDs (comma separated)" value={scopeQuery.group_ids} onChange={(event) => { setScopeQuery({ ...scopeQuery, group_ids: event.target.value }); setScopePreview(null); }} /><input placeholder="Firmware versions (comma separated)" value={scopeQuery.firmware} onChange={(event) => { setScopeQuery({ ...scopeQuery, firmware: event.target.value }); setScopePreview(null); }} /><input placeholder="Health statuses (comma separated)" value={scopeQuery.health} onChange={(event) => { setScopeQuery({ ...scopeQuery, health: event.target.value }); setScopePreview(null); }} /><input className="wide-input" placeholder="Exclude device IDs (comma or space separated)" value={excludedDeviceText} onChange={(event) => { setExcludedDeviceText(event.target.value); setScopePreview(null); }} /><button type="button" className="ghost-button" disabled={scopeLoading || !planRelease} onClick={previewScope}>{scopeLoading ? 'Calculating scope…' : 'Preview server scope'}</button><button type="submit" className="primary-button" disabled={!scopePreview?.scope || Number(planRate) < 1 || Number(planRate) > 10000}>Create update plan</button></form>{scopePreview?.scope ? <div className="scope-preview-grid"><span>Target <strong>{formatNumber(scopePreview.target_count || 0)}</strong></span><span>Excluded <strong>{formatNumber(scopePreview.excluded_count || 0)}</strong></span><span>Scope <code>{scopePreview.scope.scope_hash}</code></span><span>Expires <strong>{scopePreview.scope.expires_at || '—'}</strong></span></div> : null}{planMessage ? <p className="notice">{planMessage}</p> : null}</section> : null}
       {hasSelection && releases.length ? <section className="panel firmware-panel"><div className="panel-head"><div><h3>Firmware Version</h3><p>The version must be uploaded and checked before it can be published to the update plan.</p></div></div><div className="table-wrap"><table className="data-table"><thead><tr><th>Product</th><th>Version</th><th>Status</th><th>Action</th></tr></thead><tbody>{releases.map((release) => <tr key={`${release.product_id}:${release.id || release.release_id}`}><td>{selectedProduct.name}</td><td>{release.version}</td><td>{release.state}</td><td>{canRelease && String(release.state).toLowerCase() === 'ready' ? <button type="button" className="ghost-button" onClick={() => releaseAction(release, 'publish')}>Publish</button> : null}{canRelease && String(release.state).toLowerCase() === 'published' ? <button type="button" className="link-button" onClick={() => releaseAction(release, 'revoke')}>Withdraw</button> : null}{!canRelease ? <span className="muted">Read-only</span> : null}</td></tr>)}</tbody></table></div></section> : null}
 
       {hasSelection && loading && !distribution ? <p className="empty-state">Loading {selectedProduct.name} state of the firmware.</p> : null}
@@ -3465,6 +3467,17 @@ function FirmwareOTAPage({ loading, distribution, selectedProductId, products, r
 }
 
 function FirmwareOTADashboard({ campaigns, selectedCampaignId, onSelect, onAction, canManage, busyAction }) {
+  const [rateDrafts, setRateDrafts] = useState({});
+  const [rateMessages, setRateMessages] = useState({});
+  async function updateRate(campaign) {
+    const rate = Number(rateDrafts[campaign.campaign_id] ?? campaign.rate_limit_per_minute ?? 100);
+    if (!Number.isInteger(rate) || rate < 1 || rate > 10000) {
+      setRateMessages((messages) => ({ ...messages, [campaign.campaign_id]: 'Enter a whole number from 1 to 10,000.' }));
+      return;
+    }
+    const ok = await onAction(campaign.campaign_id, 'rate-limit', { rate_limit_per_minute: rate });
+    setRateMessages((messages) => ({ ...messages, [campaign.campaign_id]: ok ? 'Upgrade rate updated.' : 'Upgrade rate could not be updated.' }));
+  }
   return (
     <section className="panel firmware-panel ota-dashboard" aria-label="OTA Dashboard">
       <div className="panel-head">
@@ -3479,6 +3492,11 @@ function FirmwareOTADashboard({ campaigns, selectedCampaignId, onSelect, onActio
             const waiting = firmwareCampaignWaitingProgress(campaign);
             const control = firmwareDashboardAction(campaign, canManage);
             const controlBusy = control && busyAction === `${campaign.campaign_id}:${control.action}`;
+            const rateBusy = busyAction === `${campaign.campaign_id}:rate-limit`;
+            const configuredRate = campaign.rate_limit_per_minute || 100;
+            const effectiveRate = campaign.effective_rate_limit_per_minute || configuredRate;
+            const systemMaxRate = campaign.system_max_rate_limit_per_minute || 10000;
+            const canChangeRate = canManage && ['draft', 'scheduled', 'active', 'paused'].includes(normalizeStatusKey(campaign.state));
             return (
               <article className={`ota-dashboard-row${selectedCampaignId === campaign.campaign_id ? ' is-selected' : ''}`} key={campaign.campaign_id}>
                 <button
@@ -3494,6 +3512,7 @@ function FirmwareOTADashboard({ campaigns, selectedCampaignId, onSelect, onActio
                   <span className="ota-dashboard-row__meta">
                     <span>Target {campaign.target_version || '—'}</span>
                     <time dateTime={campaign.started_at || undefined}>Started {formatFirmwareStartTime(campaign.started_at)}</time>
+                    <span>Rate {formatNumber(configuredRate)}/min · effective {formatNumber(effectiveRate)}/min</span>
                   </span>
                   <span className="ota-dashboard-waiting-copy">
                     <span>Waiting devices</span>
@@ -3512,6 +3531,7 @@ function FirmwareOTADashboard({ campaigns, selectedCampaignId, onSelect, onActio
                   </span>
                 </button>
                 <div className="ota-dashboard-row__actions">
+                  {canChangeRate ? <div className="ota-dashboard-rate"><label><span>Devices/minute</span><input type="number" min="1" max={systemMaxRate} step="1" value={rateDrafts[campaign.campaign_id] ?? configuredRate} onChange={(event) => setRateDrafts((rates) => ({ ...rates, [campaign.campaign_id]: event.target.value }))} /></label><button type="button" className="ghost-button" disabled={Boolean(busyAction)} onClick={() => updateRate(campaign)}>{rateBusy ? 'Saving…' : 'Update rate'}</button><small>System max {formatNumber(systemMaxRate)}/min</small>{rateMessages[campaign.campaign_id] ? <small role="status">{rateMessages[campaign.campaign_id]}</small> : null}</div> : <span className="muted">Rate {formatNumber(configuredRate)}/min · effective {formatNumber(effectiveRate)}/min</span>}
                   {control ? (
                     <button
                       type="button"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2566,6 +2566,32 @@ p {
   min-width: 104px;
 }
 
+.ota-dashboard-row__actions,
+.ota-dashboard-rate,
+.ota-dashboard-rate label {
+  display: grid;
+  gap: 8px;
+}
+
+.ota-dashboard-rate label span,
+.ota-dashboard-rate small,
+.ota-rate-field span {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.ota-dashboard-rate input {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  max-width: 150px;
+  padding: 9px 10px;
+}
+
+.ota-rate-field {
+  display: grid;
+  gap: 6px;
+}
+
 .risk-table-head {
   color: var(--muted);
   font-size: 12px;


### PR DESCRIPTION
## Summary
- require a devices-per-minute rate when creating an OTA job, defaulting to 100
- display configured, effective, and system OTA rates in the dashboard
- allow authorized operators to change the future dispatch rate at runtime
- validate 1–10,000 in the BFF and map runtime updates to the canonical Video Cloud action

## Validation
- `GOWORK=off go test ./...`
- `npm --prefix web test`
- `npm --prefix web run build`
- `git diff --check`