### PR TITLE
docs: My Clouds and cloud-scoped Product console design

### DIFF
--- a/docs/MULTICLOUD_WEBUI.md
+++ b/docs/MULTICLOUD_WEBUI.md
@@ -70,8 +70,8 @@ history access; separately audited platform history is not a customer-view route
 Transfer UI identifies source and target, eligible/quota state, ownership version,
 balance/currency/snapshot version, debt/payment/work blockers and durable progress.
 Before request/acceptance, show that the current owner must settle Billing and
-leave strictly positive available credit: zero and negative balance cannot
-transfer. Render `balance_not_positive` with the observed balance, separately
+leave nonnegative available credit: zero is eligible, negative balance cannot
+transfer. Render `balance_negative` with the observed balance, separately
 from unsettled invoices/usage and pending financial work; a positive number alone
 does not enable transfer. Server eligibility and fenced rechecks remain authoritative.
 Both parties explicitly confirm the same amount; changes clear old confirmations.
@@ -88,13 +88,14 @@ to switch ownership back. Precommit cancellation waits for confirmed hold releas
 The new owner sets up their payment instrument/consent independently. Old owner's
 tab is removed from the cloud only after committed authority changes; other clouds
 and the shared global session remain usable.
-If final settlement leaves zero/negative credit, explain that transfer is blocked
+If final settlement leaves negative credit, explain that transfer is blocked
 and the original owner remains responsible. Offer precommit cancellation; only
 after confirmed hold release may the original owner settle/top up normally and
 start a fresh transfer. Do not offer payment inside a fenced handoff. Test negative,
-zero, positive-but-unsettled, eligible-positive and positive-to-zero race states.
+zero/positive-but-unsettled, eligible-zero/positive and nonnegative-to-negative
+race states. Positive-to-zero requires fresh confirmation of the new snapshot.
 The delete dialog continues to require zero balance; its rule is intentionally
-different from transfer's positive-balance requirement.
+different from transfer's nonnegative-balance requirement.
 
 ## BFF and verification
 

--- a/docs/MULTICLOUD_WEBUI.md
+++ b/docs/MULTICLOUD_WEBUI.md
@@ -69,6 +69,11 @@ history access; separately audited platform history is not a customer-view route
 
 Transfer UI identifies source and target, eligible/quota state, ownership version,
 balance/currency/snapshot version, debt/payment/work blockers and durable progress.
+Before request/acceptance, show that the current owner must settle Billing and
+leave strictly positive available credit: zero and negative balance cannot
+transfer. Render `balance_not_positive` with the observed balance, separately
+from unsettled invoices/usage and pending financial work; a positive number alone
+does not enable transfer. Server eligibility and fenced rechecks remain authoritative.
 Both parties explicitly confirm the same amount; changes clear old confirmations.
 Email acceptance preserves the token through login and removes it from visible
 URL/history after capture. Token possession alone is not acceptance or consent.
@@ -83,6 +88,13 @@ to switch ownership back. Precommit cancellation waits for confirmed hold releas
 The new owner sets up their payment instrument/consent independently. Old owner's
 tab is removed from the cloud only after committed authority changes; other clouds
 and the shared global session remain usable.
+If final settlement leaves zero/negative credit, explain that transfer is blocked
+and the original owner remains responsible. Offer precommit cancellation; only
+after confirmed hold release may the original owner settle/top up normally and
+start a fresh transfer. Do not offer payment inside a fenced handoff. Test negative,
+zero, positive-but-unsettled, eligible-positive and positive-to-zero race states.
+The delete dialog continues to require zero balance; its rule is intentionally
+different from transfer's positive-balance requirement.
 
 ## BFF and verification
 

