### PR TITLE
Unify Cloud Admin account login and view switching

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -255,7 +255,7 @@ render human management permissions such as Manage Devices or Edit Product.
 - `POST /api/admin/brand-clouds`: Account Manager-backed brand cloud create.
 - `GET /api/admin/brand-clouds/{id}`: Account Manager-backed brand cloud read.
 - `PATCH /api/admin/brand-clouds/{id}`: Account Manager-backed brand cloud update.
-- `POST /api/admin/brand-clouds/{id}/members`: Account Manager-backed brand cloud member assignment.
+- `POST /api/admin/brand-clouds/{id}/users`: find or create a global user and assign its Account Manager-backed Brand Cloud membership.
 - `GET /assets/...`: built frontend assets.
 - `GET /*`: React SPA fallback.
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 79.9% |
+| Go total coverage | 79.8% |
 | Go coverage gate | >= 65.0% |
 | Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
@@ -28,13 +28,13 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 87.7% |
+| `rtk_cloud_admin/internal/accountclient` | 87.2% |
 | `rtk_cloud_admin/internal/app` | 80.5% |
 | `rtk_cloud_admin/internal/billingclient` | 30.2% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |
-| `rtk_cloud_admin/internal/store` | 80.2% |
+| `rtk_cloud_admin/internal/store` | 79.3% |
 | `rtk_cloud_admin/internal/videoclient` | 86.3% |
 
 ## Artifact Policy

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -103,15 +103,15 @@ paths:
         "503":
           $ref: "#/components/responses/PlainTextError"
 
-  /api/auth/customer/login:
+  /api/auth/login:
     post:
-      operationId: postApiAuthCustomerLogin
+      operationId: postApiAuthLogin
       x-rtk-feature-id: FEAT-AM-SIGNUP-001
       x-rtk-requirement-ids:
         - REQ-E2E-CA-SIGNUP-EMAIL-001
       tags: [Auth]
-      summary: Customer password login
-      description: Enabled by default; set `CUSTOMER_PASSWORD_LOGIN_ENABLED=false` to disable.
+      summary: Global human account login
+      description: Authenticates one global user, loads memberships and platform capabilities once, and creates a shared account session.
       security: []
       requestBody:
         required: true
@@ -276,41 +276,6 @@ paths:
         "503":
           $ref: "#/components/responses/PlainTextError"
 
-  /api/auth/brand-cloud/activate:
-    post:
-      operationId: postApiAuthBrandCloudActivate
-      x-rtk-feature-id: FEAT-AM-SIGNUP-001
-      x-rtk-requirement-ids:
-        - REQ-E2E-CA-SIGNUP-EMAIL-001
-      tags: [Auth]
-      summary: Set a password and activate a pending Brand Cloud user
-      description: Proxies tenant-scoped one-time activation to Account Manager, establishes an HTTP-only Admin Console session, and returns only redacted Brand/account identity fields.
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [tenant_slug, token, password]
-              properties:
-                tenant_slug:
-                  type: string
-                token:
-                  type: string
-                password:
-                  type: string
-                  minLength: 8
-      responses:
-        "200":
-          description: Brand Cloud account activation succeeded and set `rtk_admin_session`.
-        "400":
-          $ref: "#/components/responses/PlainTextError"
-        "502":
-          $ref: "#/components/responses/PlainTextError"
-        "503":
-          $ref: "#/components/responses/PlainTextError"
-
   /api/auth/forgot-password:
     post:
       operationId: postApiAuthForgotPassword
@@ -434,41 +399,6 @@ paths:
         "503":
           $ref: "#/components/responses/PlainTextError"
 
-  /api/auth/platform/login:
-    post:
-      operationId: postApiAuthPlatformLogin
-      x-rtk-feature-id: FEAT-AM-SIGNUP-001
-      x-rtk-requirement-ids:
-        - REQ-E2E-CA-SIGNUP-EMAIL-001
-      tags: [Auth, Platform Admin]
-      summary: Account Manager platform-admin password login
-      description: Authenticates Account Manager platform-admin credentials during the migration period. Local Cloud Admin break-glass login is not supported.
-      security: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/LoginRequest"
-      responses:
-        "200":
-          description: Login succeeded and set `rtk_admin_session`.
-          headers:
-            Set-Cookie:
-              schema:
-                type: string
-              description: HTTP-only `rtk_admin_session` cookie.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/StatusOK"
-        "400":
-          $ref: "#/components/responses/PlainTextError"
-        "401":
-          $ref: "#/components/responses/PlainTextError"
-        "403":
-          $ref: "#/components/responses/PlainTextError"
-
   /api/auth/logout:
     post:
       operationId: postApiAuthLogout
@@ -539,6 +469,31 @@ paths:
           $ref: "#/components/responses/PlainTextError"
         "403":
           $ref: "#/components/responses/PlainTextError"
