### PR TITLE
Update OTA rate E2E contracts

### DIFF
--- a/web/e2e/brand-fleet-pages.spec.mjs
+++ b/web/e2e/brand-fleet-pages.spec.mjs
@@ -5,7 +5,7 @@ const pages = [
   ['overview', 'Device Overview'],
   ['devices', 'Devices'],
   ['product-services', 'Products and Services'],
-  ['firmware-ota', 'Firmware Update'],
+  ['firmware-ota', 'Firmware OTA'],
   ['reports', 'Reports'],
   ['access', 'Members & Permissions'],
   ['settings', 'Settings'],
@@ -57,7 +57,7 @@ test('[UI-CA-FLEETPAGE-005] Brand Cloud overview access and settings share one n
 test('[UI-CA-FLEETPAGE-003] retired batch work route opens firmware upgrade status @brand-fleet', async ({ page }) => {
   await login(page, 'developer');
   await page.goto('/console/brand-e2e-01/jobs');
-  await expect(page.getByRole('heading', { name: 'Firmware Update' }).first()).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'Firmware OTA' }).first()).toBeVisible();
   await expect(page).toHaveURL(/\/console\/brand-e2e-01\/firmware-ota$/);
   await expect(page.getByRole('button', { name: 'Batch Tasks' })).toHaveCount(0);
 });

--- a/web/e2e/brand-fleet-staging.spec.mjs
+++ b/web/e2e/brand-fleet-staging.spec.mjs
@@ -9,7 +9,7 @@ test('[UI-CA-STAGING-002] Brandname staging read-only smoke @staging @brand-flee
     [`/console/${cloudId}/overview`, 'Device Overview'],
     [`/console/${cloudId}/devices`, 'Devices'],
     [`/console/${cloudId}/product-services`, 'Products and Services'],
-    [`/console/${cloudId}/firmware-ota`, 'Firmware Update'],
+    [`/console/${cloudId}/firmware-ota`, 'Firmware OTA'],
     [`/console/${cloudId}/reports`, 'Reports'],
   ]) {
     await page.goto(path);

--- a/web/e2e/brand-fleet-workflows.spec.mjs
+++ b/web/e2e/brand-fleet-workflows.spec.mjs
@@ -19,7 +19,7 @@ test.describe('Brandname async workflows', () => {
   test('[UI-CA-OTA-001] OTA scope preview is server calculated and immutable @brand-fleet @smoke', async ({ page }) => {
     await login(page, 'developer');
     await page.goto('/console/brand-e2e-01/firmware-ota');
-    await expectPageTitle(page, 'Firmware Update');
+    await expectPageTitle(page, 'Firmware OTA');
     const preview = await page.request.post('/api/update-plans/scope-preview', {
       headers: { 'Content-Type': 'application/json' },
       data: { product_id: 'product-alpha', query: { region: ['na'], firmware: ['v3.8.0'] }, excluded_device_ids: ['dev-e2e-001'] },
@@ -30,13 +30,13 @@ test.describe('Brandname async workflows', () => {
 
     const plan = await page.request.post('/api/update-plans', {
       headers: { 'Content-Type': 'application/json', 'Idempotency-Key': 'e2e-ota-plan-1' },
-      data: { product_id: 'product-alpha', release_id: 'release-e2e-1', name: 'E2E OTA plan', scope: scopeBody.scope },
+      data: { product_id: 'product-alpha', release_id: 'release-e2e-1', name: 'E2E OTA plan', scope: scopeBody.scope, rate_limit_per_minute: 100 },
     });
     expect([201, 202]).toContain(plan.status());
     const tampered = { ...scopeBody.scope, target_count: 999999 };
     const rejected = await page.request.post('/api/update-plans', {
       headers: { 'Content-Type': 'application/json', 'Idempotency-Key': 'e2e-ota-plan-tampered' },
-      data: { product_id: 'product-alpha', release_id: 'release-e2e-1', name: 'tampered', scope: tampered },
+      data: { product_id: 'product-alpha', release_id: 'release-e2e-1', name: 'tampered', scope: tampered, rate_limit_per_minute: 100 },
     });
     expect(rejected.status()).toBe(409);
   });


### PR DESCRIPTION
## Summary
- update firmware page expectations to the Firmware OTA heading
- include the required devices-per-minute rate in OTA plan fixtures

## Validation
- targeted Playwright desktop tests for UI-CA-FLEETPAGE-001, UI-CA-FLEETPAGE-003, and UI-CA-OTA-001 (3 passed)