### PR TITLE
fix: initialize unified account scope after email activation

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -340,6 +340,14 @@ not fall back to `/v1/brand-clouds/{tenantSlug}/auth/*`. Owner activation links
 terminate in the global activation UI and subsequent logout/login uses the same
 `/api/auth/login` path as every other human account.
 
+When email verification returns account tokens, the BFF resolves `/v1/me`
+before creating the session, selects the first membership as the active Brand
+Cloud, and uses the same membership-first view selection as global login.
+Platform-only accounts enter the platform view; accounts with neither membership
+nor platform capability receive 403 without a session cookie. The verification
+response includes the selected `kind`, which the UI uses for its destination.
+Logout remains reachable from the navigation drawer on narrow screens.
+
 ## Upstream Integration
 
 ### [REQ-CA-BFF-UPSTREAM-001] Configured upstream integrations fail explicitly and remain observable

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -150,7 +150,7 @@ paths:
         - REQ-E2E-CA-SIGNUP-EMAIL-001
       tags: [Auth]
       summary: Verify a customer signup email and set its initial password
-      description: Proxies the callback token and new password to Account Manager and creates a customer session when tokens are returned. The Web UI consumes the opaque token from the callback URL without rendering it or exposing an editable token field.
+      description: Proxies the callback token and new password to Account Manager. When tokens are returned, resolves global /v1/me before creating a unified account session, selects the first membership as the active Brand Cloud, and returns the selected view kind (membership first, otherwise platform capability). Accounts without either receive 403 without a session cookie. The Web UI consumes the opaque token from the callback URL without rendering it or exposing an editable token field and routes to the selected account view.
       security: []
       requestBody:
         required: true
@@ -171,6 +171,10 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerifyEmailResult"
         "400":
+          $ref: "#/components/responses/PlainTextError"
+        "401":
+          $ref: "#/components/responses/PlainTextError"
+        "403":
           $ref: "#/components/responses/PlainTextError"
         "502":
           $ref: "#/components/responses/PlainTextError"
@@ -3426,6 +3430,10 @@ components:
           $ref: "#/components/schemas/User"
         tokens:
           $ref: "#/components/schemas/Tokens"
+        kind:
+          type: string
+          enum: [customer, platform_admin]
+          description: Selected account view; present when activation creates a session.
     AuthSessionResult:
       type: object
       required: [status, kind]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1089,15 +1089,20 @@ func (s *Server) apiCustomerVerifyEmail(w http.ResponseWriter, r *http.Request) 
 		s.writeAuthProxyError(w, err)
 		return
 	}
+	kind := ""
 	if result.Tokens.AccessToken != "" {
-		session, sessionErr := s.sessions.CreateSession("customer", result.User.ID, result.User.Email, result.Tokens.AccessToken, result.Tokens.RefreshToken, "", tokenTTL(result.Tokens))
+		session, selectedKind, sessionErr := s.createSessionFromActivatedLogin(r.Context(), accountclient.LoginResult{User: result.User, Tokens: result.Tokens})
 		if sessionErr != nil {
-			writeError(w, sessionErr)
+			s.writeAuthProxyError(w, sessionErr)
 			return
 		}
+		kind = selectedKind
 		setSessionCookie(w, session.ID)
 	}
-	writeJSONStatus(w, http.StatusOK, result)
+	writeJSONStatus(w, http.StatusOK, struct {
+		accountclient.VerifyEmailResult
+		Kind string `json:"kind,omitempty"`
+	}{VerifyEmailResult: result, Kind: kind})
 }
 
 func (s *Server) apiCustomerVerificationStatus(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -235,6 +235,10 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 		t.Fatalf("missing verification password status = %d, want 400", missingPasswordRec.Code)
 	}
 	sessionCookie := verifyRec.Result().Cookies()[0]
