### PR TITLE
fix: show global account activation state

### DIFF
--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -4,7 +4,7 @@
 
 | Item | Result |
 |---|---|
-| Go total coverage | 79.8% |
+| Go total coverage | 80.0% |
 | Go coverage gate | >= 65.0% |
 | Report source | CI-generated canonical candidate |
 | Raw logs | GitHub Actions artifact only |
@@ -28,13 +28,13 @@
 |---|---:|
 | `rtk_cloud_admin/cmd/s3put` | 73.4% |
 | `rtk_cloud_admin/cmd/server` | 0.0% |
-| `rtk_cloud_admin/internal/accountclient` | 87.2% |
+| `rtk_cloud_admin/internal/accountclient` | 89.2% |
 | `rtk_cloud_admin/internal/app` | 80.5% |
 | `rtk_cloud_admin/internal/billingclient` | 30.2% |
 | `rtk_cloud_admin/internal/config` | 100.0% |
 | `rtk_cloud_admin/internal/correlation` | 90.5% |
 | `rtk_cloud_admin/internal/readinessfacts` | 86.0% |
-| `rtk_cloud_admin/internal/store` | 79.3% |
+| `rtk_cloud_admin/internal/store` | 80.4% |
 | `rtk_cloud_admin/internal/videoclient` | 86.3% |
 
 ## Artifact Policy

--- a/internal/accountclient/client.go
+++ b/internal/accountclient/client.go
@@ -123,6 +123,19 @@ type Member struct {
 	DisabledAt     string   `json:"disabled_at,omitempty"`
 }
 
