### PR TITLE
docs: Clarify offline SQLite backup and restore

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,16 @@ permissions:
 
 jobs:
   validate:
-    runs-on: [self-hosted, Linux, X64]
+    # PR validation is isolated from shared/offline self-hosted runners.
+    runs-on: ${{ fromJSON(github.event_name == 'pull_request' && '["ubuntu-latest"]' || '["self-hosted", "Linux", "X64"]') }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - name: Checkout workspace contracts when token is available
         env:

--- a/docs/private-cloud-deployment.md
+++ b/docs/private-cloud-deployment.md
@@ -128,8 +128,11 @@ JavaScript call the Grafana Service directly.
 
 ## Backup, Restore, And Rollback
 
-Back up the SQLite database file together with any `-wal` or `-shm` sidecar
-files when the database is in use.
+The workspace [Core Backup and Restore](../../../docs/backup-restore.md) owns
+coordinated environment recovery. V1 stops writers and archives the complete
+dedicated SQLite PVC, including any remaining WAL sidecars. Copying a live
+database and sidecars separately is not a consistent backup; use SQLite's
+backup API for an independent service-local online backup instead.
 
 For LKE, take a storage-level snapshot or quiesced file backup of the PVC before
 upgrades that may alter Admin state. Rollback must pair the known-good release
@@ -138,11 +141,12 @@ replace this section with the approved database restore procedure.
 
 Practical workflow:
 
-1. Stop the service or quiesce traffic.
-2. Copy the current database file from `DATABASE_PATH`.
+1. Stop all service processes using the database (blocking HTTP alone is insufficient).
+2. Archive the database from `DATABASE_PATH` and any remaining WAL/sidecar
+   state together; verify `PRAGMA integrity_check` on a restored copy.
 3. Archive the release version that produced the running service.
-4. Restore by replacing the database file and redeploying the known-good
-   release artifact.
+4. Restore into the stopped dedicated PVC with no stale database/WAL files,
+   using the known-good compatible release artifact.
 5. Roll back by restoring the previous database snapshot and the previous app
    artifact together.
 


### PR DESCRIPTION
Current status: merged after PR CI passed. The PR-only hosted runner correction resolved the offline self-hosted queue; staging was not operated.

## Summary

Workspace coordination PR: https://github.com/hkt999rtk/rtk_cloud_workspace/pull/374

Replace unsafe live-file-copy guidance with stopped-writer PVC archives, WAL handling and restored-copy integrity validation.

Companion to the workspace core backup/restore draft. The authoritative cross-repository procedure is [docs/backup-restore.md](https://github.com/hkt999rtk/rtk_cloud_workspace/blob/codex/core-backup-restore/docs/backup-restore.md). Service documentation owns service-local details; contracts retain normative authority.

## Initial publication hold (superseded by owner merge authorization)

- Opened as a draft at the user's request. Shared staging is actively used by other testers.
- No tests, deployments, backup/restore operations or manual workflow dispatches were run for this PR publication.
- The commit intentionally includes `[skip ci]` to suppress automatic push/pull_request CI. This is not a passing CI result; validation is deferred until the owner releases the hold.
- Service documentation plus a PR-only CI runner correction: use GitHub-hosted Ubuntu with the repository's Go version; retain existing self-hosted routing for other events. No runtime deployment/infrastructure change.

## Coordination and remaining work

The owner subsequently authorized CI fixes and merge; the initial publication hold is no longer active. Shared staging remains excluded. Review together with the workspace and other companion PRs; merge leaf PRs first when authorized, then update the workspace gitlinks to the actual merged commits. Workspace environment inventories/check hooks and real OpenBao/PVC/remote-storage recovery qualification remain unfinished. This is not production readiness evidence.

