### PR TITLE
docs: complete unified account session contract validation

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -483,6 +483,12 @@ Production-mode readiness precedence:
 
 ## Developer PKI Test Bundles
 
+### [REQ-CA-BFF-PKI-TEST-001] Test certificate issuance is gated and keeps private keys in the browser
+
+<!-- rtk-requirement
+{"acceptance_layer":"integration","operation_model":"independent","gate":"pr","environments":["ci"],"evidence":["json","junit"],"required":true,"status":"active"}
+-->
+
 The Developer Console exposes `POST /api/developer/pki/test-bundles/app` and
 `POST /api/developer/pki/test-bundles/device` only when
 `DEVELOPER_PKI_TEST_TOOLS_ENABLED=true` and the runtime environment is local or

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -477,6 +477,9 @@ paths:
   /api/me/view:
     post:
       operationId: postApiMeView
+      x-rtk-feature-id: FEAT-CA-BFF-001
+      x-rtk-requirement-ids:
+        - REQ-CA-BFF-LOGIN-001
       tags: [Session]
       summary: Switch between Customer and Platform views in the same account session
       requestBody:
@@ -494,7 +497,12 @@ paths:
           description: Session view updated without reauthentication.
           content:
             application/json:
-              schema: { $ref: "#/components/schemas/StatusOK" }
+              schema:
+                type: object
+                required: [status, kind]
+                properties:
+                  status: { type: string, enum: [ok] }
+                  kind: { type: string, enum: [customer, platform_admin] }
         "400": { $ref: "#/components/responses/PlainTextError" }
         "401": { $ref: "#/components/responses/PlainTextError" }
         "403": { $ref: "#/components/responses/PlainTextError" }
@@ -559,7 +567,9 @@ paths:
   /api/products/{productID}/collaborators:
     get:
       operationId: getApiProductCollaborators
-      x-rtk-requirement-ids: [REQ-CONTRACT-PRODUCT-COLLAB-001]
+      x-rtk-feature-id: FEAT-CONTRACT-AUTHZ-001
+      x-rtk-requirement-ids:
+        - REQ-CONTRACT-PRODUCT-COLLAB-001
       tags: [Developer]
       summary: List collaborators and pending invitations for one Product project
       parameters: [{ name: productID, in: path, required: true, schema: { type: string, format: uuid } }]
@@ -570,7 +580,9 @@ paths:
   /api/products/{productID}/collaborator-invitations:
     post:
       operationId: postApiProductCollaboratorInvitation
-      x-rtk-requirement-ids: [REQ-CONTRACT-PRODUCT-COLLAB-001]
+      x-rtk-feature-id: FEAT-CONTRACT-AUTHZ-001
+      x-rtk-requirement-ids:
+        - REQ-CONTRACT-PRODUCT-COLLAB-001
       tags: [Developer]
       summary: Invite a registered developer as Editor or Viewer
       parameters:
@@ -594,7 +606,9 @@ paths:
   /api/products/{productID}/collaborators/{userID}:
     patch:
       operationId: patchApiProductCollaborator
-      x-rtk-requirement-ids: [REQ-CONTRACT-PRODUCT-COLLAB-001]
+      x-rtk-feature-id: FEAT-CONTRACT-AUTHZ-001
+      x-rtk-requirement-ids:
+        - REQ-CONTRACT-PRODUCT-COLLAB-001
       tags: [Developer]
       summary: Change an Editor or Viewer role
       parameters:
@@ -604,7 +618,9 @@ paths:
       responses: { "200": { description: Collaborator updated. }, "404": { $ref: "#/components/responses/PlainTextError" } }
     delete:
       operationId: deleteApiProductCollaborator
-      x-rtk-requirement-ids: [REQ-CONTRACT-PRODUCT-COLLAB-001]
+      x-rtk-feature-id: FEAT-CONTRACT-AUTHZ-001
+      x-rtk-requirement-ids:
+        - REQ-CONTRACT-PRODUCT-COLLAB-001
       tags: [Developer]
       summary: Remove a non-owner collaborator
       parameters:
@@ -616,7 +632,9 @@ paths:
   /api/products/{productID}/owner-transfer:
     post:
       operationId: postApiProductOwnerTransfer
-      x-rtk-requirement-ids: [REQ-CONTRACT-PRODUCT-COLLAB-001]
+      x-rtk-feature-id: FEAT-CONTRACT-AUTHZ-001
+      x-rtk-requirement-ids:
+        - REQ-CONTRACT-PRODUCT-COLLAB-001
       tags: [Developer]
       summary: Atomically transfer explicit Product ownership
       parameters:
@@ -627,7 +645,9 @@ paths:
   /api/developer/product-collaborator-invitations/accept:
     post:
       operationId: postApiDeveloperProductCollaboratorInvitationsAccept
-      x-rtk-requirement-ids: [REQ-CONTRACT-PRODUCT-COLLAB-001]
+      x-rtk-feature-id: FEAT-CONTRACT-AUTHZ-001
+      x-rtk-requirement-ids:
+        - REQ-CONTRACT-PRODUCT-COLLAB-001
       tags: [Developer]
       summary: Accept a Product invitation and atomically activate membership and assignment
       parameters: [{ $ref: "#/components/parameters/IdempotencyKey" }]
@@ -874,6 +894,9 @@ paths:
   /api/developer/pki/test-bundles/app:
     post:
       operationId: postApiDeveloperPKITestBundleApp
+      x-rtk-feature-id: FEAT-CA-BFF-001
+      x-rtk-requirement-ids:
+        - REQ-CA-BFF-PKI-TEST-001
       tags: [Developer]
       summary: Issue a short-lived app certificate bundle for SDK smoke testing
       description: |
@@ -907,6 +930,9 @@ paths:
   /api/developer/pki/test-bundles/device:
     post:
       operationId: postApiDeveloperPKITestBundleDevice
+      x-rtk-feature-id: FEAT-CA-BFF-001
+      x-rtk-requirement-ids:
+        - REQ-CA-BFF-PKI-TEST-001
       tags: [Developer]
       summary: Issue a short-lived device certificate bundle for SDK smoke testing
       description: |
@@ -1658,7 +1684,8 @@ paths:
     get:
       operationId: getApiBillingSummary
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Read the active tenant billing overview.
       security: [{ SessionCookie: [] }]
@@ -1670,7 +1697,8 @@ paths:
     get:
       operationId: getApiBillingUsage
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Read server-priced current-period usage.
       security: [{ SessionCookie: [] }]
@@ -1679,7 +1707,8 @@ paths:
     get:
       operationId: getApiBillingInvoices
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: List tenant invoices.
       security: [{ SessionCookie: [] }]
@@ -1691,7 +1720,8 @@ paths:
     get:
       operationId: getApiBillingInvoice
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Read one invoice and its immutable snapshots.
       security: [{ SessionCookie: [] }]
@@ -1701,7 +1731,8 @@ paths:
     get:
       operationId: getApiBillingInvoicePdf
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Download the immutable invoice PDF.
       security: [{ SessionCookie: [] }]
@@ -1714,7 +1745,8 @@ paths:
     get:
       operationId: getApiBillingActivity
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: List normalized customer-safe billing activity.
       security: [{ SessionCookie: [] }]
@@ -1726,7 +1758,8 @@ paths:
     get:
       operationId: getApiBillingActivityDetail
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Read one customer-safe activity timeline.
       security: [{ SessionCookie: [] }]
@@ -1736,7 +1769,8 @@ paths:
     get:
       operationId: getApiBillingProfile
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Read the prospective invoice recipient profile.
       security: [{ SessionCookie: [] }]
@@ -1744,7 +1778,8 @@ paths:
     put:
       operationId: putApiBillingProfile
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Update the prospective invoice recipient profile.
       security: [{ SessionCookie: [] }]
@@ -1754,7 +1789,8 @@ paths:
     get:
       operationId: getApiBillingStatement
       x-rtk-feature-id: FEAT-CA-BFF-001
-      x-rtk-requirement-ids: [REQ-CA-BILLING-001]
+      x-rtk-requirement-ids:
+        - REQ-CA-BILLING-001
       tags: [Billing]
       summary: Export a UTF-8 tenant billing statement.
       security: [{ SessionCookie: [] }]