+
+  /api/me/view:
+    post:
+      operationId: postApiMeView
+      tags: [Session]
+      summary: Switch between Customer and Platform views in the same account session
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              additionalProperties: false
+              required: [view]
+              properties:
+                view: { type: string, enum: [customer, platform] }
+      responses:
+        "200":
+          description: Session view updated without reauthentication.
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/StatusOK" }
+        "400": { $ref: "#/components/responses/PlainTextError" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
 
   /api/developer/brand-clouds:
     get:
@@ -2881,43 +2836,92 @@ paths:
         "503":
           $ref: "#/components/responses/PlainTextError"
 
-  /api/admin/brand-clouds/{brandCloudId}/members:
-    post:
-      operationId: postApiAdminBrandCloudsByBrandCloudIdMembers
-      x-rtk-feature-id: FEAT-CA-BRAND-001
-      x-rtk-requirement-ids:
-        - REQ-UI-CA-CLOUD-004
+  /api/admin/brand-clouds/{brandCloudId}/users:
+    get:
+      operationId: getApiAdminBrandCloudUsers
       tags: [Platform Admin, Brand Clouds]
-      summary: Assign a user to a brand cloud
+      summary: List global users that are members of a Brand Cloud
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudID"
+      responses:
+        "200":
+          description: Brand Cloud memberships with global user identity fields.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [users]
+                properties:
+                  users:
+                    type: array
+                    items: { $ref: "#/components/schemas/Member" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
+    post:
+      operationId: postApiAdminBrandCloudUsers
+      tags: [Platform Admin, Brand Clouds]
+      summary: Find or create a global user and add its Brand Cloud membership
       parameters:
         - $ref: "#/components/parameters/BrandCloudID"
       requestBody:
         required: true
         content:
           application/json:
-            schema:
-              $ref: "#/components/schemas/BrandCloudMemberRequest"
+            schema: { $ref: "#/components/schemas/BrandCloudAccountRequest" }
       responses:
         "201":
-          description: Member assignment created.
+          description: Global user and membership created; email activation is required for a new owner.
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [action, user, member]
+                properties:
+                  action: { type: string }
+                  user: { $ref: "#/components/schemas/User" }
+                  member: { $ref: "#/components/schemas/Member" }
+        "400": { $ref: "#/components/responses/PlainTextError" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
+
+  /api/admin/brand-clouds/{brandCloudId}/users/{userId}:
+    delete:
+      operationId: deleteApiAdminBrandCloudUserMembership
+      tags: [Platform Admin, Brand Clouds]
+      summary: Soft-delete a global user's Brand Cloud membership
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudID"
+        - { name: userId, in: path, required: true, schema: { type: string } }
+      responses:
+        "204": { description: Membership access removed. }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
+
+  /api/admin/brand-clouds/{brandCloudId}/users/{userId}/{action}:
+    post:
+      operationId: postApiAdminBrandCloudUserMembershipAction
+      tags: [Platform Admin, Brand Clouds]
+      summary: Enable or disable a global user's Brand Cloud membership
+      parameters:
+        - $ref: "#/components/parameters/BrandCloudID"
+        - { name: userId, in: path, required: true, schema: { type: string } }
+        - { name: action, in: path, required: true, schema: { type: string, enum: [enable, disable] } }
+      responses:
+        "200":
+          description: Updated membership.
           content:
             application/json:
               schema:
                 type: object
                 required: [member]
                 properties:
-                  member:
-                    $ref: "#/components/schemas/Member"
-        "400":
-          $ref: "#/components/responses/PlainTextError"
-        "401":
-          $ref: "#/components/responses/PlainTextError"
-        "403":
-          $ref: "#/components/responses/PlainTextError"
-        "502":
-          $ref: "#/components/responses/PlainTextError"
-        "503":
-          $ref: "#/components/responses/PlainTextError"
+                  member: { $ref: "#/components/schemas/Member" }
+        "401": { $ref: "#/components/responses/PlainTextError" }
+        "403": { $ref: "#/components/responses/PlainTextError" }
+        "502": { $ref: "#/components/responses/PlainTextError" }
 
   /api/admin/sso/providers:
     get:
@@ -3112,7 +3116,7 @@ components:
       required: [brand_cloud_id, target_type, target_id, csr_pem]
       properties:
         brand_cloud_id: { type: string }
-        target_type: { type: string, enum: [brand_cloud_user, end_user] }
+        target_type: { type: string, enum: [user, end_user] }
         target_id: { type: string }
         csr_pem:
           type: string
@@ -3518,6 +3522,10 @@ components:
         evaluation_device_quota:
           type: integer
         capabilities:
+          type: array
+          items:
+            type: string
+        platform_capabilities:
           type: array
           items:
             type: string
@@ -4913,28 +4921,39 @@ components:
         metadata:
           type: object
           additionalProperties: true
-    BrandCloudMemberRequest:
+    BrandCloudAccountRequest:
       type: object
-      required: [brand_cloud_user_id, role]
+      additionalProperties: false
+      required: [email, role]
       properties:
-        brand_cloud_user_id:
+        email:
           type: string
-          description: Brand-scoped user id. Platform Account Manager user ids are not accepted.
+          format: email
+        display_name:
+          type: string
         role:
           type: string
+          enum: [owner, admin, member]
+        activation_mode:
+          type: string
+          enum: [email, immediate]
+          default: email
     Member:
       type: object
-      required: [brand_cloud_id, brand_cloud_user_id, role]
+      required: [organization_id, user_id, role]
       properties:
-        brand_cloud_id:
+        organization_id:
           type: string
-        brand_cloud_user_id:
+        user_id:
           type: string
         email:
           type: string
           format: email
         role:
           type: string
+        disabled_at:
+          type: string
+          format: date-time
     SSOProviderStatus:
       type: object
       required: [organization_id, enabled, configured]

--- a/docs/platform-brand-cloud-management-design.md
+++ b/docs/platform-brand-cloud-management-design.md
@@ -308,18 +308,18 @@ Validation:
 - slug/code must be unique when provided
 - region must be one of the Account Manager-supported values
 
-#### Step 2: Initial Brand Admin
+#### Step 2: Initial Owner
 
 Fields:
 
-- Existing Brand User id, when the brand-scoped user already exists
+- Global user email
 - Initial role, default `owner`
 - Optional note for audit/support context, only if Account Manager accepts it
 
-The UI must make it clear that this flow assigns an existing brand-scoped user.
-Platform Account Manager user ids are not valid for brand-cloud membership.
-Creating or reactivating a brand-scoped user uses the Brand User form and then
-assigns membership by `brand_cloud_user_id`.
+Account Manager finds an existing global user by normalized email or creates a
+pending global user, then creates its `organization_members` owner row. A new
+owner always completes the global email activation flow before access is
+enabled; Cloud Admin never sets an owner password directly.
 
 #### Step 3: Entitlement Snapshot (optional information)
 
@@ -457,7 +457,7 @@ Disable and re-enable require confirmation because they affect a tenant-level
 organization. The confirmation copy must say what remains visible and what is
 blocked. Delete is intentionally absent.
 
-## Flow 2: Assign Existing Member
+## Flow 2: Add Global User Membership
 
 ### [REQ-CA-BRAND-MEMBER-001] Existing brand-user assignment validates and preserves upstream errors safely
 
@@ -465,25 +465,25 @@ blocked. Delete is intentionally absent.
 {"acceptance_layer":"ui","gate":"pr","environments":["local","ci"],"evidence":["json","screenshot"],"required":true,"status":"active"}
 -->
 
-Acceptance: Member assignment validates brand user and role locally, submits brand_cloud_user_id, updates inline on success, treats duplicates non-destructively, and renders Account Manager authorization/validation failures in user-safe language.
+Acceptance: Membership provisioning validates global user email and role locally, submits them to the users endpoint, updates inline on success, treats duplicates non-destructively, and renders Account Manager authorization/validation failures in user-safe language.
 
 Use a small drawer section or modal launched from the detail drawer.
 
 Fields:
 
-- Brand User id
+- Global user email
 - Role, default `owner` or `admin` depending on Account Manager contract
 
 Behavior:
 
 - validate required input locally
-- submit `brand_cloud_user_id` to `POST /api/admin/brand-clouds/{id}/members`
+- submit `email`, `role`, and `activation_mode=email` to `POST /api/admin/brand-clouds/{id}/users`
 - show success inline in the Members panel
 - show duplicate member as a non-destructive warning
 - preserve Account Manager authorization and validation messages in user-safe
   language
 
-## Flow 3: Review And Manage Brand Users
+## Flow 3: Review And Manage Brand Cloud Memberships
 
 ### [REQ-CA-BRAND-USERS-001] Brand-user lifecycle preserves activation state and audit history
 
@@ -491,11 +491,11 @@ Behavior:
 {"acceptance_layer":"ui","operation_model":"workflow","gate":"pr","environments":["local","ci"],"evidence":["json","screenshot"],"required":true,"status":"active"}
 -->
 
-Acceptance: The Account Manager-backed user table distinguishes pending, active, and disabled identities; approve/disable/enable/soft-delete refresh current state, and delete removes access without hard-deleting audit history.
+Acceptance: The Account Manager-backed membership table distinguishes pending activation, active, and disabled access; disable/enable/soft-delete refresh current state, and delete removes Brand Cloud access without deleting the global user or audit history.
 
-The detail drawer includes a Brand Users section backed by Account Manager,
-not by Admin Console SQLite. It lists brand-scoped users for the selected
-brand cloud and highlights pending activation users so Platform Admins can see
+The detail drawer includes a Users section backed by Account Manager,
+not by Admin Console SQLite. It lists global users and their memberships for the selected
+Brand Cloud and highlights pending activation users so Platform Admins can see
 which email addresses have been created but not activated.
 
 Filters:
@@ -506,23 +506,21 @@ Filters:
 - Disabled
 
 Rows show email, display name or user id, activation status, last update time,
-and lifecycle actions. Pending activation rows expose `Approve`, active rows
-expose `Disable`, disabled rows expose `Enable`, and all rows expose `Delete`.
-Delete is a soft-delete operation that removes brand-cloud access by disabling
-the brand-scoped user; it must not hard-delete Account Manager audit history.
+and lifecycle actions. Activation is completed only through the global email
+flow. Active rows expose `Disable`, disabled rows expose `Enable`, and all rows
+expose `Delete`. Delete only removes the membership; it must not delete the
+global user or Account Manager audit history.
 
 Behavior:
 
 - load users from `GET /api/admin/brand-clouds/{id}/users`
 - use `status=pending_verification` for the pending activation dashboard filter
-- submit approve to
-  `POST /api/admin/brand-clouds/{id}/users/{brandCloudUserId}/approve`
 - submit disable to
-  `POST /api/admin/brand-clouds/{id}/users/{brandCloudUserId}/disable`
+  `POST /api/admin/brand-clouds/{id}/users/{userId}/disable`
 - submit enable to
-  `POST /api/admin/brand-clouds/{id}/users/{brandCloudUserId}/enable`
+  `POST /api/admin/brand-clouds/{id}/users/{userId}/enable`
 - submit soft-delete to
-  `DELETE /api/admin/brand-clouds/{id}/users/{brandCloudUserId}`
+  `DELETE /api/admin/brand-clouds/{id}/users/{userId}`
 - refresh the Brand Users section after each successful lifecycle action
 
 ## Error And Edge States
@@ -556,12 +554,11 @@ Acceptance: Every Brand Cloud and Brand User UI operation maps to its Account Ma
 | Create brand cloud | `POST /api/admin/brand-clouds` | Account Manager |
 | Read detail | `GET /api/admin/brand-clouds/{id}` | Account Manager |
 | Update metadata/status | `PATCH /api/admin/brand-clouds/{id}` | Account Manager |
-| Assign member | `POST /api/admin/brand-clouds/{id}/members` | Account Manager |
+| Find/create global user and assign membership | `POST /api/admin/brand-clouds/{id}/users` | Account Manager |
 | List brand users | `GET /api/admin/brand-clouds/{id}/users` | Account Manager |
-| Approve pending brand user | `POST /api/admin/brand-clouds/{id}/users/{brandCloudUserId}/approve` | Account Manager |
-| Disable brand user | `POST /api/admin/brand-clouds/{id}/users/{brandCloudUserId}/disable` | Account Manager |
-| Enable brand user | `POST /api/admin/brand-clouds/{id}/users/{brandCloudUserId}/enable` | Account Manager |
-| Soft-delete brand user | `DELETE /api/admin/brand-clouds/{id}/users/{brandCloudUserId}` | Account Manager |
+| Disable membership | `POST /api/admin/brand-clouds/{id}/users/{userId}/disable` | Account Manager |
+| Enable membership | `POST /api/admin/brand-clouds/{id}/users/{userId}/enable` | Account Manager |
+| Soft-delete membership | `DELETE /api/admin/brand-clouds/{id}/users/{userId}` | Account Manager |
 
 The BFF may normalize response shape for the React UI, but it must not create
 authoritative brand-cloud rows in SQLite. Local audit may record forwarding
@@ -661,7 +658,7 @@ The implementation can be split into developer-ready issues:
 5. **Assign existing member**
    - implement member assignment UI and retry/error states
 6. **Review and manage brand users**
-   - implement Brand Users list, pending activation filter, approve, disable,
+   - implement global Users list, pending activation filter, disable,
      enable, and soft-delete actions
 7. **Browser QA and documentation signoff**
    - verify Platform View isolation, source unavailable states, responsive
@@ -676,12 +673,12 @@ The implementation can be split into developer-ready issues:
   APIs.
 - List, empty, loading, source unavailable, and missing upstream token states
   are defined and implemented.
-- Create flow supports validation, success, Account Manager failure, and
-  created-but-member-failed recovery.
+- Create flow supports validation, success, and atomic Account Manager
+  provisioning failure recovery.
 - Detail drawer exposes identity, status, setup checklist, members, SSO
   handoff, and recent activity/unavailable state.
 - Detail drawer exposes Brand Users with pending activation count, status
-  filter, approve, disable, enable, and soft-delete actions.
+  filter, disable, enable, and soft-delete actions.
 - No authoritative brand-cloud records are stored in Admin Console SQLite.
 - No secrets, upstream tokens, raw IdP claims, or raw private upstream payloads
   are displayed.
@@ -714,7 +711,7 @@ Manual browser QA covers:
 - source unavailable response
 - create success
 - create validation failure
-- created-but-member-failed partial failure
+- atomic user-plus-membership failure with no partial account write
 - mobile-width drawer/table behavior
 
 ## Open Design Questions

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -156,8 +156,8 @@ checks after startup:
 
 - `GET /healthz` returns `ok`
 - `GET /api/service-health` returns the upstream status summary
-- `POST /api/auth/platform/login` accepts Account Manager platform-admin
-  credentials and creates a platform session only after upstream authorization
+- `POST /api/auth/login` accepts global Account Manager credentials, fetches
+  memberships and platform capabilities once, and creates the shared account session
 - `GET /api/me` succeeds when the login cookie is replayed
 - `GET /api/summary` returns the dashboard summary payload
 - `GET /console` renders the dashboard shell

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -107,41 +107,20 @@ type BrandCloudRequest struct {
 	Metadata map[string]any `json:"metadata,omitempty"`
 }
 
-type BrandCloudMemberRequest struct {
-	BrandCloudUserID string `json:"brand_cloud_user_id"`
-	Role             string `json:"role"`
-}
-
-type BrandCloudUserRequest struct {
+type BrandCloudAccountRequest struct {
 	Email          string `json:"email"`
-	Password       string `json:"password"`
 	DisplayName    string `json:"display_name,omitempty"`
 	Role           string `json:"role"`
-	RotatePassword bool   `json:"rotate_password,omitempty"`
 	ActivationMode string `json:"activation_mode,omitempty"`
 }
 
-type BrandCloudUser struct {
-	ID                        string `json:"id"`
-	BrandCloudID              string `json:"brand_cloud_id"`
-	Email                     string `json:"email"`
-	DisplayName               string `json:"display_name,omitempty"`
-	EmailVerified             bool   `json:"email_verified"`
-	EmailVerifiedAt           string `json:"email_verified_at,omitempty"`
-	SignupPendingVerification bool   `json:"signup_pending_verification"`
-	CreatedAt                 string `json:"created_at"`
-	UpdatedAt                 string `json:"updated_at"`
-	DisabledAt                string `json:"disabled_at,omitempty"`
-}
-
 type Member struct {
-	OrganizationID   string   `json:"organization_id"`
-	UserID           string   `json:"user_id"`
-	BrandCloudUserID string   `json:"brand_cloud_user_id,omitempty"`
-	Email            string   `json:"email,omitempty"`
-	Role             string   `json:"role"`
-	Capabilities     []string `json:"capabilities,omitempty"`
-	DisabledAt       string   `json:"disabled_at,omitempty"`
+	OrganizationID string   `json:"organization_id"`
+	UserID         string   `json:"user_id"`
+	Email          string   `json:"email,omitempty"`
+	Role           string   `json:"role"`
+	Capabilities   []string `json:"capabilities,omitempty"`
+	DisabledAt     string   `json:"disabled_at,omitempty"`
 }
 
 type OwnerTransfer struct {
@@ -192,9 +171,9 @@ type ProductCollaboratorInvitation struct {
 }
 
 type BrandCloudUserResult struct {
-	Action           string         `json:"action"`
-	BrandCloudUser   BrandCloudUser `json:"brand_cloud_user"`
-	BrandCloudMember Member         `json:"brand_cloud_member"`
+	Action string `json:"action"`
+	User   User   `json:"user"`
+	Member Member `json:"member"`
 }
 
 type Device struct {
@@ -383,26 +362,30 @@ type LoginResult struct {
 	Tokens Tokens `json:"tokens"`
 }
 
-type BrandCloudActivationRequest struct {
-	Token    string `json:"token"`
-	Password string `json:"password"`
-}
-
-type BrandCloudActivationResult struct {
-	BrandCloud     BrandCloud     `json:"brand_cloud"`
-	BrandCloudUser BrandCloudUser `json:"brand_cloud_user"`
-	User           User           `json:"user"`
-	Tokens         Tokens         `json:"tokens"`
-}
-
 type RefreshResult struct {
 	Tokens Tokens `json:"tokens"`
 }
 
 type MeResult struct {
-	User          User           `json:"user"`
-	Organizations []Organization `json:"organizations"`
-	Capabilities  []string       `json:"capabilities,omitempty"`
+	User                  User           `json:"user"`
+	Organizations         []Organization `json:"organizations"`
+	Capabilities          []string       `json:"capabilities,omitempty"`
+	BrandCloudMemberships []Organization `json:"brand_cloud_memberships,omitempty"`
+	PlatformCapabilities  []string       `json:"platform_capabilities,omitempty"`
+}
+
+func (m MeResult) Memberships() []Organization {
+	if len(m.BrandCloudMemberships) > 0 {
+		return m.BrandCloudMemberships
+	}
+	return m.Organizations
+}
+
+func (m MeResult) EffectivePlatformCapabilities() []string {
+	if len(m.PlatformCapabilities) > 0 {
+		return m.PlatformCapabilities
+	}
+	return m.Capabilities
 }
 
 type SSOStartRequest struct {
@@ -568,15 +551,6 @@ func (c *Client) SignIn(ctx context.Context, email string) error {
 func (c *Client) ActivateLogin(ctx context.Context, token string) (LoginResult, error) {
 	var out LoginResult
 	err := c.doJSON(ctx, http.MethodPost, "/v1/auth/login/activate", "", AuthTokenRequest{Token: token}, &out)
-	return out, err
-}
-
-func (c *Client) ActivateBrandCloudUser(ctx context.Context, tenantSlug, token, password string) (BrandCloudActivationResult, error) {
-	var out BrandCloudActivationResult
-	path := "/v1/brand-clouds/" + url.PathEscape(strings.TrimSpace(tenantSlug)) + "/auth/activate"
-	err := c.doJSON(ctx, http.MethodPost, path, "", BrandCloudActivationRequest{
-		Token: token, Password: password,
-	}, &out)
 	return out, err
 }
 
@@ -1037,25 +1011,16 @@ func (c *Client) UpdateBrandCloud(ctx context.Context, accessToken, brandCloudID
 	return body.BrandCloud, err
 }
 
-func (c *Client) AssignBrandCloudMember(ctx context.Context, accessToken, brandCloudID string, req BrandCloudMemberRequest) (Member, error) {
-	var body struct {
-		Member Member `json:"member"`
-	}
-	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/members"
-	err := c.doJSON(ctx, http.MethodPost, path, accessToken, req, &body)
-	return body.Member, err
-}
-
-func (c *Client) CreateBrandCloudUser(ctx context.Context, accessToken, brandCloudID string, req BrandCloudUserRequest) (BrandCloudUserResult, int, error) {
+func (c *Client) CreateBrandCloudUser(ctx context.Context, accessToken, brandCloudID string, req BrandCloudAccountRequest) (BrandCloudUserResult, int, error) {
 	var body BrandCloudUserResult
 	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/users"
 	status, err := c.doJSONStatus(ctx, http.MethodPost, path, accessToken, req, &body)
 	return body, status, err
 }
 
-func (c *Client) BrandCloudUsers(ctx context.Context, accessToken, brandCloudID string, query url.Values) ([]BrandCloudUser, error) {
+func (c *Client) BrandCloudUsers(ctx context.Context, accessToken, brandCloudID string, query url.Values) ([]Member, error) {
 	var body struct {
-		BrandCloudUsers []BrandCloudUser `json:"brand_cloud_users"`
+		Users []Member `json:"users"`
 	}
 	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/users"
 	if len(query) > 0 {
@@ -1064,33 +1029,29 @@ func (c *Client) BrandCloudUsers(ctx context.Context, accessToken, brandCloudID 
 	if err := c.doJSON(ctx, http.MethodGet, path, accessToken, nil, &body); err != nil {
 		return nil, err
 	}
-	return body.BrandCloudUsers, nil
+	return body.Users, nil
 }
 
-func (c *Client) DisableBrandCloudUser(ctx context.Context, accessToken, brandCloudID, brandCloudUserID string) (BrandCloudUser, error) {
-	return c.brandCloudUserAction(ctx, accessToken, brandCloudID, brandCloudUserID, "disable")
+func (c *Client) DisableBrandCloudUser(ctx context.Context, accessToken, brandCloudID, userID string) (Member, error) {
+	return c.brandCloudUserAction(ctx, accessToken, brandCloudID, userID, "disable")
 }
 
-func (c *Client) EnableBrandCloudUser(ctx context.Context, accessToken, brandCloudID, brandCloudUserID string) (BrandCloudUser, error) {
-	return c.brandCloudUserAction(ctx, accessToken, brandCloudID, brandCloudUserID, "enable")
+func (c *Client) EnableBrandCloudUser(ctx context.Context, accessToken, brandCloudID, userID string) (Member, error) {
+	return c.brandCloudUserAction(ctx, accessToken, brandCloudID, userID, "enable")
 }
 
-func (c *Client) ApproveBrandCloudUser(ctx context.Context, accessToken, brandCloudID, brandCloudUserID string) (BrandCloudUser, error) {
-	return c.brandCloudUserAction(ctx, accessToken, brandCloudID, brandCloudUserID, "approve")
-}
-
-func (c *Client) DeleteBrandCloudUser(ctx context.Context, accessToken, brandCloudID, brandCloudUserID string) error {
-	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/users/" + url.PathEscape(brandCloudUserID)
+func (c *Client) DeleteBrandCloudUser(ctx context.Context, accessToken, brandCloudID, userID string) error {
+	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/users/" + url.PathEscape(userID)
 	return c.doJSON(ctx, http.MethodDelete, path, accessToken, nil, nil)
 }
 
-func (c *Client) brandCloudUserAction(ctx context.Context, accessToken, brandCloudID, brandCloudUserID, action string) (BrandCloudUser, error) {
+func (c *Client) brandCloudUserAction(ctx context.Context, accessToken, brandCloudID, userID, action string) (Member, error) {
 	var body struct {
-		BrandCloudUser BrandCloudUser `json:"brand_cloud_user"`
+		Member Member `json:"member"`
 	}
-	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/users/" + url.PathEscape(brandCloudUserID) + "/" + action
+	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/users/" + url.PathEscape(userID) + "/" + action
 	err := c.doJSON(ctx, http.MethodPost, path, accessToken, nil, &body)
-	return body.BrandCloudUser, err
+	return body.Member, err
 }
 
 func (c *Client) Devices(ctx context.Context, accessToken, orgID string) ([]Device, error) {

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -126,7 +126,7 @@ func TestClientFleetAndDeveloperWrappers(t *testing.T) {
 	check("DeveloperBrandClouds", err)
 	_, _, err = client.DeveloperBrandCloud(ctx, "access", "brand/1")
 	check("DeveloperBrandCloud", err)
-	_, err = client.IssueDeveloperPKITestAppCertificate(ctx, "access", "brand/1", "idem-1", "brand_cloud_user", "user/1", "csr")
+	_, err = client.IssueDeveloperPKITestAppCertificate(ctx, "access", "brand/1", "idem-1", "user", "user/1", "csr")
 	check("IssueDeveloperPKITestAppCertificate", err)
 	_, err = client.CreateDeveloperPKITestProductionRun(ctx, "access", "brand/1", "profile/1", "idem-2", time.Now(), time.Now().Add(24*time.Hour))
 	check("CreateDeveloperPKITestProductionRun", err)
@@ -172,7 +172,7 @@ func TestClientFleetAndDeveloperWrappers(t *testing.T) {
 	_, err = client.AcceptDeveloperOwnerTransfer(ctx, "access", "owner-token")
 	check("AcceptDeveloperOwnerTransfer", err)
 
-	_, _, err = client.CreateBrandCloudUser(ctx, "access", "brand/1", BrandCloudUserRequest{})
+	_, _, err = client.CreateBrandCloudUser(ctx, "access", "brand/1", BrandCloudAccountRequest{})
 	check("CreateBrandCloudUser", err)
 	_, err = client.Device(ctx, "access", "org/1", "device/1")
 	check("Device", err)
@@ -288,7 +288,6 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 
 	var createBody map[string]any
 	var patchBody map[string]any
-	var memberBody map[string]any
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if got := r.Header.Get("Authorization"); got != "Bearer admin-access" {
 			t.Fatalf("%s Authorization = %q, want Bearer admin-access", r.URL.Path, got)
@@ -310,23 +309,15 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 				t.Fatal(err)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": "Realtek Connect Plus", "organization_kind": "brand_cloud", "status": "disabled"}})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/members":
-			if err := json.NewDecoder(r.Body).Decode(&memberBody); err != nil {
-				t.Fatal(err)
-			}
-			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"brand_cloud_id": "brand-1", "brand_cloud_user_id": "brand-user-1", "role": "owner"}})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users":
 			if r.URL.Query().Get("status") != "pending_verification" {
 				t.Fatalf("brand user status query = %q", r.URL.Query().Get("status"))
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_users": []map[string]any{{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com", "signup_pending_verification": true}}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"user_id": "user-1", "organization_id": "brand-1", "email": "owner@example.com", "role": "owner", "disabled_at": "2026-06-11T00:00:00Z"}}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/disable":
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_user": map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com", "disabled_at": "2026-06-11T00:00:00Z"}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"user_id": "brand-user-1", "organization_id": "brand-1", "email": "owner@example.com", "disabled_at": "2026-06-11T00:00:00Z"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/enable":
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_user": map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com"}})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/approve":
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_user": map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com", "email_verified": true, "signup_pending_verification": false}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"user_id": "brand-user-1", "organization_id": "brand-1", "email": "owner@example.com"}})
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1":
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -364,18 +355,11 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 	if updated.Status != "disabled" || patchBody["status"] != "disabled" {
 		t.Fatalf("updated brand cloud = %#v body=%#v", updated, patchBody)
 	}
-	member, err := client.AssignBrandCloudMember(t.Context(), "admin-access", "brand-1", BrandCloudMemberRequest{BrandCloudUserID: "brand-user-1", Role: "owner"})
-	if err != nil {
-		t.Fatalf("AssignBrandCloudMember returned error: %v", err)
-	}
-	if member.BrandCloudUserID != "brand-user-1" || memberBody["brand_cloud_user_id"] != "brand-user-1" {
-		t.Fatalf("member = %#v body=%#v", member, memberBody)
-	}
 	users, err := client.BrandCloudUsers(t.Context(), "admin-access", "brand-1", url.Values{"status": []string{"pending_verification"}})
 	if err != nil {
 		t.Fatalf("BrandCloudUsers returned error: %v", err)
 	}
-	if len(users) != 1 || users[0].ID != "brand-user-1" || !users[0].SignupPendingVerification {
+	if len(users) != 1 || users[0].UserID != "user-1" || users[0].DisabledAt == "" {
 		t.Fatalf("brand cloud users = %#v", users)
 	}
 	disabled, err := client.DisableBrandCloudUser(t.Context(), "admin-access", "brand-1", "brand-user-1")
@@ -391,13 +375,6 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 	}
 	if enabled.DisabledAt != "" {
 		t.Fatalf("enabled brand cloud user = %#v", enabled)
-	}
-	approved, err := client.ApproveBrandCloudUser(t.Context(), "admin-access", "brand-1", "brand-user-1")
-	if err != nil {
-		t.Fatalf("ApproveBrandCloudUser returned error: %v", err)
-	}
-	if !approved.EmailVerified || approved.SignupPendingVerification {
-		t.Fatalf("approved brand cloud user = %#v", approved)
 	}
 	if err := client.DeleteBrandCloudUser(t.Context(), "admin-access", "brand-1", "brand-user-1"); err != nil {
 		t.Fatalf("DeleteBrandCloudUser returned error: %v", err)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -256,6 +256,7 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("GET /api/admin/grafana/", s.apiAdminGrafanaProxy)
 	s.mux.HandleFunc("GET /api/me", s.apiMe)
 	s.mux.HandleFunc("POST /api/me/active-org", s.apiActiveOrg)
+	s.mux.HandleFunc("POST /api/me/view", s.apiAccountView)
 	s.mux.HandleFunc("GET /api/developer/brand-clouds", s.apiDeveloperBrandClouds)
 	s.mux.HandleFunc("GET /api/developer/brand-clouds/{brandCloudID}", s.apiDeveloperBrandCloud)
 	s.mux.HandleFunc("GET /api/developer/brand-clouds/{brandCloudID}/members", s.apiDeveloperBrandCloudMembers)
@@ -276,18 +277,16 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/developer/pki/test-bundles/app", s.apiDeveloperPKITestAppBundle)
 	s.mux.HandleFunc("POST /api/developer/pki/test-bundles/device", s.apiDeveloperPKITestDeviceBundle)
 	s.mux.HandleFunc("POST /api/auth/customer/signup", s.apiCustomerSignup)
-	s.mux.HandleFunc("POST /api/auth/customer/login", s.apiCustomerLogin)
+	s.mux.HandleFunc("POST /api/auth/login", s.apiLogin)
 	s.mux.HandleFunc("POST /api/auth/customer/verify-email", s.apiCustomerVerifyEmail)
 	s.mux.HandleFunc("POST /api/auth/customer/verification-status", s.apiCustomerVerificationStatus)
 	s.mux.HandleFunc("POST /api/auth/customer/resend-verification", s.apiCustomerResendVerification)
 	s.mux.HandleFunc("POST /api/auth/sign-in", s.apiAuthSignIn)
 	s.mux.HandleFunc("POST /api/auth/login/activate", s.apiAuthLoginActivate)
-	s.mux.HandleFunc("POST /api/auth/brand-cloud/activate", s.apiAuthBrandCloudActivate)
 	s.mux.HandleFunc("POST /api/auth/forgot-password", s.apiAuthForgotPassword)
 	s.mux.HandleFunc("POST /api/auth/reset-password", s.apiAuthResetPassword)
 	s.mux.HandleFunc("POST /api/auth/sso/start", s.apiSSOStart)
 	s.mux.HandleFunc("GET /api/auth/sso/callback", s.apiSSOCallback)
-	s.mux.HandleFunc("POST /api/auth/platform/login", s.apiPlatformLogin)
 	s.mux.HandleFunc("POST /api/auth/logout", s.apiLogout)
 	s.mux.HandleFunc("POST /api/orgs/{orgId}/quota-raise-requests", s.apiQuotaRaiseRequest)
 	s.mux.HandleFunc("GET /api/billing/account", s.apiBillingAccount)
@@ -359,13 +358,11 @@ func (s *Server) routes() {
 	s.mux.HandleFunc("POST /api/admin/brand-clouds", s.apiAdminBrandClouds)
 	s.mux.HandleFunc("GET /api/admin/brand-clouds/{brandCloudId}", s.apiAdminBrandCloud)
 	s.mux.HandleFunc("PATCH /api/admin/brand-clouds/{brandCloudId}", s.apiAdminBrandCloud)
-	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/members", s.apiAdminBrandCloudMember)
 	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/users", s.apiAdminBrandCloudUser)
 	s.mux.HandleFunc("GET /api/admin/brand-clouds/{brandCloudId}/users", s.apiAdminBrandCloudUsers)
-	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/disable", s.apiAdminBrandCloudUserAction)
-	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/enable", s.apiAdminBrandCloudUserAction)
-	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}/approve", s.apiAdminBrandCloudUserAction)
-	s.mux.HandleFunc("DELETE /api/admin/brand-clouds/{brandCloudId}/users/{brandCloudUserId}", s.apiAdminBrandCloudUserAction)
+	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/users/{userId}/disable", s.apiAdminBrandCloudUserAction)
+	s.mux.HandleFunc("POST /api/admin/brand-clouds/{brandCloudId}/users/{userId}/enable", s.apiAdminBrandCloudUserAction)
+	s.mux.HandleFunc("DELETE /api/admin/brand-clouds/{brandCloudId}/users/{userId}", s.apiAdminBrandCloudUserAction)
 	s.mux.HandleFunc("GET /api/admin/chipset-providers", s.apiAdminChipsetProviders)
 	s.mux.HandleFunc("POST /api/admin/chipset-providers", s.apiAdminChipsetProviders)
 	s.mux.HandleFunc("GET /api/admin/chipset-providers/{providerId}", s.apiAdminChipsetProvider)
@@ -401,7 +398,6 @@ func (s *Server) routes() {
 		"/login",
 		"/login/check-email",
 		"/login/activate",
-		"/brand-cloud/activate",
 		"/forgot-password",
 		"/reset-password",
 		"/signup",
@@ -609,19 +605,6 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, me)
 		return
 	}
-	if session.Kind == "platform_admin" {
-		writeJSON(w, s.meAuthSettings(contracts.Me{
-			UserID:                 session.Subject,
-			Email:                  session.Email,
-			Name:                   session.Email,
-			Kind:                   session.Kind,
-			Memberships:            []contracts.Membership{},
-			Authenticated:          true,
-			Capabilities:           platformAdminCompatibilityCapabilities(),
-			UpstreamAccountManager: s.usePlatformAdminUpstream(session),
-		}))
-		return
-	}
 	me := s.meAuthSettings(contracts.Me{
 		UserID:        session.Subject,
 		Email:         session.Email,
@@ -650,10 +633,16 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		me.UserID = upstream.User.ID
 		me.Email = upstream.User.Email
 		me.Name = fallback(upstream.User.Name, upstream.User.Email)
-		for _, org := range upstream.Organizations {
+		for _, org := range upstream.Memberships() {
 			me.Memberships = append(me.Memberships, membershipFromOrganization(org))
 		}
-		me.Capabilities = aggregateMembershipCapabilities(me.Memberships, me.ActiveOrgID)
+		me.PlatformCapabilities = upstream.EffectivePlatformCapabilities()
+		if session.Kind == "platform_admin" {
+			me.Capabilities = me.PlatformCapabilities
+			me.UpstreamAccountManager = true
+		} else {
+			me.Capabilities = aggregateMembershipCapabilities(me.Memberships, me.ActiveOrgID)
+		}
 	} else {
 		memberships, err := s.demoMemberships()
 		if err != nil {
@@ -664,9 +653,57 @@ func (s *Server) apiMe(w http.ResponseWriter, r *http.Request) {
 		if me.ActiveOrgID == "" && len(memberships) > 0 {
 			me.ActiveOrgID = memberships[0].OrganizationID
 		}
-		me.Capabilities = aggregateMembershipCapabilities(me.Memberships, me.ActiveOrgID)
+		if session.Kind == "platform_admin" {
+			me.Capabilities = platformAdminCompatibilityCapabilities()
+			me.PlatformCapabilities = me.Capabilities
+		} else {
+			me.Capabilities = aggregateMembershipCapabilities(me.Memberships, me.ActiveOrgID)
+		}
 	}
 	writeJSON(w, me)
+}
+
+func (s *Server) apiAccountView(w http.ResponseWriter, r *http.Request) {
+	session, ok := s.requestSession(r)
+	if !ok {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	var body struct {
+		View string `json:"view"`
+	}
+	if json.NewDecoder(r.Body).Decode(&body) != nil {
+		http.Error(w, "view is required", http.StatusBadRequest)
+		return
+	}
+	me, _, err := s.resolveCustomerProfile(r.Context(), accountclient.Tokens{AccessToken: session.AccessToken, RefreshToken: session.RefreshToken})
+	if err != nil {
+		s.writeCustomerError(w, err)
+		return
+	}
+	kind := ""
+	switch strings.TrimSpace(body.View) {
+	case "customer":
+		if len(me.Memberships()) > 0 {
+			kind = "customer"
+		}
+	case "platform":
+		if hasAnyPlatformCapability(me.EffectivePlatformCapabilities()) {
+			kind = "platform_admin"
+		}
+	default:
+		http.Error(w, "view must be customer or platform", http.StatusBadRequest)
+		return
+	}
+	if kind == "" {
+		http.Error(w, "view is not authorized", http.StatusForbidden)
+		return
+	}
+	if err := s.sessions.UpdateSessionKind(session.ID, kind); err != nil {
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, map[string]string{"status": "ok", "kind": kind})
 }
 
 func (s *Server) meAuthSettings(me contracts.Me) contracts.Me {
@@ -1141,55 +1178,6 @@ func (s *Server) apiAuthLoginActivate(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]string{"status": "ok", "kind": kind})
 }
 
-func (s *Server) apiAuthBrandCloudActivate(w http.ResponseWriter, r *http.Request) {
-	if !s.accountClient.Enabled() {
-		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
-		return
-	}
-	var body struct {
-		TenantSlug string `json:"tenant_slug"`
-		Token      string `json:"token"`
-		Password   string `json:"password"`
-	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil ||
-		strings.TrimSpace(body.TenantSlug) == "" ||
-		strings.TrimSpace(body.Token) == "" ||
-		len(body.Password) < 8 {
-		http.Error(w, "tenant_slug, token, and password are required", http.StatusBadRequest)
-		return
-	}
-	result, err := s.accountClient.ActivateBrandCloudUser(
-		r.Context(), strings.TrimSpace(body.TenantSlug), strings.TrimSpace(body.Token), body.Password,
-	)
-	if err != nil {
-		s.writeAuthProxyError(w, err)
-		return
-	}
-	session, err := s.sessions.CreateSession(
-		"brand_cloud_user", result.BrandCloudUser.ID, result.BrandCloudUser.Email,
-		result.Tokens.AccessToken, result.Tokens.RefreshToken, result.BrandCloud.ID,
-		tokenTTL(result.Tokens),
-	)
-	if err != nil {
-		writeError(w, err)
-		return
-	}
-	setSessionCookie(w, session.ID)
-	writeJSON(w, map[string]any{
-		"status": "ok",
-		"brand_cloud": map[string]string{
-			"id":          result.BrandCloud.ID,
-			"name":        result.BrandCloud.Name,
-			"tenant_slug": result.BrandCloud.TenantSlug,
-		},
-		"account": map[string]string{
-			"id":           result.BrandCloudUser.ID,
-			"email":        result.BrandCloudUser.Email,
-			"display_name": result.BrandCloudUser.DisplayName,
-		},
-	})
-}
-
 func (s *Server) apiAuthForgotPassword(w http.ResponseWriter, r *http.Request) {
 	if !s.accountClient.Enabled() {
 		http.Error(w, "ACCOUNT_MANAGER_BASE_URL is not configured", http.StatusServiceUnavailable)
@@ -1327,6 +1315,10 @@ func (s *Server) apiQuotaRaiseRequest(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
+	s.apiLogin(w, r)
+}
+
+func (s *Server) apiLogin(w http.ResponseWriter, r *http.Request) {
 	if !s.cfg.CustomerPasswordLoginEnabled {
 		http.Error(w, "customer password sign-in is disabled", http.StatusForbidden)
 		return
@@ -1338,6 +1330,7 @@ func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
+		Next     string `json:"next,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid login request", http.StatusBadRequest)
@@ -1362,84 +1355,65 @@ func (s *Server) apiCustomerLogin(w http.ResponseWriter, r *http.Request) {
 			tokens = login.Tokens
 		}
 	}
-	if err == nil && len(me.Organizations) == 0 {
-		http.Error(w, errCustomerActiveOrgInvalid.Error(), http.StatusForbidden)
+	if err != nil {
+		s.writeCustomerError(w, err)
+		return
+	}
+	memberships := me.Memberships()
+	kind := selectAccountView(body.Next, len(memberships) > 0, hasAnyPlatformCapability(me.EffectivePlatformCapabilities()))
+	if kind == "" {
+		http.Error(w, "account has no authorized view", http.StatusForbidden)
 		return
 	}
 	activeOrgID := ""
-	if err == nil && len(me.Organizations) > 0 {
-		activeOrgID = me.Organizations[0].ID
+	if len(memberships) > 0 {
+		activeOrgID = memberships[0].ID
 	}
-	session, err := s.sessions.CreateSession("customer", login.User.ID, login.User.Email, tokens.AccessToken, tokens.RefreshToken, activeOrgID, tokenTTL(tokens))
+	session, err := s.sessions.CreateSession(kind, login.User.ID, login.User.Email, tokens.AccessToken, tokens.RefreshToken, activeOrgID, tokenTTL(tokens))
 	if err != nil {
 		writeError(w, err)
 		return
 	}
 	setSessionCookie(w, session.ID)
-	writeJSON(w, map[string]string{"status": "ok"})
+	writeJSON(w, map[string]string{"status": "ok", "kind": kind})
 }
 
-func (s *Server) apiPlatformLogin(w http.ResponseWriter, r *http.Request) {
-	var body struct {
-		Email    string `json:"email"`
-		Password string `json:"password"`
+func selectAccountView(next string, hasMembership, hasPlatformCapability bool) string {
+	next = strings.TrimSpace(next)
+	if (next == "/admin" || strings.HasPrefix(next, "/admin/")) && hasPlatformCapability {
+		return "platform_admin"
 	}
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "invalid login request", http.StatusBadRequest)
-		return
+	if (next == "/console" || strings.HasPrefix(next, "/console/")) && hasMembership {
+		return "customer"
 	}
-	body.Email = strings.TrimSpace(body.Email)
-	session, err := s.createAccountManagerPlatformSession(r.Context(), body.Email, body.Password)
-	if err != nil {
-		http.Error(w, "invalid credentials", http.StatusUnauthorized)
-		return
+	if hasMembership {
+		return "customer"
 	}
-	setSessionCookie(w, session.ID)
-	writeJSON(w, map[string]string{"status": "ok"})
-}
-
-func (s *Server) createAccountManagerPlatformSession(ctx context.Context, email, password string) (store.Session, error) {
-	if !s.accountClient.Enabled() {
-		return store.Session{}, errCustomerSessionInvalid
+	if hasPlatformCapability {
+		return "platform_admin"
 	}
-	login, err := s.accountClient.Login(ctx, email, password)
-	if err != nil {
-		return store.Session{}, err
-	}
-	if strings.TrimSpace(login.Tokens.AccessToken) == "" {
-		return store.Session{}, errCustomerSessionInvalid
-	}
-	if _, err := s.accountClient.BrandClouds(ctx, login.Tokens.AccessToken); err != nil {
-		me, meErr := s.accountClient.Me(ctx, login.Tokens.AccessToken)
-		if meErr != nil || !hasAnyPlatformCapability(me.Capabilities) {
-			return store.Session{}, err
-		}
-	}
-	return s.sessions.CreateSession("platform_admin", login.User.ID, login.User.Email, login.Tokens.AccessToken, login.Tokens.RefreshToken, "", tokenTTL(login.Tokens))
+	return ""
 }
 
 func (s *Server) createSessionFromActivatedLogin(ctx context.Context, login accountclient.LoginResult) (store.Session, string, error) {
 	if strings.TrimSpace(login.Tokens.AccessToken) == "" {
 		return store.Session{}, "", errCustomerSessionInvalid
 	}
-	if _, platformErr := s.accountClient.BrandClouds(ctx, login.Tokens.AccessToken); platformErr == nil {
-		session, sessionErr := s.sessions.CreateSession("platform_admin", login.User.ID, login.User.Email, login.Tokens.AccessToken, login.Tokens.RefreshToken, "", tokenTTL(login.Tokens))
-		return session, "platform_admin", sessionErr
-	} else if !isAccessDeniedHTTPError(platformErr) {
-		return store.Session{}, "", platformErr
-	} else if platformMe, meErr := s.accountClient.Me(ctx, login.Tokens.AccessToken); meErr == nil && hasAnyPlatformCapability(platformMe.Capabilities) {
-		session, sessionErr := s.sessions.CreateSession("platform_admin", login.User.ID, login.User.Email, login.Tokens.AccessToken, login.Tokens.RefreshToken, "", tokenTTL(login.Tokens))
-		return session, "platform_admin", sessionErr
-	}
 	me, tokens, err := s.resolveCustomerProfile(ctx, login.Tokens)
 	if err != nil {
 		return store.Session{}, "", err
 	}
-	if len(me.Organizations) == 0 {
+	memberships := me.Memberships()
+	kind := selectAccountView("", len(memberships) > 0, hasAnyPlatformCapability(me.EffectivePlatformCapabilities()))
+	if kind == "" {
 		return store.Session{}, "", errCustomerActiveOrgInvalid
 	}
-	session, err := s.sessions.CreateSession("customer", login.User.ID, login.User.Email, tokens.AccessToken, tokens.RefreshToken, me.Organizations[0].ID, tokenTTL(tokens))
-	return session, "customer", err
+	activeOrgID := ""
+	if len(memberships) > 0 {
+		activeOrgID = memberships[0].ID
+	}
+	session, err := s.sessions.CreateSession(kind, login.User.ID, login.User.Email, tokens.AccessToken, tokens.RefreshToken, activeOrgID, tokenTTL(tokens))
+	return session, kind, err
 }
 
 func (s *Server) apiLogout(w http.ResponseWriter, r *http.Request) {
@@ -5325,36 +5299,6 @@ func (s *Server) apiAdminBrandCloud(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]accountclient.BrandCloud{"brand_cloud": brandCloud})
 }
 
-func (s *Server) apiAdminBrandCloudMember(w http.ResponseWriter, r *http.Request) {
-	session, ok := s.requireUpstreamPlatformAdmin(w, r)
-	if !ok {
-		return
-	}
-	brandCloudID := strings.TrimSpace(r.PathValue("brandCloudId"))
-	if brandCloudID == "" {
-		http.Error(w, "brand cloud id is required", http.StatusBadRequest)
-		return
-	}
-	var body accountclient.BrandCloudMemberRequest
-	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, "invalid brand cloud member request", http.StatusBadRequest)
-		return
-	}
-	body.BrandCloudUserID = strings.TrimSpace(body.BrandCloudUserID)
-	body.Role = strings.TrimSpace(body.Role)
-	if body.BrandCloudUserID == "" {
-		http.Error(w, "brand_cloud_user_id is required", http.StatusBadRequest)
-		return
-	}
-	member, err := s.accountClient.AssignBrandCloudMember(r.Context(), session.AccessToken, brandCloudID, body)
-	if err != nil {
-		s.writeUpstreamReadErrorForSession(w, session.ID, err)
-		return
-	}
-	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.member.assign", brandCloudID, "", "accepted")
-	writeJSONStatus(w, http.StatusCreated, map[string]accountclient.Member{"member": member})
-}
-
 func (s *Server) apiAdminBrandCloudUser(w http.ResponseWriter, r *http.Request) {
 	session, ok := s.requireUpstreamPlatformAdmin(w, r)
 	if !ok {
@@ -5365,7 +5309,7 @@ func (s *Server) apiAdminBrandCloudUser(w http.ResponseWriter, r *http.Request) 
 		http.Error(w, "brand cloud id is required", http.StatusBadRequest)
 		return
 	}
-	var body accountclient.BrandCloudUserRequest
+	var body accountclient.BrandCloudAccountRequest
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		http.Error(w, "invalid brand cloud user request", http.StatusBadRequest)
 		return
@@ -5400,7 +5344,7 @@ func (s *Server) apiAdminBrandCloudUsers(w http.ResponseWriter, r *http.Request)
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)
 		return
 	}
-	writeJSON(w, map[string][]accountclient.BrandCloudUser{"brand_cloud_users": users})
+	writeJSON(w, map[string][]accountclient.Member{"users": users})
 }
 
 func (s *Server) apiAdminBrandCloudUserAction(w http.ResponseWriter, r *http.Request) {
@@ -5409,32 +5353,30 @@ func (s *Server) apiAdminBrandCloudUserAction(w http.ResponseWriter, r *http.Req
 		return
 	}
 	brandCloudID := strings.TrimSpace(r.PathValue("brandCloudId"))
-	brandCloudUserID := strings.TrimSpace(r.PathValue("brandCloudUserId"))
-	if brandCloudID == "" || brandCloudUserID == "" {
+	userID := strings.TrimSpace(r.PathValue("userId"))
+	if brandCloudID == "" || userID == "" {
 		http.Error(w, "brand cloud id and user id are required", http.StatusBadRequest)
 		return
 	}
 	if r.Method == http.MethodDelete {
-		if err := s.accountClient.DeleteBrandCloudUser(r.Context(), session.AccessToken, brandCloudID, brandCloudUserID); err != nil {
+		if err := s.accountClient.DeleteBrandCloudUser(r.Context(), session.AccessToken, brandCloudID, userID); err != nil {
 			s.writeUpstreamReadErrorForSession(w, session.ID, err)
 			return
 		}
-		s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.user.delete", brandCloudID, brandCloudUserID, "accepted")
+		s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.membership.delete", brandCloudID, userID, "accepted")
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	action := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/brand-clouds/"+brandCloudID+"/users/"+brandCloudUserID), "/")
+	action := strings.Trim(strings.TrimPrefix(r.URL.Path, "/api/admin/brand-clouds/"+brandCloudID+"/users/"+userID), "/")
 	var (
-		user accountclient.BrandCloudUser
-		err  error
+		member accountclient.Member
+		err    error
 	)
 	switch action {
 	case "disable":
-		user, err = s.accountClient.DisableBrandCloudUser(r.Context(), session.AccessToken, brandCloudID, brandCloudUserID)
+		member, err = s.accountClient.DisableBrandCloudUser(r.Context(), session.AccessToken, brandCloudID, userID)
 	case "enable":
-		user, err = s.accountClient.EnableBrandCloudUser(r.Context(), session.AccessToken, brandCloudID, brandCloudUserID)
-	case "approve":
-		user, err = s.accountClient.ApproveBrandCloudUser(r.Context(), session.AccessToken, brandCloudID, brandCloudUserID)
+		member, err = s.accountClient.EnableBrandCloudUser(r.Context(), session.AccessToken, brandCloudID, userID)
 	default:
 		http.NotFound(w, r)
 		return
@@ -5443,8 +5385,8 @@ func (s *Server) apiAdminBrandCloudUserAction(w http.ResponseWriter, r *http.Req
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)
 		return
 	}
-	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.user."+action, brandCloudID, brandCloudUserID, "accepted")
-	writeJSON(w, map[string]accountclient.BrandCloudUser{"brand_cloud_user": user})
+	s.auditPlatformBrandCloudAction(r, session, "platform.brand_cloud.membership."+action, brandCloudID, userID, "accepted")
+	writeJSON(w, map[string]accountclient.Member{"member": member})
 }
 
 func (s *Server) apiAdminSSOProvider(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -71,6 +71,18 @@ func TestServerHealthAndHomeRedirect(t *testing.T) {
 	}
 }
 
+func TestSelectAccountViewRequiresAValidDestinationPrefix(t *testing.T) {
+	if got := selectAccountView("/administrator", true, true); got != "customer" {
+		t.Fatalf("invalid admin-like next selected %q, want customer fallback", got)
+	}
+	if got := selectAccountView("/console-evil", false, true); got != "platform_admin" {
+		t.Fatalf("invalid console-like next selected %q, want platform fallback", got)
+	}
+	if got := selectAccountView("/admin/health", true, true); got != "platform_admin" {
+		t.Fatalf("valid admin next selected %q", got)
+	}
+}
+
 func TestReportDeviceInTimeRangeUsesLatestObservedTimestamp(t *testing.T) {
 	device := accountclient.Device{UpdatedAt: "2026-07-10T08:00:00Z", LastSeenAt: "2026-07-11T08:00:00Z"}
 	if !reportDeviceInTimeRange(device, map[string]any{"start_at": "2026-07-11", "end_at": "2026-07-11"}) {
@@ -323,6 +335,10 @@ func TestSSOStartAndCallbackCreateSessions(t *testing.T) {
 				http.Error(w, "invalid callback", http.StatusUnauthorized)
 			}
 		case "/v1/me":
+			if r.Header.Get("Authorization") == "Bearer admin-access" {
+				_ = json.NewEncoder(w).Encode(accountclient.MeResult{User: accountclient.User{ID: "admin-1", Email: "admin@example.com"}, PlatformCapabilities: []string{"platform.audit.read"}})
+				return
+			}
 			if r.Header.Get("Authorization") != "Bearer customer-access" {
 				t.Fatalf("me Authorization = %q", r.Header.Get("Authorization"))
 			}
@@ -538,7 +554,7 @@ func TestCustomerPasswordLoginCanBeDisabled(t *testing.T) {
 	})
 
 	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("customer login status = %d, body=%s", rec.Code, rec.Body.String())
 	}
@@ -577,11 +593,11 @@ func TestCustomerPasswordLoginRejectsAccountsWithoutCustomerOrganizations(t *tes
 	})
 
 	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"root@example.com","password":"secret"}`)))
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"root@example.com","password":"secret"}`)))
 	if rec.Code != http.StatusForbidden {
 		t.Fatalf("customer login status = %d, want %d; body=%s", rec.Code, http.StatusForbidden, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "active organization is not part of the current customer memberships") {
+	if !strings.Contains(rec.Body.String(), "account has no authorized view") {
 		t.Fatalf("customer login body = %s", rec.Body.String())
 	}
 	if len(rec.Result().Cookies()) != 0 {
@@ -822,11 +838,11 @@ func TestPlatformLoginRejectsLocalBreakGlassCredentials(t *testing.T) {
 	t.Parallel()
 
 	st := mustOpenStore(t)
-	srv := New(st)
+	srv := NewWithOptions(st, Options{Config: config.Config{CustomerPasswordLoginEnabled: true}})
 	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/platform/login", strings.NewReader(`{"email":"admin@example.com","password":"secret"}`)))
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("local platform login status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"admin@example.com","password":"secret"}`)))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("local account login status = %d, want %d; body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
 	}
 }
 
@@ -908,16 +924,8 @@ func TestEmailActivationAuthBFFSetsCustomerSessionCookie(t *testing.T) {
 	srv.ServeHTTP(brandActivate, httptest.NewRequest(http.MethodPost, "/api/auth/brand-cloud/activate", strings.NewReader(`{
 		"tenant_slug":"load-run-b01","token":"owner-token","password":"owner-password"
 	}`)))
-	if brandActivate.Code != http.StatusOK {
-		t.Fatalf("brand activation status = %d, body=%s", brandActivate.Code, brandActivate.Body.String())
-	}
-	if got := brandActivate.Header().Values("Set-Cookie"); !strings.Contains(strings.Join(got, ";"), "HttpOnly") {
-		t.Fatalf("brand activation did not set HTTP-only session cookie: %v", got)
-	}
-	if body := brandActivate.Body.String(); !strings.Contains(body, `"name":"RTK-LOAD-CANARY-run-b01"`) ||
-		!strings.Contains(body, `"display_name":"Load Owner"`) ||
-		strings.Contains(body, "brand-access") || strings.Contains(body, "owner-token") || strings.Contains(body, "owner-password") {
-		t.Fatalf("brand activation response is incomplete or leaked credentials: %s", body)
+	if brandActivate.Code != http.StatusMethodNotAllowed && brandActivate.Code != http.StatusNotFound {
+		t.Fatalf("retired brand activation status = %d, body=%s", brandActivate.Code, brandActivate.Body.String())
 	}
 
 	forgot := httptest.NewRecorder()
@@ -1169,7 +1177,7 @@ func TestCustomerLoginRefreshesAndProxyMode(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
@@ -1312,7 +1320,7 @@ func TestCustomerDevicesReportVideoCloudActivationFailures(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"customer@example.com","password":"secret"}`)))
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"customer@example.com","password":"secret"}`)))
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
@@ -1397,7 +1405,7 @@ func TestCustomerDevicesUseVideoCloudTransportForOnlineReadiness(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"customer@example.com","password":"secret"}`)))
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"customer@example.com","password":"secret"}`)))
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
@@ -1436,7 +1444,7 @@ func TestCustomerDevicesUseVideoCloudTransportForOnlineReadiness(t *testing.T) {
 	}
 }
 
-func TestCustomerLoginSurvivesProfileRetryFailure(t *testing.T) {
+func TestAccountLoginRejectsProfileRetryFailure(t *testing.T) {
 	t.Parallel()
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1474,23 +1482,12 @@ func TestCustomerLoginSurvivesProfileRetryFailure(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
-	if login.Code != http.StatusOK {
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	if login.Code != http.StatusBadGateway {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
-	if len(login.Result().Cookies()) != 1 {
-		t.Fatalf("login did not set cookie")
-	}
-
-	session, err := st.GetSession(login.Result().Cookies()[0].Value)
-	if err != nil {
-		t.Fatalf("GetSession returned error: %v", err)
-	}
-	if session.AccessToken != "refreshed-access" || session.RefreshToken != "refresh-2" {
-		t.Fatalf("session tokens = %#v, want refreshed tokens", session)
-	}
-	if session.ActiveOrgID != "" {
-		t.Fatalf("session active org = %q, want empty", session.ActiveOrgID)
+	if len(login.Result().Cookies()) != 0 {
+		t.Fatalf("failed login must not set a session cookie")
 	}
 }
 
@@ -1698,7 +1695,7 @@ func TestCustomerLoginMapsUpstreamFailures(t *testing.T) {
 		})
 
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
 		srv.ServeHTTP(rec, req)
 		if rec.Code != http.StatusUnauthorized {
 			t.Fatalf("login status = %d, body=%s", rec.Code, rec.Body.String())
@@ -1727,7 +1724,7 @@ func TestCustomerLoginMapsUpstreamFailures(t *testing.T) {
 		})
 
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
 		srv.ServeHTTP(rec, req)
 		if rec.Code != http.StatusBadGateway {
 			t.Fatalf("login status = %d, body=%s", rec.Code, rec.Body.String())
@@ -1760,7 +1757,7 @@ func TestCustomerLoginMapsUpstreamFailures(t *testing.T) {
 		})
 
 		rec := httptest.NewRecorder()
-		req := httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`))
 		srv.ServeHTTP(rec, req)
 		if rec.Code != http.StatusGatewayTimeout {
 			t.Fatalf("login status = %d, body=%s", rec.Code, rec.Body.String())
@@ -1877,7 +1874,7 @@ func TestCustomerUpstreamErrorsMapDeterministically(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
@@ -1961,7 +1958,7 @@ func TestCustomerDeviceDetailRejectsOutOfOrgDevice(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateSession returned error: %v", err)
 	}
-	srv := New(st)
+	srv := NewWithOptions(st, Options{Config: config.Config{CustomerPasswordLoginEnabled: true}})
 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodGet, "/api/devices/dev-003", nil)
@@ -2002,7 +1999,7 @@ func TestDeviceTelemetryDemoReturns404ForOutOfOrgDevice(t *testing.T) {
 		t.Fatalf("SeedDemoData returned error: %v", err)
 	}
 
-	srv := New(st)
+	srv := NewWithOptions(st, Options{Config: config.Config{CustomerPasswordLoginEnabled: true}})
 	session, err := st.CreateSession("customer", "u2", "customer@example.com", "access", "refresh", "org-acme", time.Hour)
 	if err != nil {
 		t.Fatalf("CreateSession returned error: %v", err)
@@ -3981,41 +3978,29 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 				t.Fatalf("patch status = %q, want disabled", body.Status)
 			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud": map[string]any{"id": "brand-1", "name": body.Name, "organization_kind": "brand_cloud", "status": body.Status}})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/members":
-			var body accountclient.BrandCloudMemberRequest
-			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-				t.Fatal(err)
-			}
-			if body.BrandCloudUserID != "brand-user-1" || body.Role != "owner" {
-				t.Fatalf("member request = %#v", body)
-			}
-			w.WriteHeader(http.StatusCreated)
-			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"brand_cloud_id": "brand-1", "brand_cloud_user_id": "brand-user-1", "role": "owner"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users":
-			var body accountclient.BrandCloudUserRequest
+			var body accountclient.BrandCloudAccountRequest
 			if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 				t.Fatal(err)
 			}
-			if body.Email != "owner@example.com" || body.Role != "owner" || body.Password == "" {
+			if body.Email != "owner@example.com" || body.Role != "owner" || body.ActivationMode != "email" {
 				t.Fatalf("brand cloud user request = %#v", body)
 			}
 			w.WriteHeader(http.StatusCreated)
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"action":             "created",
-				"brand_cloud_user":   map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com", "email_verified": true, "signup_pending_verification": false},
-				"brand_cloud_member": map[string]any{"brand_cloud_id": "brand-1", "brand_cloud_user_id": "brand-user-1", "email": "owner@example.com", "role": "owner"},
+				"action": "created",
+				"user":   map[string]any{"id": "user-1", "email": "owner@example.com", "email_verified": false, "signup_pending_verification": true},
+				"member": map[string]any{"organization_id": "brand-1", "user_id": "user-1", "email": "owner@example.com", "role": "owner"},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users":
 			if r.URL.Query().Get("status") != "pending_verification" {
 				t.Fatalf("brand cloud users status query = %q", r.URL.Query().Get("status"))
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_users": []map[string]any{{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "pending@example.com", "email_verified": false, "signup_pending_verification": true}}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"user_id": "user-1", "organization_id": "brand-1", "email": "pending@example.com", "role": "owner", "disabled_at": "2026-06-11T00:00:00Z"}}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/disable":
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_user": map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com", "disabled_at": "2026-06-11T00:00:00Z"}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"user_id": "brand-user-1", "organization_id": "brand-1", "email": "owner@example.com", "disabled_at": "2026-06-11T00:00:00Z"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/enable":
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_user": map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com"}})
-		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/approve":
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_cloud_user": map[string]any{"id": "brand-user-1", "brand_cloud_id": "brand-1", "email": "owner@example.com", "email_verified": true, "signup_pending_verification": false}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"user_id": "brand-user-1", "organization_id": "brand-1", "email": "owner@example.com"}})
 		case r.Method == http.MethodDelete && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1":
 			w.WriteHeader(http.StatusNoContent)
 		default:
@@ -4091,23 +4076,15 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 		t.Fatalf("brand cloud update status = %d, want 200; body=%s", update.Code, update.Body.String())
 	}
 
-	member := httptest.NewRecorder()
-	memberReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds/brand-1/members", strings.NewReader(`{"brand_cloud_user_id":" brand-user-1 ","role":" owner "}`))
-	memberReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
-	srv.ServeHTTP(member, memberReq)
-	if member.Code != http.StatusCreated {
-		t.Fatalf("brand cloud member status = %d, want 201; body=%s", member.Code, member.Body.String())
-	}
-
 	brandUser := httptest.NewRecorder()
-	brandUserReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds/brand-1/users", strings.NewReader(`{"email":" OWNER@example.com ","password":"secret-password","role":" owner "}`))
+	brandUserReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds/brand-1/users", strings.NewReader(`{"email":" OWNER@example.com ","role":" owner ","activation_mode":"email"}`))
 	brandUserReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
 	srv.ServeHTTP(brandUser, brandUserReq)
 	if brandUser.Code != http.StatusCreated {
 		t.Fatalf("brand cloud user status = %d, want 201; body=%s", brandUser.Code, brandUser.Body.String())
 	}
-	if !strings.Contains(brandUser.Body.String(), `"brand_cloud_user"`) {
-		t.Fatalf("brand cloud user body missing brand_cloud_user: %s", brandUser.Body.String())
+	if !strings.Contains(brandUser.Body.String(), `"user"`) || !strings.Contains(brandUser.Body.String(), `"member"`) {
+		t.Fatalf("brand cloud account body missing user/member: %s", brandUser.Body.String())
 	}
 
 	brandUsers := httptest.NewRecorder()
@@ -4117,8 +4094,8 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 	if brandUsers.Code != http.StatusOK {
 		t.Fatalf("brand cloud users status = %d, want 200; body=%s", brandUsers.Code, brandUsers.Body.String())
 	}
-	if !strings.Contains(brandUsers.Body.String(), `"signup_pending_verification":true`) {
-		t.Fatalf("brand cloud users body missing pending user: %s", brandUsers.Body.String())
+	if !strings.Contains(brandUsers.Body.String(), `"user_id":"user-1"`) {
+		t.Fatalf("brand cloud accounts body missing global user membership: %s", brandUsers.Body.String())
 	}
 
 	disableUser := httptest.NewRecorder()
@@ -4140,17 +4117,6 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 		t.Fatalf("brand cloud user enable status = %d, want 200; body=%s", enableUser.Code, enableUser.Body.String())
 	}
 
-	approveUser := httptest.NewRecorder()
-	approveUserReq := httptest.NewRequest(http.MethodPost, "/api/admin/brand-clouds/brand-1/users/brand-user-1/approve", nil)
-	approveUserReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
-	srv.ServeHTTP(approveUser, approveUserReq)
-	if approveUser.Code != http.StatusOK {
-		t.Fatalf("brand cloud user approve status = %d, want 200; body=%s", approveUser.Code, approveUser.Body.String())
-	}
-	if !strings.Contains(approveUser.Body.String(), `"email_verified":true`) {
-		t.Fatalf("brand cloud user approve body missing verified state: %s", approveUser.Body.String())
-	}
-
 	deleteUser := httptest.NewRecorder()
 	deleteUserReq := httptest.NewRequest(http.MethodDelete, "/api/admin/brand-clouds/brand-1/users/brand-user-1", nil)
 	deleteUserReq.AddCookie(&http.Cookie{Name: "rtk_admin_session", Value: upstreamSession.ID})
@@ -4169,12 +4135,10 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 	for _, action := range []string{
 		"platform.brand_cloud.create",
 		"platform.brand_cloud.update",
-		"platform.brand_cloud.member.assign",
 		"platform.brand_cloud.user.create_or_reactivate",
-		"platform.brand_cloud.user.disable",
-		"platform.brand_cloud.user.enable",
-		"platform.brand_cloud.user.approve",
-		"platform.brand_cloud.user.delete",
+		"platform.brand_cloud.membership.disable",
+		"platform.brand_cloud.membership.enable",
+		"platform.brand_cloud.membership.delete",
 	} {
 		if !auditActions[action] {
 			t.Errorf("audit action %q was not recorded", action)
@@ -4665,7 +4629,7 @@ func TestCustomerUpstreamLifecycleIsIdempotentAndDurable(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
@@ -4921,7 +4885,7 @@ func TestDeactivateDoesNotReturnOpenProvisionOperation(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
@@ -4993,7 +4957,7 @@ func TestCustomerUpstreamLifecycleFailurePersistsFailedOperation(t *testing.T) {
 	})
 
 	login := httptest.NewRecorder()
-	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/customer/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
+	srv.ServeHTTP(login, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"user@example.com","password":"secret"}`)))
 	if login.Code != http.StatusOK {
 		t.Fatalf("login status = %d, body=%s", login.Code, login.Body.String())
 	}
@@ -5052,16 +5016,16 @@ func TestPlatformAdminLogin(t *testing.T) {
 	if err := st.Migrate(); err != nil {
 		t.Fatalf("Migrate returned error: %v", err)
 	}
-	srv := New(st)
+	srv := NewWithOptions(st, Options{Config: config.Config{CustomerPasswordLoginEnabled: true}})
 	blocked := httptest.NewRecorder()
 	srv.ServeHTTP(blocked, httptest.NewRequest(http.MethodGet, "/api/admin/audit", nil))
 	if blocked.Code != http.StatusUnauthorized {
 		t.Fatalf("admin audit without session status = %d, want %d", blocked.Code, http.StatusUnauthorized)
 	}
 	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/platform/login", strings.NewReader(`{"email":"admin@example.com","password":"secret"}`)))
-	if rec.Code != http.StatusUnauthorized {
-		t.Fatalf("platform login without Account Manager status = %d, want %d; body=%s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"admin@example.com","password":"secret"}`)))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("account login without Account Manager status = %d, want %d; body=%s", rec.Code, http.StatusServiceUnavailable, rec.Body.String())
 	}
 }
 
@@ -5083,11 +5047,11 @@ func TestPlatformAdminLoginFallsBackToAccountManagerPlatformAdmin(t *testing.T) 
 				User:   accountclient.User{ID: "root-1", Email: "root@example.com", Name: "Root"},
 				Tokens: accountclient.Tokens{AccessToken: "admin-access", RefreshToken: "admin-refresh", ExpiresIn: 3600},
 			})
-		case "/v1/admin/brand-clouds":
+		case "/v1/me":
 			if r.Header.Get("Authorization") != "Bearer admin-access" {
-				t.Fatalf("brand clouds Authorization = %q", r.Header.Get("Authorization"))
+				t.Fatalf("me Authorization = %q", r.Header.Get("Authorization"))
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"brand_clouds": []accountclient.BrandCloud{}})
+			_ = json.NewEncoder(w).Encode(accountclient.MeResult{User: accountclient.User{ID: "root-1", Email: "root@example.com"}, PlatformCapabilities: []string{"platform.brand_cloud.read"}})
 		default:
 			http.NotFound(w, r)
 		}
