### PR TITLE
feat(web): refresh Connect+ login experience

### DIFF
--- a/web/e2e/public-auth.spec.mjs
+++ b/web/e2e/public-auth.spec.mjs
@@ -1,6 +1,48 @@
 import { expect, test } from '@playwright/test';
 import { login } from './fixtures/session.mjs';
 
+test('[UI-CA-AUTH-LOGIN-001] shared login branding follows the selected auth mode @smoke', async ({ page }) => {
+  await page.goto('/login');
+
+  await expect(page.getByRole('heading', { name: 'Sign in to Connect+', exact: true })).toBeVisible();
+  await expect(page.getByText('Use your Connect+ account to continue.', { exact: true })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Sign in', exact: true })).toHaveAttribute('aria-selected', 'true');
+  await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible();
+  await expect(page).toHaveTitle('Sign in Connect+');
+
+  await page.getByRole('tab', { name: 'Create account', exact: true }).click();
+
+  await expect(page.getByRole('heading', { name: 'Create your Connect+ account', exact: true })).toBeVisible();
+  await expect(page.getByText('Create an account to get started with Connect+.', { exact: true })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Create account', exact: true })).toBeVisible();
+  await expect(page).toHaveTitle('Create account Connect+');
+});
+
+test('[UI-CA-AUTH-LOGIN-002] admin destinations use the platform sign-in context @smoke', async ({ page }) => {
+  await page.goto('/login?next=%2Fadmin%2Fhealth');
+
+  await expect(page.getByRole('heading', { name: 'Platform Admin sign in', exact: true })).toBeVisible();
+  await expect(page.getByText('Sign in with your platform administrator account.', { exact: true })).toBeVisible();
+  await expect(page.getByRole('tablist', { name: 'Auth mode' })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Create account', exact: true })).toHaveCount(0);
+  await expect(page.getByRole('button', { name: 'Sign in', exact: true })).toBeVisible();
+  await expect(page).toHaveTitle('Platform Admin sign in Connect+');
+});
+
+for (const [name, next] of [
+  ['customer', '/console/overview'],
+  ['unrelated', '/administrator'],
+  ['external', 'https://evil.example/admin'],
+]) {
+  test(`[UI-CA-AUTH-LOGIN-003] ${name} destinations keep the shared sign-in context`, async ({ page }) => {
+    await page.goto(`/login?next=${encodeURIComponent(next)}`);
+
+    await expect(page.getByRole('heading', { name: 'Sign in to Connect+', exact: true })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Create account', exact: true })).toBeVisible();
+    await expect(page).toHaveTitle('Sign in Connect+');
+  });
+}
+
 test('[UI-CA-AUTH-001] reset password keeps the URL token out of the form @smoke', async ({ page }, testInfo) => {
   let resetPayload;
   await page.route('**/api/auth/reset-password', async (route) => {

--- a/web/src/auth-routing.mjs
+++ b/web/src/auth-routing.mjs
@@ -24,6 +24,11 @@ export function loginNextFromLocation(location) {
   return normalizeLoginNext(params.get('next') || '');
 }
 
+export function isPlatformLoginNext(value) {
+  const next = normalizeLoginNext(value);
+  return Boolean(next && isAllowedAdminPath(new URL(next, 'https://connect.local').pathname));
+}
+
 export function protectedPathFromLocation(location) {
   const pathname = location?.pathname || '/';
   const search = location?.search || '';
@@ -60,8 +65,7 @@ export function destinationForSession(me, nextPath) {
 }
 
 export function passwordLoginOrderForNext(nextPath) {
-  const next = normalizeLoginNext(nextPath);
-  if (next && isAllowedAdminPath(new URL(next, 'https://connect.local').pathname)) {
+  if (isPlatformLoginNext(nextPath)) {
     return ['platform', 'customer'];
   }
   return ['customer', 'platform'];

--- a/web/src/auth-routing.test.mjs
+++ b/web/src/auth-routing.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   destinationForSession,
   isSafeLoginNext,
+  isPlatformLoginNext,
   loginNextFromLocation,
   loginPathFor,
   normalizeLoginNext,
@@ -54,6 +55,16 @@ test('password login prefers the destination view', () => {
   assert.deepEqual(passwordLoginOrderForNext('/admin/resources'), ['platform', 'customer']);
   assert.deepEqual(passwordLoginOrderForNext('/console/devices'), ['customer', 'platform']);
   assert.deepEqual(passwordLoginOrderForNext('/signup'), ['customer', 'platform']);
+});
+
+test('platform login context requires a safe admin destination', () => {
+  assert.equal(isPlatformLoginNext('/admin'), true);
+  assert.equal(isPlatformLoginNext('/admin/health?window=1#status'), true);
+  assert.equal(isPlatformLoginNext('/console/overview'), false);
+  assert.equal(isPlatformLoginNext('/administrator'), false);
+  assert.equal(isPlatformLoginNext('https://evil.example/admin'), false);
+  assert.equal(isPlatformLoginNext('//evil.example/admin'), false);
+  assert.equal(isPlatformLoginNext(''), false);
 });
 
 test('sensitive query parameters are removed without changing the rest of the address', () => {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -43,6 +43,7 @@ import {
 } from './brand-clouds.mjs';
 import {
   destinationForSession,
+  isPlatformLoginNext,
   loginNextFromLocation,
   loginPathFor,
   passwordLoginOrderForNext,
@@ -301,6 +302,7 @@ function App() {
   const customerViewBlocked = !isPlatformView && !isPublicRoute && me !== null && (me.authenticated === false || me.kind === 'platform_admin' || customerCapabilityBlocked);
 
   useEffect(() => {
+    if (active === 'login') return;
     document.title = `${titleFor(active)} · RTK Cloud`;
   }, [active]);
 
@@ -1380,10 +1382,30 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onPasswo
   const params = new URLSearchParams(window.location.search);
   const email = params.get('email') || '';
   const token = params.get('token') || '';
-  const pageHeading = active === 'reset-password' ? 'Reset your password' : 'Admin Console';
-  const pageCopy = active === 'reset-password'
-    ? 'Choose a new password for your Connect+ Ops account.'
-    : 'Login to an existing account or create a new evaluation account.';
+  const [authMode, setAuthMode] = useState('login');
+  const platformLogin = active === 'login' && isPlatformLoginNext(params.get('next') || '');
+  const loginHeading = platformLogin ? 'Platform Admin sign in' : authMode === 'signup' ? 'Create your Connect+ account' : 'Sign in to Connect+';
+  const loginCopy = platformLogin
+    ? 'Sign in with your platform administrator account.'
+    : authMode === 'signup'
+      ? 'Create an account to get started with Connect+.'
+      : 'Use your Connect+ account to continue.';
+  const pageHeading = active === 'login' ? loginHeading : active === 'reset-password' ? 'Reset your password' : 'Admin Console';
+  const pageCopy = active === 'login'
+    ? loginCopy
+    : active === 'reset-password'
+      ? 'Choose a new password for your Connect+ Ops account.'
+      : 'Login to an existing account or create a new evaluation account.';
+
+  useEffect(() => {
+    if (active !== 'login') return;
+    document.title = platformLogin
+      ? 'Platform Admin sign in Connect+'
+      : authMode === 'signup'
+        ? 'Create account Connect+'
+        : 'Sign in Connect+';
+  }, [active, authMode, platformLogin]);
+
   const content = active === 'login-check-email' ? (
     <LoginCheckEmail email={email} />
   ) : active === 'login-activate' ? (
@@ -1393,7 +1415,15 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onPasswo
   ) : active === 'reset-password' ? (
     <ResetPasswordView token={token} email={email} onResetPassword={onResetPassword} />
   ) : (
-    <LoginEntryForm initialEmail={email} onSignup={onSignup} onPasswordLogin={onPasswordLogin} disabled={loading} />
+    <LoginEntryForm
+      initialEmail={email}
+      mode={authMode}
+      onModeChange={setAuthMode}
+      platformLogin={platformLogin}
+      onSignup={onSignup}
+      onPasswordLogin={onPasswordLogin}
+      disabled={loading}
+    />
   );
   return (
     <div className="login-shell">
@@ -1401,7 +1431,7 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onPasswo
         <section className="login-primary" aria-labelledby="login-title">
           <div className="login-brand">
             <img src="/assets/realtek-logo.png" alt="Realtek" />
-            <strong>Connect+ Ops</strong>
+            <strong>Connect+</strong>
           </div>
           <h1 id="login-title">{pageHeading}</h1>
           <p className="login-copy">{pageCopy}</p>
@@ -1413,31 +1443,30 @@ function LoginPage({ active, error, loading, onSignup, onLoginActivate, onPasswo
   );
 }
 
-function LoginEntryForm({ initialEmail, onSignup, onPasswordLogin, disabled }) {
-  const [mode, setMode] = useState('login');
+function LoginEntryForm({ initialEmail, mode, onModeChange, platformLogin, onSignup, onPasswordLogin, disabled }) {
   return (
     <div className="auth-stack">
-      <div className="auth-mode-tabs" role="tablist" aria-label="Auth mode">
+      {!platformLogin ? <div className="auth-mode-tabs" role="tablist" aria-label="Auth mode">
         <button
           type="button"
           className={mode === 'login' ? 'active' : ''}
           role="tab"
           aria-selected={mode === 'login'}
-          onClick={() => setMode('login')}
+          onClick={() => onModeChange('login')}
         >
-          Login
+          Sign in
         </button>
         <button
           type="button"
           className={mode === 'signup' ? 'active' : ''}
           role="tab"
           aria-selected={mode === 'signup'}
-          onClick={() => setMode('signup')}
+          onClick={() => onModeChange('signup')}
         >
-          Sign Up
+          Create account
         </button>
-      </div>
-      {mode === 'signup' ? (
+      </div> : null}
+      {!platformLogin && mode === 'signup' ? (
         <SignupForm onSignup={onSignup} disabled={disabled} />
       ) : (
         <LoginPasswordForm initialEmail={initialEmail} onPasswordLogin={onPasswordLogin} disabled={disabled} />
@@ -1473,7 +1502,7 @@ function LoginPasswordForm({ initialEmail = '', onPasswordLogin, disabled }) {
         Password
         <input type="password" value={password} onChange={(event) => setPassword(event.target.value)} placeholder="Enter your password" required />
       </label>
-      <button type="submit" disabled={busy || disabled}>{busy ? 'Logging in' : 'Login'}</button>
+      <button type="submit" disabled={busy || disabled}>{busy ? 'Signing in' : 'Sign in'}</button>
       <a className="auth-link" href={`/forgot-password${email ? `?email=${encodeURIComponent(email)}` : ''}`}>Forgot password?</a>
       {localError ? <p className="error">{localError}</p> : null}
     </form>


### PR DESCRIPTION
## Summary
- refresh the shared login page branding and auth-mode copy for Connect+
- use consistent Sign in/Create account labels and dynamic browser titles
- show a Platform Admin-specific login context for safe `/admin` destinations and hide account creation there
- add unit and desktop/mobile Playwright coverage for login contexts and safe `next` handling

## Validation
- `npm test`
- `npm run build`
- `npx playwright test e2e/public-auth.spec.mjs --project=chromium --project=mobile`

The workspace pre-PR gate was not applicable because this is a leaf Cloud Admin submodule PR; the workspace root intentionally retains its existing gitlink and was not changed.