+	session, err := srv.sessions.GetSession(sessionCookie.Value)
+	if err != nil || session.ActiveOrgID != "org-1" || session.Kind != "customer" {
+		t.Fatalf("activated session scope: kind=%q org=%q err=%v", session.Kind, session.ActiveOrgID, err)
+	}
 
 	replayRec := httptest.NewRecorder()
 	srv.ServeHTTP(replayRec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"consumed-token","new_password":"password123"}`)))
@@ -262,6 +266,84 @@ func TestPublicSignupVerifyAndQuotaRaiseFlow(t *testing.T) {
 	}
 	if !strings.Contains(quotaRaiseBody, `"requested_quota":25`) {
 		t.Fatalf("quota raise body = %s", quotaRaiseBody)
+	}
+}
+
+func TestEmailActivationSelectsUnifiedAccountSession(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		profile     string
+		profileCode int
+		noTokens    bool
+		wantStatus  int
+		wantKind    string
+		wantOrg     string
+	}{
+		{name: "owner", profile: `{"brand_cloud_memberships":[{"id":"brand-1","role":"owner"}]}`, wantStatus: 200, wantKind: "customer", wantOrg: "brand-1"},
+		{name: "platform only", profile: `{"platform_capabilities":["platform.audit.read"]}`, wantStatus: 200, wantKind: "platform_admin"},
+		{name: "owner and platform", profile: `{"brand_cloud_memberships":[{"id":"brand-1","role":"owner"}],"platform_capabilities":["platform.audit.read"]}`, wantStatus: 200, wantKind: "customer", wantOrg: "brand-1"},
+		{name: "no access", profile: `{}`, wantStatus: 403},
+		{name: "profile unavailable", profile: `{}`, profileCode: 503, wantStatus: 502},
+		{name: "no tokens", noTokens: true, wantStatus: 200},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v1/auth/verify-email":
+					if tc.noTokens {
+						_, _ = w.Write([]byte(`{"user":{"id":"activated-user"}}`))
+						return
+					}
+					_, _ = w.Write([]byte(`{"user":{"id":"activated-user","email":"owner@example.com"},"tokens":{"access_token":"activation-access","refresh_token":"activation-refresh","expires_in":3600}}`))
+				case "/v1/me":
+					if tc.noTokens {
+						t.Error("profile fetched without activation tokens")
+					}
+					if r.Header.Get("Authorization") != "Bearer activation-access" {
+						t.Error("profile request did not use activation access token")
+					}
+					if tc.profileCode != 0 {
+						w.WriteHeader(tc.profileCode)
+					}
+					_, _ = w.Write([]byte(tc.profile))
+				default:
+					t.Errorf("unexpected upstream request: %s", r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer upstream.Close()
+			srv := NewWithOptions(mustOpenStore(t), Options{
+				Config:        config.Config{AccountManagerBaseURL: upstream.URL},
+				AccountClient: accountclient.New(upstream.URL),
+			})
+			rec := httptest.NewRecorder()
+			srv.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/api/auth/customer/verify-email", strings.NewReader(`{"token":"activation-token","new_password":"password123"}`)))
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status=%d want=%d body=%s", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			cookies := rec.Result().Cookies()
+			if tc.wantKind == "" {
+				if len(cookies) != 0 {
+					t.Fatal("unexpected session cookie")
+				}
+				return
+			}
+			if len(cookies) != 1 {
+				t.Fatalf("cookie count=%d want=1", len(cookies))
+			}
+			session, err := srv.sessions.GetSession(cookies[0].Value)
+			if err != nil || session.Kind != tc.wantKind || session.ActiveOrgID != tc.wantOrg || session.Subject != "activated-user" {
+				t.Fatalf("session kind=%q org=%q subject=%q err=%v", session.Kind, session.ActiveOrgID, session.Subject, err)
+			}
+			var response struct {
+				Kind string `json:"kind"`
+			}
+			if err := json.Unmarshal(rec.Body.Bytes(), &response); err != nil || response.Kind != tc.wantKind {
+				t.Fatalf("response kind=%q want=%q err=%v", response.Kind, tc.wantKind, err)
+			}
+		})
 	}
 }
 

--- a/web/e2e/public-auth.spec.mjs
+++ b/web/e2e/public-auth.spec.mjs
@@ -87,3 +87,40 @@ test('[UI-CA-AUTH-002] checkbox follows the shared console control style @smoke'
     contentType: 'image/png',
   });
 });
+
+test('[UI-CA-AUTH-LOGOUT-001] logout remains reachable on desktop and mobile @smoke', async ({ page }, testInfo) => {
+  await login(page, 'customer');
+  await page.goto('/console/overview');
+  const navigationButton = page.getByRole('button', { name: 'Open navigation', exact: true });
+  if (await navigationButton.isVisible()) {
+    await navigationButton.click();
+    await page.getByRole('complementary', { name: 'Primary navigation' }).getByRole('button', { name: 'Logout', exact: true }).click();
+  } else {
+    await page.getByRole('button', { name: 'Logout', exact: true }).click();
+  }
+  await expect(page.getByRole('heading', { name: 'Sign in to Connect+', exact: true })).toBeVisible();
+  const response = await page.request.get('/api/me');
+  expect((await response.json()).authenticated).toBe(false);
+  await testInfo.attach('logged-out-viewport', { body: await page.screenshot({ fullPage: true }), contentType: 'image/png' });
+});
+
+for (const [kind, destination] of [['customer', '/console/overview'], ['platform_admin', '/admin']]) {
+  test(`[UI-CA-AUTH-ACTIVATE-001] email activation enters the ${kind} account view @smoke`, async ({ page }, testInfo) => {
+    let verificationCount = 0;
+    await page.route('**/api/auth/customer/verification-status', (route) => route.fulfill({ json: { status: 'valid' } }));
+    await page.route('**/api/auth/customer/verify-email', async (route) => {
+      verificationCount += 1;
+      expect(route.request().postDataJSON()).toEqual({ token: 'fixture-activation-token', new_password: 'activation-password-123' });
+      // Establish a fixture account session; the handler itself is covered by Go tests.
+      await login(page, kind);
+      await route.fulfill({ json: { kind, tokens: { access_token: 'fixture-activation-access' } } });
+    });
+    await page.goto('/signup/verify?token=fixture-activation-token');
+    await page.getByLabel('New password', { exact: true }).fill('activation-password-123');
+    await page.getByRole('button', { name: 'Verify and continue', exact: true }).click();
+    await expect(page).toHaveURL(new RegExp(`${destination}$`));
+    await expect(page.getByRole('heading', { name: kind === 'customer' ? 'E2E Alpha Cloud' : 'Platform Home', exact: true })).toBeVisible();
+    expect(verificationCount).toBe(1);
+    await testInfo.attach('activated-account-view', { body: await page.screenshot({ fullPage: true }), contentType: 'image/png' });
+  });
+}

--- a/web/src/main.jsx
+++ b/web/src/main.jsx
@@ -1023,9 +1023,7 @@ function App() {
     try {
       const result = await postJSON('/api/auth/customer/verify-email', payload);
       if (result.tokens?.access_token) {
-        window.history.pushState({}, '', '/console/overview');
-        setActive('overview');
-        setRefreshTick((tick) => tick + 1);
+        window.location.assign(destinationForSession({ authenticated: true, kind: result.kind || 'customer' }, loginNextFromLocation(window.location)));
       }
       return result;
     } catch (err) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5992,6 +5992,7 @@ th {
 
   .sidebar-account {
     border-top-color: rgba(255, 255, 255, .16);
+    display: flex;
     flex-wrap: wrap;
     margin-top: 24px;
   }


### PR DESCRIPTION
## Summary

- Resolve global `/v1/me` after email activation before creating the shared account session. Select the first Brand Cloud membership and membership-first view, matching global login.
- Return the selected view kind and use the shared frontend destination selector instead of hardcoding the customer overview.
- Keep Logout reachable in narrow-screen navigation.
- Document the response and add owner-only, platform-only, dual-role, no-access, upstream-error, and no-token regressions plus desktop/mobile browser coverage.

## Live finding

A real email-activated staging owner had the correct global identity and owner membership, but the activation BFF session had an empty active organization. Explicit logout and fresh login selected the correct Brand Cloud and displayed `My Role: owner`. Narrow-screen CSS also hid Logout; widening the browser allowed this existing-code login verification.

## Validation

- `GOWORK=off go test ./...` passed; total coverage 80.0%.
- Six focused desktop/mobile activation destination and logout cases passed.
- Full clean-worktree workspace pre-PR passed (`local-pre-pr-20260830T224041Z`): backend/JavaScript coverage, policy/inventory, and desktop 68/68 plus mobile 29/29 governed UI evidence cases.
- No staging database verification bypass or credential disclosure.