--- a/docs/MULTICLOUD_WEBUI.md
+++ b/docs/MULTICLOUD_WEBUI.md
@@ -1,0 +1,97 @@
+# My Clouds and Product-scoped console design
+
+Status: design-first target. Canonical MULTICLOUD_OWNERSHIP.md governs ownership,
+sharing, deletion and Billing handoff. This document does not claim implementation.
+
+## Navigation and session
+
+One global account session serves developer and Platform views. Honor a safe,
+authorized login next first; otherwise memberships lead to /console/clouds,
+platform-only capability to Platform View, and neither to a clear no-access page.
+No additional login or per-cloud identity is introduced.
+
+| Page | Content and authority |
+| --- | --- |
+| /console/clouds | All / Owned / Shared tabs, cloud name, owner, my role, status, owned quota, pagination; Create for eligible accounts |
+| /console/clouds/{cloudId} | Cloud overview, Products, members/access, owner-only Billing, settings and audit |
+| /console/clouds/{cloudId}/products/{productId} | Product overview, Devices, Firmware, OTA and service settings under the same cloud |
+
+Cloud lifecycle is not hidden inside the Platform Admin console. The My Clouds
+page owns create/edit/share/transfer/delete entry points for ordinary developers.
+Backend capabilities control buttons; UI role labels are not authorization.
+Show filtered total separately from owned quota (shared clouds do not count).
+
+Every BFF request binds explicit cloud ID from route/request and verifies it
+against current Account Manager membership, lifecycle and capabilities. Product
+ID must belong to that cloud. Do not let a session-global active cloud override
+a tab's request. Two tabs may operate two clouds. Cancel outstanding requests on
+navigation, reject stale responses and partition caches by cloud/authorization
+version. Server-held jobs and downloads keep immutable scope and revalidate
+authority. Old routes redirect only when scope is unambiguous and authorized;
+never replay a mutation against a newly selected cloud.
+
+## CRUD and collaboration
+
+Create: name and optional description; show owned count/limit; generate one
+idempotency key per deliberate submission and reuse it on retry. The creator
+becomes sole owner. Edit changes name/description, not cloud UUID/tenant slug.
+
+Share: target verified developer email, role and scope. Default viewer with
+selected Products; require at least one accessible same-cloud Product. An empty
+cloud can be shared by explicitly selecting whole-cloud viewer. Whole-cloud text
+states that future Products are included. Viewer does not include Billing,
+secrets, payment methods or playback. Existing admin/member grants remain visible
+without being mislabeled read-only. Show pending invites with resend/cancel and
+30-minute expiry; recipient must explicitly accept in the matching global session.
+
+Members: owner alone manages cloud admission and approved Product scope. Product
+collaboration cannot auto-enroll external users or re-enable disabled membership.
+Removing access invalidates downstream grants; rejoin requires new grants. Show
+an explanatory access-revoked state if the current tab loses authorization.
+
+Delete: fetch deletion-preflight; render resource, running-work, balance,
+unsettled-usage/payment/refund/dispute and unavailable-service blockers separately.
+Only an empty, zero-balance settled cloud is eligible. Explicit confirmation
+submits DELETE with an idempotency key; server rechecks and returns 202/operation.
+Show durable progress, retryable failure and completion, never optimistic success.
+Historical records are retained; no nonempty-cloud cascade-delete option exists.
+
+## Ownership and Billing
+
+Only the cloud owner sees tenant Billing. Platform access remains a separate
+audited view and cannot use arbitrary actor/permission headers from the browser.
+An owner of another cloud receives no Billing visibility here.
+
+Transfer UI identifies source and target, eligible/quota state, ownership version,
+balance/currency/snapshot version, debt/payment/work blockers and durable progress.
+Both parties explicitly confirm the same amount; changes clear old confirmations.
+Email acceptance preserves the token through login and removes it from visible
+URL/history after capture. Token possession alone is not acceptance or consent.
+
+Explain before acceptance: positive balance stays with the cloud; old payment
+methods/auto-charge consent do not; cost-producing operations may pause during
+settlement; old owner loses all cloud/Product/Billing access; Product-owner roles
+held by that person move to the new owner. Existing other collaborators remain.
+
+After owner commit, failed finalization shows recovery-in-progress, not a button
+to switch ownership back. Precommit cancellation waits for confirmed hold release.
+The new owner sets up their payment instrument/consent independently. Old owner's
+tab is removed from the cloud only after committed authority changes; other clouds
+and the shared global session remain usable.
+
+## BFF and verification
+
+Extend /api/developer/brand-clouds with POST, PATCH/detail, deletion-preflight,
+DELETE, operation status and versioned transfer preview/confirmation. Preserve
+existing invitation/acceptance paths and extend viewer access_scope. Whitelist
+mutable fields, enforce CSRF/idempotency and never proxy caller-supplied trusted
+Billing actor headers. All cloud-scoped existing BFF endpoints gain explicit,
+validated scope; ownership management never trusts cached role snapshots alone.
+
+Desktop/mobile E2E covers empty and multi-page cloud lists, owned/shared totals,
+creation quota, edit, invited viewer scopes/current/future Products, revoked access,
+two-tab concurrent clouds, stale requests, safe next/old URLs, deletion blockers,
+balanced transfer confirmation and persistent failure/retry states. Use mocked
+provider service only for CI; real staging activation, sharing, device association,
+certificate and MQTT evidence remains a separate release gate. No snapshots or
+passing tests are claimed by this design-only change.

