### PR TITLE
Fix customer capability redirect loop

### DIFF
--- a/web/e2e/access-control.spec.mjs
+++ b/web/e2e/access-control.spec.mjs
@@ -24,3 +24,31 @@ test('[UI-CA-ACCESS-003] customer view is separated from platform navigation', a
   await page.goto('/admin/health');
   await expect(page.getByRole('heading', { name: 'Platform access denied', exact: true })).toBeVisible();
 });
+
+test('[UI-CA-ACCESS-004] missing route capability stays on the access gate without protected API requests @smoke', async ({ page }) => {
+  await login(page, 'customer');
+  const billingRequests = [];
+  page.on('request', (request) => {
+    if (new URL(request.url()).pathname.startsWith('/api/billing/')) billingRequests.push(request.url());
+  });
+
+  await page.goto('/console/billing');
+
+  await expect(page.getByRole('heading', { name: 'Brand Cloud capability required', exact: true })).toBeVisible();
+  await expect(page).toHaveURL(/\/console\/billing$/);
+  await page.waitForTimeout(1_000);
+  expect(billingRequests).toEqual([]);
+  await expect(page.getByRole('heading', { name: 'Admin Console', exact: true })).toHaveCount(0);
+});
+
+test('[UI-CA-ACCESS-005] forbidden dashboard response does not redirect an authenticated session to login @smoke', async ({ page }) => {
+  await login(page, 'customer');
+  await page.route('**/api/summary', (route) => route.fulfill({ status: 403, contentType: 'application/json', body: '{"error":"forbidden"}' }));
+
+  await page.goto('/console/overview');
+
+  await expect(page.getByText('The requested data could not be loaded. Please try again.')).toBeVisible();
+  await expect(page).toHaveURL(/\/console\/overview$/);
+  await page.waitForTimeout(1_000);
+  await expect(page.getByRole('heading', { name: 'Admin Console', exact: true })).toHaveCount(0);
+});

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -404,6 +404,11 @@ function App() {
           setLoading(false);
           return;
         }
+        if (!isMemberInvitationAccept && !isPlatformView && nextMe.kind === 'customer' && !canAccessCustomerRoute(active, nextMe.capabilities)) {
+          setBilling(null);
+          setLoading(false);
+          return;
+        }
 
         const prefix = useAdminApi ? '/api/admin' : '/api';
         const baseRequests = useAdminApi
@@ -641,7 +646,7 @@ function App() {
         }
       } catch (err) {
         if (!alive) return;
-        if (err.isAuthError) {
+        if (err.isAuthError && err.status === 401) {
           if (!isLoginRoute) {
             window.location.replace(loginPathFor(protectedPathFromLocation(window.location)));
             return;


### PR DESCRIPTION
## Summary
- stop loading protected dashboard data when the active customer lacks the route capability
- redirect to sign-in only for 401 responses, preserving valid sessions on 403
- add desktop and mobile regression coverage for the Billing capability gate

## Local verification
- `npm test` (101 passed)
- `npx playwright test e2e/access-control.spec.mjs --project=chromium` (5 passed)
- `npx playwright test e2e/access-control.spec.mjs --project=mobile` (2 passed)
- `npm run build`