### PR TITLE
Stop capability-gated routes before customer API loads

### DIFF
--- a/web/e2e/access-control.spec.mjs
+++ b/web/e2e/access-control.spec.mjs
@@ -27,17 +27,19 @@ test('[UI-CA-ACCESS-003] customer view is separated from platform navigation', a
 
 test('[UI-CA-ACCESS-004] missing route capability stays on the access gate without protected API requests @smoke', async ({ page }) => {
   await login(page, 'customer');
-  const billingRequests = [];
+  const protectedRequests = [];
   page.on('request', (request) => {
-    if (new URL(request.url()).pathname.startsWith('/api/billing/')) billingRequests.push(request.url());
+    const path = new URL(request.url()).pathname;
+    if (path === '/api/developer/brand-clouds' || path.startsWith('/api/billing/')) protectedRequests.push(path);
   });
+  await page.route('**/api/developer/brand-clouds', (route) => route.fulfill({ status: 403, contentType: 'application/json', body: '{"error":"forbidden"}' }));
 
   await page.goto('/console/billing');
 
   await expect(page.getByRole('heading', { name: 'Brand Cloud capability required', exact: true })).toBeVisible();
   await expect(page).toHaveURL(/\/console\/billing$/);
   await page.waitForTimeout(1_000);
-  expect(billingRequests).toEqual([]);
+  expect(protectedRequests).toEqual([]);
   await expect(page.getByRole('heading', { name: 'Admin Console', exact: true })).toHaveCount(0);
 });
 

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -354,29 +354,7 @@ function App() {
       try {
         const nextMe = await fetchJSON('/api/me');
         if (!alive) return;
-        const requestedCloudId = cloudIdFromPath(window.location.pathname);
-        if (nextMe.authenticated && nextMe.kind === 'customer' && requestedCloudId && requestedCloudId !== nextMe.active_org_id) {
-          const switchResponse = await fetch('/api/me/active-org', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ organization_id: requestedCloudId }) });
-          if (!switchResponse.ok) {
-            setError('This Brand Cloud is not available to the signed-in developer.');
-            setLoading(false);
-            return;
-          }
-          window.location.reload();
-          return;
-        }
         setMe(nextMe);
-
-        if (nextMe.authenticated && nextMe.kind === 'customer') {
-          const developerCloudResult = await fetchJSON('/api/developer/brand-clouds').catch((err) => {
-            if (err.isAuthError) throw err;
-            return { brand_clouds: [] };
-          });
-          if (!alive) return;
-          setDeveloperBrandClouds(developerCloudResult.brand_clouds || []);
-        } else {
-          setDeveloperBrandClouds([]);
-        }
 
         if (isLoginRoute) {
           if (nextMe.authenticated) {
@@ -408,6 +386,29 @@ function App() {
           setBilling(null);
           setLoading(false);
           return;
+        }
+
+        const requestedCloudId = cloudIdFromPath(window.location.pathname);
+        if (nextMe.kind === 'customer' && requestedCloudId && requestedCloudId !== nextMe.active_org_id) {
+          const switchResponse = await fetch('/api/me/active-org', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ organization_id: requestedCloudId }) });
+          if (!switchResponse.ok) {
+            setError('This Brand Cloud is not available to the signed-in developer.');
+            setLoading(false);
+            return;
+          }
+          window.location.reload();
+          return;
+        }
+
+        if (nextMe.kind === 'customer') {
+          const developerCloudResult = await fetchJSON('/api/developer/brand-clouds').catch((err) => {
+            if (err.isAuthError) throw err;
+            return { brand_clouds: [] };
+          });
+          if (!alive) return;
+          setDeveloperBrandClouds(developerCloudResult.brand_clouds || []);
+        } else {
+          setDeveloperBrandClouds([]);
         }
 
         const prefix = useAdminApi ? '/api/admin' : '/api';


### PR DESCRIPTION
## Summary
- evaluate login, session kind, and customer route capability before protected customer API calls
- prevent a forbidden Brand Cloud lookup from causing login/Billing redirect loops
- strengthen UI-CA-ACCESS-004 to prove no Brand Cloud or Billing requests occur behind the capability gate

## Local verification
- npm test (101 passed)
- npm run build
- npx playwright test e2e/access-control.spec.mjs --project=chromium (5 passed)
- npx playwright test e2e/access-control.spec.mjs --project=mobile (2 passed)