--- a/docs/MULTICLOUD_WEBUI.md
+++ b/docs/MULTICLOUD_WEBUI.md
@@ -61,6 +61,11 @@ Historical records are retained; no nonempty-cloud cascade-delete option exists.
 Only the cloud owner sees tenant Billing. Platform access remains a separate
 audited view and cannot use arbitrary actor/permission headers from the browser.
 An owner of another cloud receives no Billing visibility here.
+Historical invoices, activity, exports and downloads show only the current
+owner's responsibility periods plus the confirmed opening balance. Do not show
+predecessor payer identity, invoices or line-item history; mixed-period data is
+withheld unless the server provides a safe projection. Old owners have no cloud
+history access; separately audited platform history is not a customer-view route.
 
 Transfer UI identifies source and target, eligible/quota state, ownership version,
 balance/currency/snapshot version, debt/payment/work blockers and durable progress.

--- a/docs/MULTICLOUD_WEBUI.md
+++ b/docs/MULTICLOUD_WEBUI.md
@@ -9,6 +9,11 @@ One global account session serves developer and Platform views. Honor a safe,
 authorized login next first; otherwise memberships lead to /console/clouds,
 platform-only capability to Platform View, and neither to a clear no-access page.
 No additional login or per-cloud identity is introduced.
+For an eligible developer with no memberships, the no-access state explains the
+absence of cloud access and links to My Clouds/create; it is not an account lockout.
+My Clouds may show an empty list and quota without requiring existing ownership.
+Viewer-only developers and owners deleting their last cloud can create a new
+owned cloud. The backend rechecks account eligibility and quota on submission.
 
 | Page | Content and authority |
 | --- | --- |
@@ -21,7 +26,7 @@ page owns create/edit/share/transfer/delete entry points for ordinary developers
 Backend capabilities control buttons; UI role labels are not authorization.
 Show filtered total separately from owned quota (shared clouds do not count).
 
-Every BFF request binds explicit cloud ID from route/request and verifies it
+Every cloud-scoped BFF request binds explicit cloud ID from route/request and verifies it
 against current Account Manager membership, lifecycle and capabilities. Product
 ID must belong to that cloud. Do not let a session-global active cloud override
 a tab's request. Two tabs may operate two clouds. Cancel outstanding requests on
@@ -29,6 +34,9 @@ navigation, reject stale responses and partition caches by cloud/authorization
 version. Server-held jobs and downloads keep immutable scope and revalidate
 authority. Old routes redirect only when scope is unambiguous and authorized;
 never replay a mutation against a newly selected cloud.
