### PR TITLE
Preserve Cloud scope checks before capability gate

### DIFF
--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -382,21 +382,22 @@ function App() {
           setLoading(false);
           return;
         }
-        if (!isMemberInvitationAccept && !isPlatformView && nextMe.kind === 'customer' && !canAccessCustomerRoute(active, nextMe.capabilities)) {
-          setBilling(null);
-          setLoading(false);
-          return;
-        }
 
         const requestedCloudId = cloudIdFromPath(window.location.pathname);
         if (nextMe.kind === 'customer' && requestedCloudId && requestedCloudId !== nextMe.active_org_id) {
           const switchResponse = await fetch('/api/me/active-org', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ organization_id: requestedCloudId }) });
           if (!switchResponse.ok) {
-            setError('This Brand Cloud is not available to the signed-in developer.');
+            setError('Access forbidden: This Brand Cloud is not available to the signed-in developer.');
             setLoading(false);
             return;
           }
           window.location.reload();
+          return;
+        }
+
+        if (!isMemberInvitationAccept && !isPlatformView && nextMe.kind === 'customer' && !canAccessCustomerRoute(active, nextMe.capabilities)) {
+          setBilling(null);
+          setLoading(false);
           return;
         }
 


### PR DESCRIPTION
## Summary
- preserve Brand Cloud URL scope validation before the customer capability gate
- keep capability-gated routes ahead of Brand Cloud data loading
- make cross-cloud rejection explicitly report forbidden access

## Local verification
- npm run build
- npx playwright test e2e/access-control.spec.mjs e2e/brand-fleet-cloud.spec.mjs --project=chromium (7 passed)
- npx playwright test e2e/access-control.spec.mjs --project=mobile (2 passed)