### PR TITLE
docs: align feature selector with unified login

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -8,10 +8,10 @@ rtk_spec:
 
 # RTK Cloud Admin Console Specification
 
-## [FEAT-CA-BFF-001] Tenant-aware Cloud Admin BFF and operational console boundary
+## [FEAT-CA-BFF-001] Unified-account Cloud Admin BFF and operational console boundary
 
 <!-- rtk-feature
-{"owner":"rtk_cloud_admin","risk":"critical","status":"active","change_paths":["repos/rtk_cloud_admin/**","scripts/go/rtk-cloud/**"],"commit_anchors":["workspace","cloud_admin"],"surfaces":[{"kind":"api-route","source":"repos/rtk_cloud_admin/docs/openapi.yaml","selector":"postApiAuthCustomerLogin"}]}
+{"owner":"rtk_cloud_admin","risk":"critical","status":"active","change_paths":["repos/rtk_cloud_admin/**","scripts/go/rtk-cloud/**"],"commit_anchors":["workspace","cloud_admin"],"surfaces":[{"kind":"api-route","source":"repos/rtk_cloud_admin/docs/openapi.yaml","selector":"postApiAuthLogin"}]}
 -->
 
 ## Summary


### PR DESCRIPTION
Updates the Cloud Admin feature metadata to reference the unified `POST /api/auth/login` operation so workspace spec inventory and feature qualification validate the merged authentication contract.