+Global login, account/session, My Clouds list/create and platform APIs do not
+require a selected cloud. They validate their global account/platform authority;
+creating a cloud assigns the caller its initial ownership atomically.
 
 ## CRUD and collaboration
 
@@ -43,6 +51,11 @@ states that future Products are included. Viewer does not include Billing,
 secrets, payment methods or playback. Existing admin/member grants remain visible
 without being mislabeled read-only. Show pending invites with resend/cancel and
 30-minute expiry; recipient must explicitly accept in the matching global session.
+Replay requires the same target, role and complete normalized scope. If an existing
+pending invite has a different Product set or scope kind, show a conflict with its
+unchanged scope and offer cancel then create; never report the requested narrowing
+as applied. Resend preserves scope. Test reordered equivalent IDs, changed-scope
+conflicts and cancel/recreate with old-token rejection and new-scope-only access.
 
 Members: owner alone manages cloud admission and approved Product scope. Product
 collaboration cannot auto-enroll external users or re-enable disabled membership.

--- a/docs/MULTICLOUD_WEBUI.md
+++ b/docs/MULTICLOUD_WEBUI.md
@@ -1,6 +1,6 @@
 # My Clouds and Product-scoped console design
 
-Status: design-first target. Canonical MULTICLOUD_OWNERSHIP.md governs ownership,
+Status: design-first target. Canonical [MULTICLOUD_OWNERSHIP.md](https://github.com/hkt999rtk/rtk_cloud_contracts_doc/blob/codex/multicloud-owner-design/MULTICLOUD_OWNERSHIP.md) governs ownership,
 sharing, deletion and Billing handoff. This document does not claim implementation.
 
 ## Navigation and session
@@ -58,6 +58,10 @@ as applied. Resend preserves scope. Test reordered equivalent IDs, changed-scope
 conflicts and cancel/recreate with old-token rejection and new-scope-only access.
 
 Members: owner alone manages cloud admission and approved Product scope. Product
+membership readback uses `GET /api/developer/brand-clouds/{cloudId}/members`,
+proxying the owner-authorized member collection and its current persisted scopes.
+Reload after PATCH and acceptance; do not reconstruct grants from old invitations.
+Product
 collaboration cannot auto-enroll external users or re-enable disabled membership.
 Removing access invalidates downstream grants; rejoin requires new grants. Show
 an explanatory access-revoked state if the current tab loses authorization.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -316,12 +316,12 @@ Unified account sessions:
 - route guards use global capabilities and active-organization capabilities,
   not the login path or a UI role switch
 - a valid `next` route is honored only when authorized; otherwise the default is
-  Brand Fleet when memberships exist, then Platform View when platform access
+  My Clouds (`/console/clouds`) when memberships exist, then Platform View when platform access
   exists, otherwise the no-access page
 - accounts with both platform capability and Brand Cloud membership can switch
   views and organizations without logging in again
-- switching active organization revalidates membership; failure retains the
-  previous active organization
+- switching clouds revalidates the explicit route/request scope for that tab;
+  failure retains that tab's previous authorized route, not a shared session scope
 - demo mode remains available only for local development when Account Manager
   is not configured
 - Cloud Admin does not provide a local break-glass administrator account.
@@ -376,23 +376,34 @@ Service health:
 
 ## Billing BFF And Customer View
 
-### [REQ-CA-BILLING-001] Billing UI is active-organization scoped and provider safe
+### [REQ-CA-BILLING-001] Billing UI is explicitly cloud scoped and provider safe
 
 <!-- rtk-requirement
 {"acceptance_layer":"ui","operation_model":"independent","gate":"pr","environments":["local","ci"],"evidence":["json","screenshot"],"required":true,"status":"active"}
 -->
 
-Acceptance: `/console/billing` resolves the organization exclusively from the
-authenticated account session's active membership, displays integer-minor-unit balance and ledger
+Acceptance: `/console/clouds/{cloudId}/billing` explicitly identifies the cloud;
+each request revalidates the session's current sole ownership of that cloud,
+ownership version and capabilities. It displays integer-minor-unit balance and ledger
 facts, safe payment-method metadata, automatic top-up guardrails, and normalized
 intent states; it never accepts or displays PAN, CVV, opaque provider method
 references, provider transaction references, request hashes, or raw provider
 payloads.
 
-The BFF exposes `/api/billing/*` routes and maps them to the Account Manager
-`/v1/orgs/{activeOrgId}/*` contract. `Idempotency-Key`, `If-Match`, and
+The BFF exposes cloud-bound `/api/developer/brand-clouds/{cloudId}/billing/*`
+routes and maps them to Account Manager `/v1/orgs/{cloudId}/*` operations. There
+is no session-global active membership fallback. Legacy `/console/billing` and
+`/api/billing/*` cannot execute ambiguous operations: navigate only when an
+explicit authorized cloud can be recovered, otherwise require selection; never
+replay a mutation against the last session-selected cloud. `Idempotency-Key`, `If-Match`, and
 `X-Request-Id` are forwarded where applicable. Upstream payment errors are
 reduced to an allowlist of stable customer-safe codes and messages.
+Bind forms, cached data, payment intents, hosted-return state and idempotency
+context to cloud UUID/actor/ownership version. Two tabs remain independent;
+reject stale state after ownership changes and suppress superseded responses.
+Tenant financial-history reads also enforce responsibility periods as described
+in [MULTICLOUD_WEBUI.md](MULTICLOUD_WEBUI.md); owner role alone does not reveal
+predecessor records. Non-owner viewer/admin/member Billing access is denied.
 
 NewebPay hosted setup and merchant-initiated charge controls remain visibly
 `BLOCKED` until written capability approval and sandbox qualification exist.

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -581,11 +581,16 @@ boundary are defined by
 `rtk_cloud_contracts_doc/CHIPSET_SDK_INFORMATION_PROVIDER.md`.
 # Developer Brand Fleet Dashboard contract
 
-The Developer console uses one global developer session and a server-side
-active Brand Cloud scope. `/api/developer/brand-clouds` is the selector source
-of truth; switching validates membership, refreshes capabilities, and clears
-cloud-scoped frontend state. Fleet routes do not trust browser-supplied tenant
-IDs or totals.
+The multi-cloud target UI is specified in [MULTICLOUD_WEBUI.md](MULTICLOUD_WEBUI.md):
+My Clouds precedes cloud management and Product navigation, and tenant Billing
+requires the sole owner. The design is not a claim of deployed UI completeness.
+
+The Developer console uses one global developer session and explicit per-request
+Brand Cloud scope. `/api/developer/brand-clouds` is the list/selector source of
+truth; switching validates membership, refreshes capabilities, and isolates
+cloud-scoped frontend state. A browser cloud ID is untrusted input to validate,
+not permission, and a session-global selection cannot override another tab's
+scope. Fleet routes do not trust browser-supplied totals.
 
 Authorization uses explicit capabilities rather than a UI role switch. Jobs,
 reports, and provisioning store immutable server-side scope snapshots and
@@ -614,12 +619,14 @@ reason. Team management uses `/api/developer/*`; Platform Admin Brand Cloud
 lifecycle management remains under `/api/admin/*`.
 
 Developer team writes are owner-only. Inviting an existing verified Developer
-creates a 30-minute pending invitation for the `admin` or `member` role and
+creates a 30-minute pending invitation for the `admin`, `member` or `viewer` role and
 does not create membership. The Team page lists pending invitations and offers
 explicit resend and cancel actions. The email acceptance route preserves the
 token across authentication, removes it from the visible URL after capture,
 and requires an explicit accept action from the matching signed-in Developer.
-Ownership changes continue to use the separate owner-transfer workflow.
+Viewer invitations explicitly select Products or whole-cloud future-inclusive
+read-only scope. Ownership changes use the separate Billing-coordinated transfer
+workflow and remove the previous owner's access rather than leaving them admin.
 
 
 ## RTK Feature Requirement Inventory

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -197,12 +197,14 @@ memberships without re-authentication.
 - `GET /healthz`: plain health check.
 - `POST /api/auth/login`: the only human password-login BFF route. It calls
   Account Manager `/v1/auth/login` once, then `/v1/me`, and stores one account
-  session containing the upstream tokens, global capabilities, memberships,
-  and active organization selection.
+  session containing upstream tokens, global capabilities and memberships;
+  cloud authorization is resolved separately for each explicitly scoped request.
 - `POST /api/auth/logout`: deletes local session metadata.
-- `GET /api/me`: current user, global capabilities, memberships, active
-  organization, available views, and demo/auth state.
-- `POST /api/me/active-org`: switches active organization for the current session.
+- `GET /api/me`: current user, global capabilities, cloud memberships, available
+  views and demo/auth state; any legacy selected-cloud field is only a UI hint.
+- `POST /api/me/active-org`: compatibility validation of a requested cloud and
+  its current capabilities; it cannot set shared session authorization scope or
+  change the target of another tab's reads/mutations.
 - `GET /api/summary`: customer and platform dashboard summary.
 - `GET /api/admin/platform-dashboard`: platform-admin protected Platform
   Dashboard BFF contract with server-side allowlisted Prometheus queries for
@@ -298,8 +300,9 @@ of hiding the entire dashboard.
 -->
 
 Acceptance: Daily human access uses Account Manager SSO or the single password
-login, every route checks the session's effective capability and selected
-organization, expired/invalid upstream tokens delete local session metadata and
+login; global routes check global account/platform capabilities, while cloud
+routes resolve capabilities from each request's explicitly validated cloud ID,
+never a session-global selected organization. Expired/invalid upstream tokens delete local session metadata and
 clear the cookie before returning 401, and no local break-glass account exists.
 
 Production human authentication is verified by Account Manager. Admin Console
@@ -313,8 +316,9 @@ Unified account sessions:
 
 - credentials are posted once, only to `/api/auth/login`, and never stored
 - the BFF stores session metadata plus upstream access/refresh tokens
-- route guards use global capabilities and active-organization capabilities,
-  not the login path or a UI role switch
+- global route guards use global capabilities; cloud route guards resolve current
+  membership/capabilities for that request's validated cloud UUID, not a shared
+  active-organization snapshot, login path or UI role switch
 - a valid `next` route is honored only when authorized; otherwise the default is
   My Clouds (`/console/clouds`) when memberships exist, then Platform View when platform access
   exists, otherwise the no-access page
@@ -557,7 +561,8 @@ Environment variables:
 - Store tests for SQLite schema creation, seed data, device queries, operation queries, audit metadata insertion, migration idempotence, and upgrade from the current v2 schema.
 - Store tests for versioned migrations, admin password verification, and session expiry.
 - App tests for one-request account login, upstream proxy mode, provision proxy,
-  active-organization switching, dual Platform/Brand capability, and route guards.
+  independent per-tab cloud switching, global-route access without cloud selection,
+  dual Platform/Brand capability, and request-scoped route guards.
 - Frontend build verification with `npm run build`.
 - Backend build verification with `go test ./...` and `go build ./cmd/server`.
 - Native server smoke verification for `/healthz`, `/api/service-health`, the

--- a/docs/webui-customer-view-design.md
+++ b/docs/webui-customer-view-design.md
@@ -1,16 +1,19 @@
 # Brand Fleet Management WebUI Design
 
-Status: current approved direction for the Brand Fleet Management refresh.
+Status: Brand Fleet layout reference. The design-first
+[multi-cloud WebUI contract](MULTICLOUD_WEBUI.md) supersedes cloud navigation,
+scope, sharing, ownership and Billing behavior below; runtime changes wait for
+the complete docs-only review/merge gate.
 
 ## Runtime Brand Cloud session contract
 
-The production console uses one global human account session and a server-side
-active Brand Cloud scope. The shell displays the signed-in developer identity
-and a selector populated only by `GET /api/developer/brand-clouds`. Switching
-clouds refreshes `/api/me`, capabilities, and every cloud-scoped query; a
-failed switch keeps the previous cloud active. URLs are cloud-scoped and safe
-to deep-link or refresh. A browser-supplied `brand_cloud_id` is never trusted
-for fleet authorization.
+The target console uses one global human account session, with cloud scope
+explicit in each route and BFF request. The server validates that scope against
+current membership/capabilities; no session-global active-cloud selection may
+override it. The shell selector is populated by `GET /api/developer/brand-clouds`
+and navigates only its own tab. Switching cancels old requests and isolates caches
+by cloud; failure preserves the current tab's authorized route. URLs support
+deep-link/refresh only after scope validation, never by trusting a browser ID.
 
 Navigation and actions are derived from active-cloud capabilities, not a UI
 role switch. Display roles remain useful for explanation, but authorization
@@ -19,7 +22,7 @@ uses the capability matrix in `ROLES.md`.
 The login page posts credentials exactly once to `POST /api/auth/login`. The BFF
 calls Account Manager global login and `/v1/me`; the browser never probes
 separate customer, platform, or tenant login endpoints. A valid deep-link
-`next` route wins when authorized. Otherwise the default landing is Brand Fleet
+`next` route wins when authorized. Otherwise the default landing is My Clouds
 when at least one membership exists, Platform View when only platform access
 exists, and a no-access page when neither exists. A dual-capability account can
 switch Platform View, Brand Fleet, and active Brand Clouds without logging in
@@ -391,8 +394,10 @@ and tab strip. The content responsibilities are:
   acceptance for every authenticated customer developer, and PKI test bundle
   issuance for `pki.test.issue`.
 
-The organization selector remains the single authority for active scope. The
-page header must not introduce a second Brand Cloud picker.
+The validated route/request cloud ID is the authority for that request's scope.
+The organization selector navigates the current tab; it is not shared session
+state and cannot redirect another tab's operations. Avoid duplicate pickers in
+one page header.
 
 ### Access data composition and failure isolation
 


### PR DESCRIPTION
Designs ordinary developer My Clouds all/owned/shared management, create/edit/share/transfer/delete flows, Products below each cloud, owner-only Billing, explicit per-request BFF scope and browser-tab/cache isolation. Documents durable blockers/progress and desktop/mobile acceptance. Removes obsolete session-global cloud authority and previous-owner admin retention language.

Docs only, dependent on reviewed canonical multi-cloud contract. No UI, BFF implementation or browser session was changed. Runtime/BFF OpenAPI delivery follows the full design gate.

Validation: default clean-worktree pre-PR local-pre-pr-20260831T030206Z PASS on d2562c4, selected Go/JS coverage and complete configured desktop/mobile E2E; new UI is not claimed implemented.

Latest revision: transfer requires fully settled available balance >= 0 (zero allowed, negative rejected), with all independent settlement blockers retained. Supersedes earlier strictly-positive wording. Default clean-worktree pre-PR local-pre-pr-20260831T034310Z passed at integration 6f0e587; four OpenAPI files, required inventory (zero blockers), catalog and balance-boundary checks passed. Current-head CI remains required.

Approval: user approved the design review and instructed execution on 2026-08-31, including the previously asked financial-history visibility rule. Known review findings have been addressed; runtime follows the complete docs merge.

Final local validation: default clean-worktree pre-PR local-pre-pr-20260831T035526Z PASS at integration 299a690; 4 OpenAPI documents, 601 operations / zero inventory blockers, catalog, phase-aware status schema cases PASS. New runtime/staging acceptance remains pending.