@@ -5096,12 +5060,12 @@ func TestPlatformAdminLoginFallsBackToAccountManagerPlatformAdmin(t *testing.T) 
 
 	st := mustOpenStore(t)
 	srv := NewWithOptions(st, Options{
-		Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+		Config:        config.Config{AccountManagerBaseURL: upstream.URL, CustomerPasswordLoginEnabled: true},
 		AccountClient: accountclient.New(upstream.URL),
 	})
 
 	rec := httptest.NewRecorder()
-	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/platform/login", strings.NewReader(`{"email":"root@example.com","password":"secret"}`)))
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"email":"root@example.com","password":"secret"}`)))
 	if rec.Code != http.StatusOK {
 		t.Fatalf("platform login status = %d, body=%s", rec.Code, rec.Body.String())
 	}

--- a/internal/app/developer_pki_test.go
+++ b/internal/app/developer_pki_test.go
@@ -57,7 +57,7 @@ func TestDeveloperPKIAppBundleProxy(t *testing.T) {
 	defer upstream.Close()
 
 	srv, sessionID := newDeveloperPKITestServer(t, upstream.URL, "")
-	req := developerPKIRequest(t, sessionID, "/api/developer/pki/test-bundles/app", "idem-app", `{"brand_cloud_id":"brand-1","target_type":"brand_cloud_user","target_id":"user-1","csr_pem":"CSR"}`)
+	req := developerPKIRequest(t, sessionID, "/api/developer/pki/test-bundles/app", "idem-app", `{"brand_cloud_id":"brand-1","target_type":"user","target_id":"user-1","csr_pem":"CSR"}`)
 	rec := httptest.NewRecorder()
 	srv.ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK || rec.Header().Get("Content-Type") != certificateBundleMIME || rec.Header().Get("Cache-Control") != "no-store" {

--- a/internal/app/store_ports.go
+++ b/internal/app/store_ports.go
@@ -12,6 +12,7 @@ type sessionStore interface {
 	GetSession(id string) (store.Session, error)
 	UpdateSessionActiveOrg(id, orgID string) error
 	UpdateSessionTokens(id, accessToken, refreshToken string, ttl time.Duration) error
+	UpdateSessionKind(id, kind string) error
 	DeleteSession(id string) error
 }
 

--- a/internal/billingclient/client.go
+++ b/internal/billingclient/client.go
@@ -344,7 +344,7 @@ func (c *Client) doHeaders(ctx context.Context, method, path, actorID, permissio
 
 func (c *Client) headers(req *http.Request, actorID, permission string) {
 	req.Header.Set("Authorization", "Bearer "+c.serviceToken)
-	req.Header.Set("X-Billing-Actor-Type", "brand_cloud_user")
+	req.Header.Set("X-Billing-Actor-Type", "user")
 	req.Header.Set("X-Billing-Actor-ID", actorID)
 	req.Header.Set("X-Billing-Permissions", permission)
 }

--- a/internal/contracts/contracts.go
+++ b/internal/contracts/contracts.go
@@ -411,6 +411,7 @@ type Me struct {
 	DemoMode                     bool         `json:"demo_mode"`
 	Authenticated                bool         `json:"authenticated"`
 	Capabilities                 []string     `json:"capabilities,omitempty"`
+	PlatformCapabilities         []string     `json:"platform_capabilities,omitempty"`
 	UpstreamAccountManager       bool         `json:"upstream_account_manager"`
 	CustomerPasswordLoginEnabled bool         `json:"customer_password_login_enabled"`
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -593,6 +593,14 @@ func (s *Store) UpdateSessionTokens(id, accessToken, refreshToken string, ttl ti
 	return err
 }
 
+func (s *Store) UpdateSessionKind(id, kind string) error {
+	if kind != "customer" && kind != "platform_admin" {
+		return fmt.Errorf("invalid session kind")
+	}
+	_, err := s.db.Exec(`UPDATE sessions SET kind = ? WHERE id = ?`, kind, id)
+	return err
+}
+
 func (s *Store) DeleteSession(id string) error {
 	_, err := s.db.Exec(`DELETE FROM sessions WHERE id = ?`, id)
 	return err

--- a/web/e2e/fixtures/session.mjs
+++ b/web/e2e/fixtures/session.mjs
@@ -1,7 +1,7 @@
 import { expect } from '@playwright/test';
 
 export async function login(page, kind) {
-  const endpoint = kind.startsWith('platform_') ? '/api/auth/platform/login' : '/api/auth/customer/login';
+	const endpoint = '/api/auth/login';
   const customerIdentity = {
     customer: ['customer@example.com', 'e2e-customer-password'],
     developer: ['developer@example.com', 'e2e-developer-password'],
@@ -14,7 +14,8 @@ export async function login(page, kind) {
     platform_reader: ['platform.reader@example.com', 'e2e-platform-reader-password'],
   };
   const [email, password] = platformIdentity[kind] || customerIdentity[kind] || customerIdentity.customer;
-  const response = await page.request.post(endpoint, { data: { email, password } });
+	const next = kind.startsWith('platform_') ? '/admin' : '/console';
+	const response = await page.request.post(endpoint, { data: { email, password, next } });
   expect(response.ok()).toBeTruthy();
 }
 

--- a/web/scripts/e2e-fixture-server.mjs
+++ b/web/scripts/e2e-fixture-server.mjs
@@ -352,7 +352,7 @@ async function handleDeveloperResource(req, res, url) {
     if (!invitation || invitation.status !== 'pending' || new Date(invitation.expires_at) <= new Date()) return send(res, 404, { code: 'INVITATION_NOT_FOUND', message: 'Invitation is invalid or expired.' });
     invitation.status = 'accepted';
     invitation.accepted_at = new Date().toISOString();
-    const member = { organization_id: invitation.brand_cloud_id, brand_cloud_user_id: invitation.target_user_id, email: invitation.target_email, role: invitation.role, capabilities: [] };
+    const member = { organization_id: invitation.brand_cloud_id, user_id: invitation.target_user_id, email: invitation.target_email, role: invitation.role, capabilities: [] };
     state.members.push(member);
     return send(res, 200, { invitation: publicInvitation(invitation), member });
   }
@@ -370,7 +370,7 @@ async function handleDeveloperResource(req, res, url) {
   const clouds = state.brandClouds.map((brand) => ({ ...brand, role: 'owner', capabilities: customerProfile(req).organizations.find((item) => item.id === brand.id)?.capabilities || [] }));
   if (!cloudID && req.method === 'GET') return send(res, 200, { brand_clouds: clouds, pagination: { limit: 25, offset: 0, total: clouds.length }, developer_cloud_limit: 5 });
   if (!clouds.some((brand) => brand.id === cloudID)) return send(res, 403, { code: 'MEMBERSHIP_REQUIRED', message: 'Current developer is not a member of this Brand Cloud.' });
-  if (!suffix && req.method === 'GET') return send(res, 200, { brand_cloud: clouds.find((brand) => brand.id === cloudID), membership: { organization_id: cloudID, brand_cloud_user_id: 'customer-user', role: 'owner', capabilities: clouds.find((brand) => brand.id === cloudID).capabilities } });
+  if (!suffix && req.method === 'GET') return send(res, 200, { brand_cloud: clouds.find((brand) => brand.id === cloudID), membership: { organization_id: cloudID, user_id: 'customer-user', role: 'owner', capabilities: clouds.find((brand) => brand.id === cloudID).capabilities } });
   if (suffix === '/members' && req.method === 'GET') return send(res, 200, { members: state.members.filter((member) => member.organization_id === cloudID), pagination: { limit: 25, offset: 0, total: state.members.filter((member) => member.organization_id === cloudID).length } });
   if (suffix === '/members/invitations' && req.method === 'GET') return send(res, 200, { invitations: state.invitations.filter((invitation) => invitation.brand_cloud_id === cloudID).map(publicInvitation) });
   if (suffix === '/members/invitations' && req.method === 'POST') {
@@ -394,7 +394,7 @@ async function handleDeveloperResource(req, res, url) {
   }
   const memberMatch = suffix.match(/^\/members\/([^/]+)(?:\/(disable|enable))?$/);
   if (memberMatch) {
-    const member = state.members.find((item) => item.brand_cloud_user_id === decodeURIComponent(memberMatch[1]) && item.organization_id === cloudID);
+    const member = state.members.find((item) => item.user_id === decodeURIComponent(memberMatch[1]) && item.organization_id === cloudID);
     if (!member) return send(res, 404, { error: 'member not found' });
     if (memberMatch[2] === 'disable') member.disabled_at = new Date().toISOString();
     if (memberMatch[2] === 'enable') delete member.disabled_at;
@@ -445,30 +445,22 @@ async function handleResource(req, res, root, id, suffix) {
     Object.assign(brand, await readBody(req));
     return send(res, 200, { brand_cloud: brand });
   }
-  if (suffix === '/members' && req.method === 'POST') {
-    if (process.env.E2E_FAIL_ACTION === 'member-assign') return send(res, 502, { error: 'fixture member assignment failure' });
-    const body = await readBody(req);
-    const user = state.users.find((item) => item.id === body.brand_cloud_user_id);
-    const member = { organization_id: id, user_id: body.brand_cloud_user_id, brand_cloud_user_id: body.brand_cloud_user_id, email: user?.email || '', role: body.role || 'owner' };
-    state.members.push(member);
-    return send(res, 201, { member });
-  }
-  if (suffix === '/users' && req.method === 'GET') return send(res, 200, { brand_cloud_users: state.users.filter((user) => user.brand_cloud_id === id) });
+  if (suffix === '/users' && req.method === 'GET') return send(res, 200, { users: state.members.filter((member) => member.organization_id === id) });
   if (suffix === '/users' && req.method === 'POST') {
     const body = await readBody(req);
-    const user = { id: `bcu-created-${state.users.length + 1}`, brand_cloud_id: id, email: body.email, display_name: body.display_name || 'E2E Created User', email_verified: false, signup_pending_verification: true, created_at: new Date().toISOString(), updated_at: new Date().toISOString() };
+    const user = { id: `user-created-${state.users.length + 1}`, email: body.email, name: body.display_name || 'E2E Created User', email_verified: false, signup_pending_verification: true, created_at: new Date().toISOString(), updated_at: new Date().toISOString() };
+    const member = { organization_id: id, user_id: user.id, email: user.email, role: body.role || 'member', disabled_at: new Date().toISOString() };
     state.users.push(user);
-    return send(res, 201, { action: 'created', brand_cloud_user: user, brand_cloud_member: { organization_id: id, brand_cloud_user_id: user.id, email: user.email, role: body.role || 'member' } });
+    state.members.push(member);
+    return send(res, 201, { action: 'created', user, member });
   }
-  const userAction = suffix.match(/^\/users\/([^/]+)(?:\/(disable|enable|approve))?$/);
+  const userAction = suffix.match(/^\/users\/([^/]+)(?:\/(disable|enable))?$/);
   if (userAction) {
-    const user = state.users.find((item) => item.id === decodeURIComponent(userAction[1]));
-    if (!user) return send(res, 404, { error: 'user not found' });
-    if (userAction[2] === 'disable') user.disabled_at = new Date().toISOString();
-    if (userAction[2] === 'enable') delete user.disabled_at;
-    if (userAction[2] === 'approve') user.signup_pending_verification = false;
-    if (req.method === 'DELETE') user.disabled_at = new Date().toISOString();
-    return send(res, 200, { brand_cloud_user: user });
+    const member = state.members.find((item) => item.user_id === decodeURIComponent(userAction[1]) && item.organization_id === id);
+    if (!member) return send(res, 404, { error: 'member not found' });
+    if (userAction[2] === 'disable' || req.method === 'DELETE') member.disabled_at = new Date().toISOString();
+    if (userAction[2] === 'enable') delete member.disabled_at;
+    return send(res, 200, { member });
   }
   return send(res, 404, { error: 'not found' });
 }

--- a/web/scripts/load-owner-activation-live-e2e.mjs
+++ b/web/scripts/load-owner-activation-live-e2e.mjs
@@ -15,11 +15,10 @@ const imapUID = Number(requiredEnv('LOAD_OWNER_IMAP_UID'));
 const parsedActivationURL = new URL(activationURL);
 if (
   parsedActivationURL.origin !== expectedOrigin ||
-  parsedActivationURL.pathname.replace(/\/$/, '') !== '/brand-cloud/activate' ||
-  parsedActivationURL.searchParams.get('tenant') !== expectedTenant ||
+  parsedActivationURL.pathname.replace(/\/$/, '') !== '/signup/verify' ||
   !parsedActivationURL.searchParams.get('token')
 ) {
-  throw new Error('activation URL does not match the expected staging tenant');
+  throw new Error('activation URL is not a global signup verification URL');
 }
 
 const browser = await chromium.launch().catch(() => chromium.launch({ channel: 'chrome' }));
@@ -30,30 +29,36 @@ try {
   page.on('response', (response) => {
     if (
       response.request().method() === 'POST' &&
-      new URL(response.url()).pathname === '/api/auth/brand-cloud/activate'
+      new URL(response.url()).pathname === '/api/auth/customer/verify-email'
     ) activationResponse = response;
   });
   await page.goto(activationURL, { waitUntil: 'networkidle' });
-  await page.getByPlaceholder('New password').fill(password);
-  await page.getByRole('button', { name: 'Activate account' }).click();
-  await page.getByText(`Activated ${expectedDisplayName} for ${expectedBrandName}.`, { exact: true }).waitFor({ timeout: 30_000 });
+  await page.getByLabel('New password', { exact: true }).fill(password);
+  await page.getByRole('button', { name: 'Verify and continue', exact: true }).click();
+  await page.waitForURL(/\/console\//, { timeout: 30_000 });
   if (!activationResponse || activationResponse.status() !== 200) {
     throw new Error(`brand owner activation returned HTTP ${activationResponse?.status() || 'unknown'}`);
   }
-  const body = await activationResponse.json();
-  if (
-    body.brand_cloud?.name !== expectedBrandName ||
-    body.brand_cloud?.tenant_slug !== expectedTenant ||
-    body.account?.email !== expectedEmail ||
-    body.account?.display_name !== expectedDisplayName
-  ) {
-    throw new Error('activation response did not match the resolved brand plan');
+  const meResponse = await page.request.get(`${expectedOrigin}/api/me`);
+  const me = await meResponse.json();
+  if (!meResponse.ok() || me.email !== expectedEmail || !me.memberships?.some((item) => item.organization === expectedBrandName && item.role === 'owner')) {
+    throw new Error(`activated global account did not expose owner membership for ${expectedTenant}`);
   }
   const cookies = await context.cookies(expectedOrigin);
   if (!cookies.some((cookie) => cookie.name === 'rtk_admin_session' && cookie.httpOnly)) {
     throw new Error('activation did not establish an HTTP-only Admin Console session');
   }
+  await page.request.post(`${expectedOrigin}/api/auth/logout`);
   await context.close();
+
+  const loginContext = await browser.newContext();
+  const loginPage = await loginContext.newPage();
+  await loginPage.goto(`${expectedOrigin}/login`, { waitUntil: 'networkidle' });
+  await loginPage.getByLabel('Email', { exact: true }).fill(expectedEmail);
+  await loginPage.getByLabel('Password', { exact: true }).fill(password);
+  await loginPage.getByRole('button', { name: 'Login', exact: true }).click();
+  await loginPage.waitForURL(/\/console\//, { timeout: 30_000 });
+  await loginContext.close();
 
   const replayContext = await browser.newContext();
   const replayPage = await replayContext.newPage();
@@ -61,12 +66,12 @@ try {
   replayPage.on('response', (response) => {
     if (
       response.request().method() === 'POST' &&
-      new URL(response.url()).pathname === '/api/auth/brand-cloud/activate'
+      new URL(response.url()).pathname === '/api/auth/customer/verify-email'
     ) replayResponse = response;
   });
   await replayPage.goto(activationURL, { waitUntil: 'networkidle' });
-  await replayPage.getByPlaceholder('New password').fill(password);
-  await replayPage.getByRole('button', { name: 'Activate account' }).click();
+  await replayPage.getByLabel('New password', { exact: true }).fill(password);
+  await replayPage.getByRole('button', { name: 'Verify and continue', exact: true }).click();
   await replayPage.locator('.error').first().waitFor({ state: 'visible', timeout: 30_000 });
   if (!replayResponse || replayResponse.status() !== 400) {
     throw new Error(`replayed activation token returned HTTP ${replayResponse?.status() || 'unknown'}`);

--- a/web/src/http.test.mjs
+++ b/web/src/http.test.mjs
@@ -49,7 +49,7 @@ test('postJSON throws on failed quota raise responses', async () => {
 test('postJSON returns parsed JSON for successful responses', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (url, init) => {
-    assert.equal(url, '/api/auth/customer/login');
+    assert.equal(url, '/api/auth/login');
     assert.equal(init.method, 'POST');
     assert.equal(init.headers['Content-Type'], 'application/json');
     assert.equal(init.body, JSON.stringify({ email: 'owner@example.com' }));
@@ -60,7 +60,7 @@ test('postJSON returns parsed JSON for successful responses', async () => {
     };
   };
 
-  const payload = await postJSON('/api/auth/customer/login', { email: 'owner@example.com' });
+  const payload = await postJSON('/api/auth/login', { email: 'owner@example.com' });
   assert.deepEqual(payload, {
     status: 'ok',
     user: { email: 'owner@example.com' },
@@ -89,7 +89,7 @@ test('postJSON propagates network failures', async () => {
   };
 
   await assert.rejects(
-    () => postJSON('/api/auth/customer/login', { email: 'owner@example.com' }),
+    () => postJSON('/api/auth/login', { email: 'owner@example.com' }),
     /network unavailable/,
   );
 

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -289,7 +289,7 @@ function App() {
   const mobileMenuButtonRef = useRef(null);
   const isPublicRoute = isPublicRouteId(active);
   const isLoginRoute = active === 'login';
-  const isAuthEntryRoute = active === 'login' || active === 'login-check-email' || active === 'login-activate' || active === 'brand-cloud-activate' || active === 'forgot-password' || active === 'reset-password';
+  const isAuthEntryRoute = active === 'login' || active === 'login-check-email' || active === 'login-activate' || active === 'forgot-password' || active === 'reset-password';
   const isPlatformView = isPlatformRouteId(active);
   const isMemberInvitationAccept = active === 'brand-cloud-member-invitation-accept' || active === 'product-collaborator-invitation-accept';
   const navigationRoute = me?.kind === 'platform_admin' ? 'platform-dashboard' : me?.kind === 'customer' ? 'overview' : active;
@@ -903,13 +903,6 @@ function App() {
     try {
       const result = await postJSON('/api/admin/brand-clouds', payload.brandCloud);
       let memberError = '';
-      if (payload.initialMember?.brand_cloud_user_id) {
-        try {
-          await postJSON(`/api/admin/brand-clouds/${encodeURIComponent(result.brand_cloud.id)}/members`, payload.initialMember);
-        } catch (err) {
-          memberError = userFacingBrandCloudError(err);
-        }
-      }
       if (payload.initialUser?.email) {
         try {
           await postJSON(`/api/admin/brand-clouds/${encodeURIComponent(result.brand_cloud.id)}/users`, payload.initialUser);
@@ -935,17 +928,6 @@ function App() {
       const result = await sendJSONWithMethod('PATCH', `/api/admin/brand-clouds/${encodeURIComponent(brandCloudID)}`, patch);
       setBrandClouds((brands) => brands.map((brand) => brand.id === brandCloudID ? result.brand_cloud : brand));
       return result.brand_cloud;
-    } catch (err) {
-      const message = userFacingBrandCloudError(err);
-      setError(message);
-      throw new Error(message);
-    }
-  }
-
-  async function handleAssignBrandCloudMember(brandCloudID, payload) {
-    setError('');
-    try {
-      return await postJSON(`/api/admin/brand-clouds/${encodeURIComponent(brandCloudID)}/members`, payload);
     } catch (err) {
       const message = userFacingBrandCloudError(err);
       setError(message);
@@ -982,40 +964,14 @@ function App() {
   async function handlePasswordLogin(credentials) {
     setError('');
     const nextPath = loginNextFromLocation(window.location);
-    const order = passwordLoginOrderForNext(nextPath);
-    const errors = {};
-    for (const kind of order) {
-      try {
-        if (kind === 'platform') {
-          await postJSON('/api/auth/platform/login', credentials);
-          window.location.assign(destinationForSession({ authenticated: true, kind: 'platform_admin' }, nextPath));
-          return;
-        }
-        await postJSON('/api/auth/customer/login', credentials);
-        window.location.assign(destinationForSession({ authenticated: true, kind: 'customer' }, nextPath));
-        return;
-      } catch (err) {
-        errors[kind] = err;
-      }
+    try {
+      const result = await postJSON('/api/auth/login', { ...credentials, next: nextPath });
+      window.location.assign(destinationForSession({ authenticated: true, kind: result.kind }, nextPath));
+    } catch (err) {
+      if (err?.status === 401 || /invalid credentials/i.test(err?.message || '')) throw new Error('Email or password is incorrect.');
+      if (err?.status === 403) throw new Error('This account does not have access to an available view.');
+      throw new Error('Sign-in is temporarily unavailable. Please try again later.');
     }
-
-    const message = `${errors.customer?.message || ''}\n${errors.platform?.message || ''}`;
-    if (order[0] === 'platform' && message.includes('platform password sign-in is disabled')) {
-      const nextError = 'Platform password sign-in is not enabled for this environment.';
-      throw new Error(nextError);
-    }
-    if (order[0] === 'customer' && message.includes('customer password sign-in is disabled')) {
-      const nextError = 'Password sign-in is not enabled for this environment.';
-      throw new Error(nextError);
-    }
-    if (((errors.customer?.status === 401 || errors.customer?.status === 403) &&
-      (errors.platform?.status === 401 || errors.platform?.status === 403)) ||
-      /invalid credentials/i.test(message)) {
-      const nextError = 'Email or password is incorrect.';
-      throw new Error(nextError);
-    }
-    const nextError = 'Sign-in is temporarily unavailable. Please try again later.';
-    throw new Error(nextError);
   }
 
   async function handleLoginActivate(token) {
@@ -1024,16 +980,6 @@ function App() {
       const result = await postJSON('/api/auth/login/activate', { token });
       window.location.assign(destinationForSession({ authenticated: true, kind: result.kind || 'customer' }, loginNextFromLocation(window.location)));
       return result;
-    } catch (err) {
-      const nextError = userFacingLoginActivationError(err);
-      throw new Error(nextError);
-    }
-  }
-
-  async function handleBrandCloudActivate(payload) {
-    setError('');
-    try {
-      return await postJSON('/api/auth/brand-cloud/activate', payload);
     } catch (err) {
       const nextError = userFacingLoginActivationError(err);
       throw new Error(nextError);
@@ -1149,6 +1095,16 @@ function App() {
     setRefreshTick((tick) => tick + 1);
   }
 
+  async function handleSwitchView(view) {
+	setError('');
+	try {
+	  const result = await postJSON('/api/me/view', { view });
+	  window.location.assign(result.kind === 'platform_admin' ? '/admin' : '/console');
+	} catch (err) {
+	  setError(err?.message || 'View switch failed.');
+	}
+  }
+
   async function handleLogout() {
     setMobileNavOpen(false);
     setError('');
@@ -1187,7 +1143,6 @@ function App() {
           loading={loading}
           onSignup={handleSignup}
           onLoginActivate={handleLoginActivate}
-          onBrandCloudActivate={handleBrandCloudActivate}
           onPasswordLogin={handlePasswordLogin}
           onForgotPassword={handleForgotPassword}
           onResetPassword={handleResetPassword}
@@ -1272,6 +1227,8 @@ function App() {
             <h1>{titleFor(active)}</h1>
           </div>
           <div className="topbar-controls">
+			{me?.authenticated && me?.kind === 'customer' && (me?.platform_capabilities?.length ?? 0) > 0 ? <button type="button" className="ghost-button" onClick={() => handleSwitchView('platform')}>Platform view</button> : null}
+			{me?.authenticated && me?.kind === 'platform_admin' && (me?.memberships?.length ?? 0) > 0 ? <button type="button" className="ghost-button" onClick={() => handleSwitchView('customer')}>Brand Cloud view</button> : null}
             {me?.kind === 'customer' && (developerBrandClouds.length > 1 || (me?.memberships?.length ?? 0) > 1) ? (
               <select
                 className="org-switcher"
@@ -1406,7 +1363,6 @@ function App() {
             }}
             onCreateBrand={handleCreateBrandCloud}
             onUpdateBrand={handleUpdateBrandCloud}
-            onAssignMember={handleAssignBrandCloudMember}
             onCreateUser={handleCreateBrandCloudUser}
           />
         ) : null}
@@ -1420,7 +1376,7 @@ function App() {
   );
 }
 
-function LoginPage({ active, error, loading, onSignup, onLoginActivate, onBrandCloudActivate, onPasswordLogin, onForgotPassword, onResetPassword }) {
+function LoginPage({ active, error, loading, onSignup, onLoginActivate, onPasswordLogin, onForgotPassword, onResetPassword }) {
   const params = new URLSearchParams(window.location.search);
   const email = params.get('email') || '';
   const token = params.get('token') || '';
@@ -1432,8 +1388,6 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onBrandC
     <LoginCheckEmail email={email} />
   ) : active === 'login-activate' ? (
     <LoginActivateView token={token} onLoginActivate={onLoginActivate} />
-  ) : active === 'brand-cloud-activate' ? (
-    <BrandCloudActivateView token={token} tenant={params.get('tenant') || ''} onActivate={onBrandCloudActivate} />
   ) : active === 'forgot-password' ? (
     <ForgotPasswordView email={email} onForgotPassword={onForgotPassword} />
   ) : active === 'reset-password' ? (
@@ -1455,36 +1409,6 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onBrandC
           {error ? <div className="error">{error}</div> : null}
         </section>
       </main>
-    </div>
-  );
-}
-
-function BrandCloudActivateView({ token, tenant, onActivate }) {
-  const [password, setPassword] = useState('');
-  const [status, setStatus] = useState('');
-  const [error, setLocalError] = useState('');
-  const [busy, setBusy] = useState(false);
-  async function submit(event) {
-    event.preventDefault();
-    setBusy(true);
-    setLocalError('');
-    try {
-      const result = await onActivate({ tenant_slug: tenant, token, password });
-      setStatus(`Activated ${result.account?.display_name || result.account?.email || 'account'} for ${result.brand_cloud?.name || tenant}.`);
-    } catch (err) {
-      setLocalError(userFacingLoginActivationError(err));
-    } finally {
-      setBusy(false);
-    }
-  }
-  return (
-    <div className="auth-stack">
-      <form className="auth-inline" onSubmit={submit}>
-        <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="New password" minLength="8" required />
-        <button type="submit" disabled={busy || !token || !tenant}>{busy ? 'Activating' : 'Activate account'}</button>
-      </form>
-      {status ? <p className="auth-status">{status}</p> : null}
-      {error ? <p className="error">{error}</p> : null}
     </div>
   );
 }
@@ -3126,7 +3050,7 @@ function BillingProfilePage({ profile, tabs, canManage, onRefresh }) {
 }
 function PKITestBundleTool({ activeCloudId }) {
   const [kind, setKind] = useState('app');
-  const [targetType, setTargetType] = useState('brand_cloud_user');
+  const [targetType, setTargetType] = useState('user');
   const [targetId, setTargetId] = useState('');
   const [profileId, setProfileId] = useState('');
   const [serial, setSerial] = useState('');
@@ -3148,7 +3072,7 @@ function PKITestBundleTool({ activeCloudId }) {
     } catch (_) { setMessage('The test bundle could not be created. Please try again.'); }
     finally { setBusy(false); }
   }
-  return <section className="panel"><div className="panel-head"><div><h3>PKI Test Bundle</h3><p>The exportable P-256 key is generated locally; only the CSR is sent to the backend. Certificates are valid for 30 days and intended for local or staging use only.</p></div></div><form className="inline-form pki-test-form" onSubmit={issue}><select className="select-control" aria-label="Certificate Type" value={kind} onChange={(event) => setKind(event.target.value)}><option value="app">App mTLS</option><option value="device">Device mTLS</option></select>{kind === 'app' ? <select className="select-control" aria-label="App Identity Type" value={targetType} onChange={(event) => setTargetType(event.target.value)}><option value="brand_cloud_user">Brand Cloud user</option><option value="end_user">End user</option></select> : null}<input required placeholder={kind === 'device' ? 'Device ID' : 'User ID'} value={targetId} onChange={(event) => setTargetId(event.target.value)} />{kind === 'device' ? <><input required placeholder="Device profile ID" value={profileId} onChange={(event) => setProfileId(event.target.value)} /><input required placeholder="Serial number" value={serial} onChange={(event) => setSerial(event.target.value)} /></> : null}<button type="submit" className="primary-button" disabled={busy}>{busy ? 'Creating…' : 'Generate and download'}</button></form>{message ? <p className="notice" role="status">{message}</p> : null}</section>;
+  return <section className="panel"><div className="panel-head"><div><h3>PKI Test Bundle</h3><p>The exportable P-256 key is generated locally; only the CSR is sent to the backend. Certificates are valid for 30 days and intended for local or staging use only.</p></div></div><form className="inline-form pki-test-form" onSubmit={issue}><select className="select-control" aria-label="Certificate Type" value={kind} onChange={(event) => setKind(event.target.value)}><option value="app">App mTLS</option><option value="device">Device mTLS</option></select>{kind === 'app' ? <select className="select-control" aria-label="App Identity Type" value={targetType} onChange={(event) => setTargetType(event.target.value)}><option value="user">Global user</option><option value="end_user">End user</option></select> : null}<input required placeholder={kind === 'device' ? 'Device ID' : 'User ID'} value={targetId} onChange={(event) => setTargetId(event.target.value)} />{kind === 'device' ? <><input required placeholder="Device profile ID" value={profileId} onChange={(event) => setProfileId(event.target.value)} /><input required placeholder="Serial number" value={serial} onChange={(event) => setSerial(event.target.value)} /></> : null}<button type="submit" className="primary-button" disabled={busy}>{busy ? 'Creating…' : 'Generate and download'}</button></form>{message ? <p className="notice" role="status">{message}</p> : null}</section>;
 }
 
 function ReportsPage({ data, products, loading, canCreate, onRefresh }) {
@@ -4612,7 +4536,6 @@ function PlatformBrandClouds({
   onCloseDrawer,
   onCreateBrand,
   onUpdateBrand,
-  onAssignMember,
   onCreateUser,
 }) {
   const kpis = brandCloudKPIs(brands);
@@ -4712,7 +4635,6 @@ function PlatformBrandClouds({
           brand={selectedBrand}
           onClose={onCloseDrawer}
           onUpdateBrand={onUpdateBrand}
-          onAssignMember={onAssignMember}
           onCreateUser={onCreateUser}
         />
       ) : null}
@@ -4726,9 +4648,7 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
     region: '',
     tier: 'Evaluation',
     initialMode: 'none',
-    userId: '',
-    email: '',
-    password: '',
+	email: '',
     displayName: '',
     role: 'owner',
   });
@@ -4748,23 +4668,15 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
       return;
     }
     if (step < 3) {
-      if (step === 2 && form.initialMode === 'existing' && !form.userId.trim()) {
-        setMessage('Existing Brand User id is required.');
-        return;
-      }
-      if (step === 2 && form.initialMode === 'create' && (!form.email.trim() || !form.password.trim())) {
-        setMessage('Initial admin email and password are required.');
+	  if (step === 2 && form.initialMode === 'create' && !form.email.trim()) {
+		setMessage('Initial owner email is required.');
         return;
       }
       setStep((current) => current + 1);
       return;
     }
-    if (form.initialMode === 'existing' && !form.userId.trim()) {
-      setMessage('Existing Brand User id is required.');
-      return;
-    }
-    if (form.initialMode === 'create' && (!form.email.trim() || !form.password.trim())) {
-      setMessage('Initial admin email and password are required.');
+	if (form.initialMode === 'create' && !form.email.trim()) {
+	  setMessage('Initial owner email is required.');
       return;
     }
     setSubmitting(true);
@@ -4777,13 +4689,11 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
             tier: form.tier,
           },
         },
-        initialMember: form.initialMode === 'existing' ? { brand_cloud_user_id: form.userId.trim(), role: form.role } : null,
-        initialUser: form.initialMode === 'create' ? {
-          email: form.email.trim(),
-          password: form.password,
-          display_name: form.displayName.trim() || undefined,
-          role: form.role,
-          rotate_password: true,
+		initialUser: form.initialMode === 'create' ? {
+		  email: form.email.trim(),
+		  display_name: form.displayName.trim() || undefined,
+		  role: form.role,
+		  activation_mode: 'email',
         } : null,
       };
       const result = await onCreateBrand(payload);
@@ -4823,15 +4733,13 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
             <>
               <label>Initial admin mode<select className="input" value={form.initialMode} onChange={(event) => update('initialMode', event.target.value)}>
                 <option value="none">Assign later</option>
-                <option value="existing">Assign existing Brand User id</option>
-                <option value="create">Create or reactivate brand user</option>
-              </select></label>
-              {form.initialMode === 'existing' ? <label>Brand User id<input className="input" value={form.userId} onChange={(event) => update('userId', event.target.value)} /></label> : null}
-              {form.initialMode === 'create' ? (
-                <>
-                  <label>Email<input className="input" type="email" value={form.email} onChange={(event) => update('email', event.target.value)} /></label>
-                  <label>Temporary password<input className="input" type="password" value={form.password} onChange={(event) => update('password', event.target.value)} /></label>
-                  <label>Display name<input className="input" value={form.displayName} onChange={(event) => update('displayName', event.target.value)} /></label>
+				<option value="create">Invite global user by email</option>
+			  </select></label>
+			  {form.initialMode === 'create' ? (
+				<>
+				  <label>Email<input className="input" type="email" value={form.email} onChange={(event) => update('email', event.target.value)} /></label>
+				  <label>Display name<input className="input" value={form.displayName} onChange={(event) => update('displayName', event.target.value)} /></label>
+				  <p className="source-note">The owner receives the global account activation email; no tenant password is created.</p>
                 </>
               ) : null}
               {form.initialMode !== 'none' ? <label>Role<select className="input" value={form.role} onChange={(event) => update('role', event.target.value)}><option value="owner">Owner</option><option value="admin">Admin</option><option value="member">Member</option></select></label> : null}
@@ -4842,7 +4750,7 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
               <h3>Review</h3>
               <div><span>Brand</span><strong>{form.name}</strong></div>
               <div><span>Tier</span><strong>{form.tier}</strong></div>
-              <div><span>Initial admin</span><strong>{form.initialMode === 'none' ? 'Assign later' : form.initialMode === 'existing' ? form.userId : form.email}</strong></div>
+			  <div><span>Initial owner</span><strong>{form.initialMode === 'none' ? 'Assign later' : form.email}</strong></div>
               <p className="source-note">Quota and SSO setup can be completed after creation.</p>
             </section>
           ) : null}
@@ -4858,12 +4766,11 @@ function BrandCloudCreateDrawer({ onClose, onCreateBrand }) {
   );
 }
 
-function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember, onCreateUser }) {
+function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onCreateUser }) {
   const [detailBrand, setDetailBrand] = useState(brand);
   const [ssoProvider, setSSOProvider] = useState(null);
   const [detailSource, setDetailSource] = useState({ status: 'loading', message: '' });
-  const [member, setMember] = useState({ brand_cloud_user_id: '', role: 'owner' });
-  const [user, setUser] = useState({ email: '', password: '', display_name: '', role: 'admin' });
+  const [user, setUser] = useState({ email: '', display_name: '', role: 'admin' });
   const [users, setUsers] = useState([]);
   const [userFilter, setUserFilter] = useState('all');
   const [usersSource, setUsersSource] = useState({ status: 'loading', message: '' });
@@ -4897,7 +4804,7 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
       if (nextFilter !== 'all') params.set('status', nextFilter);
       const suffix = params.toString() ? `?${params.toString()}` : '';
       const result = await fetchJSON(`/api/admin/brand-clouds/${encodeURIComponent(brand.id)}/users${suffix}`);
-      setUsers(result.brand_cloud_users || []);
+	  setUsers(result.users || []);
       setUsersSource({ status: 'ready', message: '' });
     } catch (err) {
       setUsers([]);
@@ -4926,39 +4833,22 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
     }
   }
 
-  async function submitMember(event) {
-    event.preventDefault();
-    setMessage('');
-    if (!member.brand_cloud_user_id.trim()) {
-      setMessage('Brand User id is required.');
-      return;
-    }
-    try {
-      await onAssignMember(brand.id, { brand_cloud_user_id: member.brand_cloud_user_id.trim(), role: member.role });
-      setMessage('Member assigned.');
-      setMember({ brand_cloud_user_id: '', role: 'owner' });
-    } catch (err) {
-      setMessage(userFacingBrandCloudError(err));
-    }
-  }
-
   async function submitUser(event) {
     event.preventDefault();
     setMessage('');
-    if (!user.email.trim() || !user.password.trim()) {
-      setMessage('Email and password are required.');
+	if (!user.email.trim()) {
+	  setMessage('Email is required.');
       return;
     }
     try {
       const result = await onCreateUser(brand.id, {
         email: user.email.trim(),
-        password: user.password,
-        display_name: user.display_name.trim() || undefined,
-        role: user.role,
-        rotate_password: true,
+		display_name: user.display_name.trim() || undefined,
+		role: user.role,
+		activation_mode: 'email',
       });
-      setMessage(result.action === 'created' ? 'Brand user created and assigned.' : 'Brand user reactivated or assigned.');
-      setUser({ email: '', password: '', display_name: '', role: 'admin' });
+	  setMessage(result.action === 'created' ? 'Global user created; activation email queued.' : 'Existing global user assigned; sign-in email queued.');
+	  setUser({ email: '', display_name: '', role: 'admin' });
       await loadUsers(userFilter);
     } catch (err) {
       setMessage(userFacingBrandCloudError(err));
@@ -4969,17 +4859,13 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
     setMessage('');
     try {
       if (action === 'delete' && !window.confirm(`Remove Brand Cloud access for ${row.email}?`)) return;
-      const path = `/api/admin/brand-clouds/${encodeURIComponent(brand.id)}/users/${encodeURIComponent(row.id)}`;
+	  const path = `/api/admin/brand-clouds/${encodeURIComponent(brand.id)}/users/${encodeURIComponent(row.user_id)}`;
       if (action === 'delete') {
         await sendJSONWithMethod('DELETE', path);
         setMessage('Brand user removed.');
       } else {
         await sendJSONWithMethod('POST', `${path}/${action}`, {});
-        if (action === 'approve') {
-          setMessage('Brand user approved.');
-        } else {
-          setMessage(action === 'disable' ? 'Brand user disabled.' : 'Brand user enabled.');
-        }
+		setMessage(action === 'disable' ? 'Membership disabled.' : 'Membership enabled.');
       }
       await loadUsers(userFilter);
     } catch (err) {
@@ -5050,8 +4936,8 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
         <section className="brand-cloud-users">
           <div className="panel-head compact-head">
             <div>
-              <h3>Brand Users</h3>
-              <p>Review activation state and manage brand-scoped access.</p>
+			  <h3>Global Users</h3>
+			  <p>Review each global account's membership in this Brand Cloud.</p>
             </div>
             <select className="input small-input" value={userFilter} onChange={(event) => changeUserFilter(event.target.value)} aria-label="Filter Brand Cloud users">
               <option value="all">All users</option>
@@ -5078,20 +4964,15 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
                   {users.map((row) => {
                     const status = brandCloudUserStatus(row);
                     return (
-                      <tr key={row.id}>
-                        <td><strong>{row.email}</strong><small>{row.display_name || row.id}</small></td>
+					  <tr key={row.user_id}>
+						<td><strong>{row.email}</strong><small>{row.display_name || row.user_id}</small></td>
                         <td><StatusBadge value={status.key === 'pending_verification' ? 'setup_required' : status.key} label={status.label} /></td>
                         <td>{row.updated_at ? formatRelativeTime(row.updated_at) : '-'}</td>
                         <td>
                           <div className="row-actions">
                             {status.key === 'disabled' ? (
                               <button type="button" className="inline-action" onClick={() => updateBrandUser(row, 'enable')}><Icon name="rotate-right" />Enable</button>
-                            ) : status.key === 'pending_verification' ? (
-                              <>
-                                <button type="button" className="inline-action" onClick={() => updateBrandUser(row, 'approve')}><Icon name="circle-check" />Approve</button>
-                                <button type="button" className="inline-action" onClick={() => updateBrandUser(row, 'disable')}><Icon name="ban" />Disable</button>
-                              </>
-                            ) : (
+							) : (
                               <button type="button" className="inline-action" onClick={() => updateBrandUser(row, 'disable')}><Icon name="ban" />Disable</button>
                             )}
                             <button type="button" className="inline-action danger-link" onClick={() => updateBrandUser(row, 'delete')}><Icon name="trash" />Delete</button>
@@ -5106,19 +4987,13 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onAssignMember,
           ) : null}
         </section>
         <section className="brand-cloud-form-grid">
-          <form className="drawer-form compact" onSubmit={submitMember}>
-            <h3><Icon name="user-plus" />Assign Existing Brand User</h3>
-            <label>Brand User id<input className="input" value={member.brand_cloud_user_id} onChange={(event) => setMember((current) => ({ ...current, brand_cloud_user_id: event.target.value }))} /></label>
-            <label>Role<select className="input" value={member.role} onChange={(event) => setMember((current) => ({ ...current, role: event.target.value }))}><option value="owner">Owner</option><option value="admin">Admin</option><option value="member">Member</option></select></label>
-            <button type="submit" className="primary-button"><Icon name="user-check" />Assign Existing Brand User</button>
-          </form>
-          <form className="drawer-form compact" onSubmit={submitUser}>
-            <h3><Icon name="envelope-circle-check" />Create Or Reactivate Brand User</h3>
-            <label>Email<input className="input" type="email" value={user.email} onChange={(event) => setUser((current) => ({ ...current, email: event.target.value }))} /></label>
-            <label>Temporary password<input className="input" type="password" value={user.password} onChange={(event) => setUser((current) => ({ ...current, password: event.target.value }))} /></label>
-            <label>Display name<input className="input" value={user.display_name} onChange={(event) => setUser((current) => ({ ...current, display_name: event.target.value }))} /></label>
-            <label>Role<select className="input" value={user.role} onChange={(event) => setUser((current) => ({ ...current, role: event.target.value }))}><option value="owner">Owner</option><option value="admin">Admin</option><option value="member">Member</option></select></label>
-            <button type="submit" className="primary-button"><Icon name="plus" />Create Or Reactivate User</button>
+		  <form className="drawer-form compact" onSubmit={submitUser}>
+			<h3><Icon name="envelope-circle-check" />Assign Global User</h3>
+			<label>Email<input className="input" type="email" value={user.email} onChange={(event) => setUser((current) => ({ ...current, email: event.target.value }))} /></label>
+			<label>Display name<input className="input" value={user.display_name} onChange={(event) => setUser((current) => ({ ...current, display_name: event.target.value }))} /></label>
+			<label>Role<select className="input" value={user.role} onChange={(event) => setUser((current) => ({ ...current, role: event.target.value }))}><option value="owner">Owner</option><option value="admin">Admin</option><option value="member">Member</option></select></label>
+			<p className="source-note">Email activation uses the shared global account flow. Owner accounts can never be provisioned with an admin-supplied password.</p>
+			<button type="submit" className="primary-button"><Icon name="plus" />Assign and Send Email</button>
           </form>
         </section>
         {message ? <p className="form-message">{message}</p> : null}

--- a/web/src/routes.mjs
+++ b/web/src/routes.mjs
@@ -88,7 +88,7 @@ export const platformNavGroups = [
 
 export const platformNavItems = platformNavGroups.flatMap((group) => group.items);
 
-const publicRouteIds = new Set(['login', 'login-check-email', 'login-activate', 'brand-cloud-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'signup-verification-expired', 'verify']);
+const publicRouteIds = new Set(['login', 'login-check-email', 'login-activate', 'forgot-password', 'reset-password', 'signup', 'signup-check-email', 'signup-verification-expired', 'verify']);
 
 export function isPublicRouteId(route) {
   return publicRouteIds.has(route);
@@ -144,7 +144,6 @@ export function titleFor(active) {
     login: 'Sign in',
     'login-check-email': 'Check your email',
     'login-activate': 'Activate sign-in',
-    'brand-cloud-activate': 'Activate brand account',
     'forgot-password': 'Forgot password',
     'reset-password': 'Reset password',
     signup: 'Sign up',
@@ -180,7 +179,6 @@ export function routeFromPath(path) {
   if (path === '/login' || path === '/login/') return 'login';
   if (path === '/login/check-email' || path.startsWith('/login/check-email/')) return 'login-check-email';
   if (path === '/login/activate' || path.startsWith('/login/activate/')) return 'login-activate';
-  if (path === '/brand-cloud/activate' || path.startsWith('/brand-cloud/activate/')) return 'brand-cloud-activate';
   if (path === '/forgot-password' || path.startsWith('/forgot-password/')) return 'forgot-password';
   if (path === '/reset-password' || path.startsWith('/reset-password/')) return 'reset-password';
   if (path === '/signup' || path === '/signup/') return 'signup';

--- a/web/src/routes.test.mjs
+++ b/web/src/routes.test.mjs
@@ -41,7 +41,7 @@ test('maps public signup paths to auth routes', () => {
   assert.equal(routeFromPath('/login/'), 'login');
   assert.equal(routeFromPath('/login/check-email'), 'login-check-email');
   assert.equal(routeFromPath('/login/activate'), 'login-activate');
-  assert.equal(routeFromPath('/brand-cloud/activate'), 'brand-cloud-activate');
+	assert.equal(routeFromPath('/brand-cloud/activate'), 'overview');
   assert.equal(routeFromPath('/forgot-password'), 'forgot-password');
   assert.equal(routeFromPath('/reset-password'), 'reset-password');
   assert.equal(routeFromPath('/signup'), 'signup');


### PR DESCRIPTION
## Summary
- replace customer/platform BFF login routes with one `/api/auth/login`
- resolve memberships and platform capabilities from global `/v1/me`
- choose a valid requested destination, then customer view, then platform view
- allow customer/platform view switching in one account session
- update Brand Cloud user management to global `{user, member}` responses
- move owner activation browser coverage to the global verification and login flow

Implements contracts documentation merged in hkt999rtk/rtk_cloud_contracts_doc#128 and Cloud Admin design documentation merged in #301.

## Validation
- `GOWORK=off go test ./...`
- `npm test -- --run` (101 passing)
- `npm run build`