+type BrandCloudAccountListItem struct {
+	OrganizationID            string `json:"organization_id"`
+	UserID                    string `json:"user_id"`
+	Email                     string `json:"email"`
+	DisplayName               string `json:"display_name,omitempty"`
+	Role                      string `json:"role"`
+	EmailVerified             bool   `json:"email_verified"`
+	SignupPendingVerification bool   `json:"signup_pending_verification"`
+	DisabledAt                string `json:"disabled_at,omitempty"`
+	CreatedAt                 string `json:"created_at"`
+	UpdatedAt                 string `json:"updated_at"`
+}
+
 type OwnerTransfer struct {
 	ID                string `json:"id"`
 	BrandCloudID      string `json:"brand_cloud_id"`
@@ -1018,9 +1031,9 @@ func (c *Client) CreateBrandCloudUser(ctx context.Context, accessToken, brandClo
 	return body, status, err
 }
 
-func (c *Client) BrandCloudUsers(ctx context.Context, accessToken, brandCloudID string, query url.Values) ([]Member, error) {
+func (c *Client) BrandCloudUsers(ctx context.Context, accessToken, brandCloudID string, query url.Values) ([]BrandCloudAccountListItem, error) {
 	var body struct {
-		Users []Member `json:"users"`
+		Users []BrandCloudAccountListItem `json:"users"`
 	}
 	path := "/v1/admin/brand-clouds/" + url.PathEscape(brandCloudID) + "/users"
 	if len(query) > 0 {

--- a/internal/accountclient/client_test.go
+++ b/internal/accountclient/client_test.go
@@ -55,6 +55,37 @@ func TestClientLoginAndMe(t *testing.T) {
 	}
 }
 
+func TestMeResultCompatibilityAccessors(t *testing.T) {
+	legacyOrg := Organization{ID: "legacy-org"}
+	brandCloud := Organization{ID: "brand-cloud"}
+	me := MeResult{Organizations: []Organization{legacyOrg}, Capabilities: []string{"platform.read"}}
+	if got := me.Memberships(); len(got) != 1 || got[0].ID != legacyOrg.ID {
+		t.Fatalf("legacy memberships = %#v", got)
+	}
+	if got := me.EffectivePlatformCapabilities(); len(got) != 1 || got[0] != "platform.read" {
+		t.Fatalf("legacy platform capabilities = %#v", got)
+	}
+	me.BrandCloudMemberships = []Organization{brandCloud}
+	me.PlatformCapabilities = []string{"platform.write"}
+	if got := me.Memberships(); len(got) != 1 || got[0].ID != brandCloud.ID {
+		t.Fatalf("brand cloud memberships = %#v", got)
+	}
+	if got := me.EffectivePlatformCapabilities(); len(got) != 1 || got[0] != "platform.write" {
+		t.Fatalf("platform capabilities = %#v", got)
+	}
+}
+
+func TestHTTPErrorFormatting(t *testing.T) {
+	withBody := (&HTTPError{Method: http.MethodPost, Path: "/v1/auth/login", StatusCode: http.StatusUnauthorized, Body: "invalid credentials"}).Error()
+	if !strings.Contains(withBody, "invalid credentials") {
+		t.Fatalf("error with body = %q", withBody)
+	}
+	withoutBody := (&HTTPError{Method: http.MethodGet, Path: "/v1/me", StatusCode: http.StatusUnauthorized}).Error()
+	if strings.Contains(withoutBody, ": ") || !strings.Contains(withoutBody, "returned 401") {
+		t.Fatalf("error without body = %q", withoutBody)
+	}
+}
+
 func TestClientRefresh(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -313,7 +344,7 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 			if r.URL.Query().Get("status") != "pending_verification" {
 				t.Fatalf("brand user status query = %q", r.URL.Query().Get("status"))
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"user_id": "user-1", "organization_id": "brand-1", "email": "owner@example.com", "role": "owner", "disabled_at": "2026-06-11T00:00:00Z"}}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"user_id": "user-1", "organization_id": "brand-1", "email": "owner@example.com", "role": "owner", "email_verified": false, "signup_pending_verification": true, "disabled_at": "2026-06-11T00:00:00Z", "created_at": "2026-06-10T00:00:00Z", "updated_at": "2026-06-11T00:00:00Z"}}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/disable":
 			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"user_id": "brand-user-1", "organization_id": "brand-1", "email": "owner@example.com", "disabled_at": "2026-06-11T00:00:00Z"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/enable":
@@ -359,7 +390,7 @@ func TestClientBrandCloudLifecycle(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BrandCloudUsers returned error: %v", err)
 	}
-	if len(users) != 1 || users[0].UserID != "user-1" || users[0].DisabledAt == "" {
+	if len(users) != 1 || users[0].UserID != "user-1" || users[0].EmailVerified || !users[0].SignupPendingVerification || users[0].DisabledAt == "" {
 		t.Fatalf("brand cloud users = %#v", users)
 	}
 	disabled, err := client.DisableBrandCloudUser(t.Context(), "admin-access", "brand-1", "brand-user-1")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5344,7 +5344,7 @@ func (s *Server) apiAdminBrandCloudUsers(w http.ResponseWriter, r *http.Request)
 		s.writeUpstreamReadErrorForSession(w, session.ID, err)
 		return
 	}
-	writeJSON(w, map[string][]accountclient.Member{"users": users})
+	writeJSON(w, map[string][]accountclient.BrandCloudAccountListItem{"users": users})
 }
 
 func (s *Server) apiAdminBrandCloudUserAction(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -3996,7 +3996,7 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 			if r.URL.Query().Get("status") != "pending_verification" {
 				t.Fatalf("brand cloud users status query = %q", r.URL.Query().Get("status"))
 			}
-			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"user_id": "user-1", "organization_id": "brand-1", "email": "pending@example.com", "role": "owner", "disabled_at": "2026-06-11T00:00:00Z"}}})
+			_ = json.NewEncoder(w).Encode(map[string]any{"users": []map[string]any{{"user_id": "user-1", "organization_id": "brand-1", "email": "pending@example.com", "role": "owner", "email_verified": false, "signup_pending_verification": true, "disabled_at": "2026-06-11T00:00:00Z", "created_at": "2026-06-10T00:00:00Z", "updated_at": "2026-06-11T00:00:00Z"}}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/disable":
 			_ = json.NewEncoder(w).Encode(map[string]any{"member": map[string]any{"user_id": "brand-user-1", "organization_id": "brand-1", "email": "owner@example.com", "disabled_at": "2026-06-11T00:00:00Z"}})
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/admin/brand-clouds/brand-1/users/brand-user-1/enable":
@@ -4094,7 +4094,7 @@ func TestPlatformAdminBrandCloudsProxyRequiresUpstreamToken(t *testing.T) {
 	if brandUsers.Code != http.StatusOK {
 		t.Fatalf("brand cloud users status = %d, want 200; body=%s", brandUsers.Code, brandUsers.Body.String())
 	}
-	if !strings.Contains(brandUsers.Body.String(), `"user_id":"user-1"`) {
+	if !strings.Contains(brandUsers.Body.String(), `"user_id":"user-1"`) || !strings.Contains(brandUsers.Body.String(), `"signup_pending_verification":true`) {
 		t.Fatalf("brand cloud accounts body missing global user membership: %s", brandUsers.Body.String())
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -401,11 +401,17 @@ func TestSummarySessionsFailedOperationsAndAuditWrapper(t *testing.T) {
 	if err := st.UpdateSessionTokens("missing-session", "access-x", "refresh-x", time.Hour); err != nil {
 		t.Fatalf("UpdateSessionTokens missing session returned error: %v", err)
 	}
+	if err := st.UpdateSessionKind(session.ID, "platform_admin"); err != nil {
+		t.Fatalf("UpdateSessionKind returned error: %v", err)
+	}
+	if err := st.UpdateSessionKind(session.ID, "unsupported"); err == nil {
+		t.Fatal("UpdateSessionKind accepted an unsupported session kind")
+	}
 	updated, err := st.GetSession(session.ID)
 	if err != nil {
 		t.Fatalf("GetSession returned error: %v", err)
 	}
-	if updated.ActiveOrgID != "org-nova" || updated.AccessToken != "access-2" || updated.RefreshToken != "refresh-2" {
+	if updated.Kind != "platform_admin" || updated.ActiveOrgID != "org-nova" || updated.AccessToken != "access-2" || updated.RefreshToken != "refresh-2" {
 		t.Fatalf("updated session = %#v", updated)
 	}
 

--- a/web/e2e/brand-cloud.spec.mjs
+++ b/web/e2e/brand-cloud.spec.mjs
@@ -16,7 +16,7 @@ test.describe('Brand Clouds', () => {
     await page.getByRole('button', { name: 'View', exact: true }).first().click();
     await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();
     await expect(page.getByText('SSO enabled', { exact: true })).toBeVisible();
-    await expect(page.getByText('Brand Users', { exact: true })).toBeVisible();
+    await expect(page.getByText('Global Users', { exact: true })).toBeVisible();
     await expect(page.getByText('trace-e2e-001', { exact: true })).toHaveCount(0);
   });
 
@@ -39,25 +39,20 @@ test.describe('Brand Clouds', () => {
     const dialog = page.getByRole('dialog', { name: 'Brand Cloud detail' });
     await expect(dialog).toBeVisible();
     await expect(dialog.getByRole('button', { name: 'Re-enable Brand Cloud' })).toBeVisible();
-    await expect(dialog.getByText('Pending Activation', { exact: true })).toBeVisible();
-    await dialog.getByRole('button', { name: 'Approve' }).click();
-    await expect(dialog.getByText('Brand user approved.', { exact: true })).toBeVisible();
-    await dialog.getByRole('button', { name: 'Disable', exact: true }).first().click();
-    await expect(dialog.getByText('Brand user disabled.', { exact: true })).toBeVisible();
-    await dialog.getByRole('button', { name: 'Enable', exact: true }).first().click();
-    await expect(dialog.getByText('Brand user enabled.', { exact: true })).toBeVisible();
+    const pendingUserRow = dialog.getByRole('row').filter({ hasText: 'user02-01@e2e.example' });
+    await expect(pendingUserRow.getByText('Pending Activation', { exact: true })).toBeVisible();
+    await pendingUserRow.getByRole('button', { name: 'Disable', exact: true }).click();
+    await expect(dialog.getByText('Membership disabled.', { exact: true })).toBeVisible();
+    await pendingUserRow.getByRole('button', { name: 'Enable', exact: true }).click();
+    await expect(dialog.getByText('Membership enabled.', { exact: true })).toBeVisible();
     page.once('dialog', (confirmation) => confirmation.accept());
-    await dialog.getByRole('button', { name: 'Delete', exact: true }).first().click();
-    await expect(dialog.getByText('Brand user removed.', { exact: true })).toBeVisible();
+    await pendingUserRow.getByRole('button', { name: 'Delete', exact: true }).click();
+    await expect(dialog.getByText('Membership removed.', { exact: true })).toBeVisible();
     await dialog.getByRole('button', { name: 'Re-enable Brand Cloud' }).click();
     await expect(dialog.getByText('Brand Cloud enabled.', { exact: true })).toBeVisible();
-    await dialog.getByLabel('Brand User id').fill('brand-user-beta-owner');
-    await dialog.getByRole('button', { name: 'Assign Existing Brand User' }).click();
-    await expect(dialog.getByText('Member assigned.', { exact: true })).toBeVisible();
     await dialog.getByLabel('Email').fill('new-admin@example.com');
-    await dialog.getByLabel('Temporary password').fill('e2e-temporary-password');
-    await dialog.getByRole('button', { name: 'Create Or Reactivate User' }).click();
-    await expect(dialog.getByText('Brand user created and assigned.', { exact: true })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Assign and Send Email' }).click();
+    await expect(dialog.getByText('Global user created; activation email queued.', { exact: true })).toBeVisible();
   });
 
   test('[UI-CA-CLOUD-005] create stepper completes a Brand Cloud creation', async ({ page }) => {
@@ -78,8 +73,8 @@ test.describe('Brand Clouds', () => {
     const dialog = page.getByRole('dialog', { name: 'Create Brand Cloud' });
     await dialog.getByLabel('Brand display name').fill('E2E Partial Owner Cloud');
     await dialog.getByRole('button', { name: 'Continue' }).click();
-    await dialog.getByLabel('Initial admin mode').selectOption('existing');
-    await dialog.getByRole('textbox', { name: 'Brand User id' }).fill('brand-user-alpha-owner');
+    await dialog.getByLabel('Initial admin mode').selectOption('create');
+    await dialog.getByLabel('Email').fill('partial-owner@example.com');
     await dialog.getByRole('button', { name: 'Continue' }).click();
     await dialog.getByRole('button', { name: 'Create Brand Cloud', exact: true }).click();
     await expect(page.getByRole('dialog', { name: 'Brand Cloud detail' })).toBeVisible();

--- a/web/scripts/e2e-fixture-server.mjs
+++ b/web/scripts/e2e-fixture-server.mjs
@@ -14,6 +14,10 @@ const [brandClouds, users, members, devices, operations, logs, sessions, prometh
   load('operations.json'), load('service-logs.json'), load('sessions.json'), load('prometheus-series.json'),
 ]);
 const state = { brandClouds, users, members, devices, operations, logs, sessions, prometheus, jobs: [], reports: [], sources: [], transfers: [], invitations: [], chipsetProviders: [], idempotency: new Map(), requestLog: [] };
+for (const user of state.users) {
+  if (!user.brand_cloud_id || state.members.some((member) => member.organization_id === user.brand_cloud_id && member.user_id === user.id)) continue;
+  state.members.push({ organization_id: user.brand_cloud_id, user_id: user.id, email: user.email, role: 'member' });
+}
 let platformValidationAllowed = true;
 
 const server = createServer(async (req, res) => {
@@ -445,7 +449,13 @@ async function handleResource(req, res, root, id, suffix) {
     Object.assign(brand, await readBody(req));
     return send(res, 200, { brand_cloud: brand });
   }
-  if (suffix === '/users' && req.method === 'GET') return send(res, 200, { users: state.members.filter((member) => member.organization_id === id) });
+  if (suffix === '/users' && req.method === 'GET') {
+    const memberships = state.members.filter((member) => member.organization_id === id).map((member) => {
+      const user = state.users.find((candidate) => candidate.id === member.user_id) || {};
+      return { ...user, ...member, id: user.id || member.user_id };
+    });
+    return send(res, 200, { users: memberships });
+  }
   if (suffix === '/users' && req.method === 'POST') {
     const body = await readBody(req);
     const user = { id: `user-created-${state.users.length + 1}`, email: body.email, name: body.display_name || 'E2E Created User', email_verified: false, signup_pending_verification: true, created_at: new Date().toISOString(), updated_at: new Date().toISOString() };
@@ -458,7 +468,11 @@ async function handleResource(req, res, root, id, suffix) {
   if (userAction) {
     const member = state.members.find((item) => item.user_id === decodeURIComponent(userAction[1]) && item.organization_id === id);
     if (!member) return send(res, 404, { error: 'member not found' });
-    if (userAction[2] === 'disable' || req.method === 'DELETE') member.disabled_at = new Date().toISOString();
+    if (req.method === 'DELETE') {
+      state.members.splice(state.members.indexOf(member), 1);
+      return send(res, 204, null);
+    }
+    if (userAction[2] === 'disable') member.disabled_at = new Date().toISOString();
     if (userAction[2] === 'enable') delete member.disabled_at;
     return send(res, 200, { member });
   }

--- a/web/src/brand-clouds.mjs
+++ b/web/src/brand-clouds.mjs
@@ -78,8 +78,8 @@ export function filterBrandClouds(brands, filters = {}) {
 }
 
 export function brandCloudUserStatus(user) {
-  if (user?.disabled_at) return { key: 'disabled', label: 'Disabled' };
   if (user?.signup_pending_verification) return { key: 'pending_verification', label: 'Pending Activation' };
+  if (user?.disabled_at) return { key: 'disabled', label: 'Disabled' };
   return { key: 'active', label: 'Active' };
 }
 

--- a/web/src/brand-clouds.test.mjs
+++ b/web/src/brand-clouds.test.mjs
@@ -41,7 +41,7 @@ test('filters Brand Clouds across name id owner metadata status and tier', () =>
 test('maps Brand Cloud user activation states for platform review', () => {
   assert.deepEqual(brandCloudUserStatus({}), { key: 'active', label: 'Active' });
   assert.deepEqual(brandCloudUserStatus({ signup_pending_verification: true }), { key: 'pending_verification', label: 'Pending Activation' });
-  assert.deepEqual(brandCloudUserStatus({ disabled_at: '2026-06-11T00:00:00Z', signup_pending_verification: true }), { key: 'disabled', label: 'Disabled' });
+  assert.deepEqual(brandCloudUserStatus({ disabled_at: '2026-06-11T00:00:00Z', signup_pending_verification: true }), { key: 'pending_verification', label: 'Pending Activation' });
 });
 
 test('Brand Clouds errors are stable and do not expose upstream payload details', () => {

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -4891,7 +4891,7 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onCreateUser })
 	  const path = `/api/admin/brand-clouds/${encodeURIComponent(brand.id)}/users/${encodeURIComponent(row.user_id)}`;
       if (action === 'delete') {
         await sendJSONWithMethod('DELETE', path);
-        setMessage('Brand user removed.');
+        setMessage('Membership removed.');
       } else {
         await sendJSONWithMethod('POST', `${path}/${action}`, {});
 		setMessage(action === 'disable' ? 'Membership disabled.' : 'Membership enabled.');
@@ -4999,7 +4999,7 @@ function BrandCloudDetailDrawer({ brand, onClose, onUpdateBrand, onCreateUser })
                         <td>{row.updated_at ? formatRelativeTime(row.updated_at) : '-'}</td>
                         <td>
                           <div className="row-actions">
-                            {status.key === 'disabled' ? (
+                            {row.disabled_at ? (
                               <button type="button" className="inline-action" onClick={() => updateBrandUser(row, 'enable')}><Icon name="rotate-right" />Enable</button>
 							) : (
                               <button type="button" className="inline-action" onClick={() => updateBrandUser(row, 'disable')}><Icon name="ban" />Disable</button>


### PR DESCRIPTION
## Summary
- carry global account activation state through the Brand Cloud user BFF
- distinguish pending account activation from disabled membership controls
- update fixtures and lifecycle browser tests for global users/memberships

Canonical contract: hkt999rtk/rtk_cloud_contracts_doc#129
Account Manager implementation: hkt999rtk/rtk_account_manager#290

## Validation
- `GOWORK=off go test ./internal/accountclient ./internal/app`
- `npm test -- --runInBand` (101 passed)
- Brand Cloud Playwright desktop/mobile: 5 passed, 2 scenario-gated skips
- production web build passed