@@ -2297,7 +2333,7 @@ paths:
           application/json:
             schema: { type: object, additionalProperties: true }
       responses:
-        "200": { description: Affected devices, regions, services, and policy actions. }
+        "200": { description: "Affected devices, regions, services, and policy actions." }
         "403": { $ref: "#/components/responses/PlainTextError" }
 
   /api/products/{id}/releases:
@@ -2843,6 +2879,9 @@ paths:
   /api/admin/brand-clouds/{brandCloudId}/users:
     get:
       operationId: getApiAdminBrandCloudUsers
+      x-rtk-feature-id: FEAT-CA-BRAND-001
+      x-rtk-requirement-ids:
+        - REQ-UI-CA-CLOUD-004
       tags: [Platform Admin, Brand Clouds]
       summary: List global users that are members of a Brand Cloud
       parameters:
@@ -2864,6 +2903,9 @@ paths:
         "502": { $ref: "#/components/responses/PlainTextError" }
     post:
       operationId: postApiAdminBrandCloudUsers
+      x-rtk-feature-id: FEAT-CA-BRAND-001
+      x-rtk-requirement-ids:
+        - REQ-UI-CA-CLOUD-004
       tags: [Platform Admin, Brand Clouds]
       summary: Find or create a global user and add its Brand Cloud membership
       parameters:
@@ -2893,6 +2935,9 @@ paths:
   /api/admin/brand-clouds/{brandCloudId}/users/{userId}:
     delete:
       operationId: deleteApiAdminBrandCloudUserMembership
+      x-rtk-feature-id: FEAT-CA-BRAND-001
+      x-rtk-requirement-ids:
+        - REQ-UI-CA-CLOUD-004
       tags: [Platform Admin, Brand Clouds]
       summary: Soft-delete a global user's Brand Cloud membership
       parameters:
@@ -2907,6 +2952,9 @@ paths:
   /api/admin/brand-clouds/{brandCloudId}/users/{userId}/{action}:
     post:
       operationId: postApiAdminBrandCloudUserMembershipAction
+      x-rtk-feature-id: FEAT-CA-BRAND-001
+      x-rtk-requirement-ids:
+        - REQ-UI-CA-CLOUD-004
       tags: [Platform Admin, Brand Clouds]
       summary: Enable or disable a global user's Brand Cloud membership
       parameters:
@@ -3985,7 +4033,7 @@ components:
         brand_clouds:
           type: array
           items: { $ref: "#/components/schemas/DeveloperBrandCloud" }
-        pagination: { $ref: "#/components/schemas/Pagination" }
+        pagination: { $ref: "#/components/schemas/DeveloperPagination" }
         developer_cloud_limit: { type: integer, minimum: 1 }
         source_status: { type: string }
 
@@ -4004,7 +4052,7 @@ components:
         members:
           type: array
           items: { $ref: "#/components/schemas/DeveloperMembership" }
-        pagination: { $ref: "#/components/schemas/Pagination" }
+        pagination: { $ref: "#/components/schemas/DeveloperPagination" }
         source_status: { type: string }
 
     BrandCloudMemberInvitation:
@@ -4051,7 +4099,7 @@ components:
         created_at: { type: string, format: date-time }
         updated_at: { type: string, format: date-time }
 
-    Pagination:
+    DeveloperPagination:
       type: object
       required: [limit, offset, total]
       properties:


### PR DESCRIPTION
## Summary
- Document the account-view response kind and map identity operations to existing requirements.
- Split pagination components with different lower bounds and fix the malformed response description.
- Preserve Billing and Product collaboration requirement mappings in inventory-readable YAML.
- Give the existing gated PKI test workflow a stable requirement ID.

## Validation
- Dialect-aware canonical and service OpenAPI validation passes.
- Strict spec inventory has zero blocking findings with companion canonical d782b3b and Account Manager 824e6aa.
- Workspace policy matrix passes locally.

Docs only: unified-session runtime fixes remain local for a follow-up implementation PR. Workspace pointer update and clean committed pre-PR gate follow leaf merges.