### PR TITLE
ci: Restore self-hosted validation and runner guidance

### DIFF
--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -1,6 +1,7 @@
 # CI Environment Notes
 
-The GitHub Actions CI workflow runs on GitHub-hosted `ubuntu-latest`.
+The GitHub Actions CI workflow runs on a self-hosted Linux x64 runner
+with labels `self-hosted`, `Linux`, and `X64`.
 It builds the Go server, builds the React frontend, and runs native smoke
 checks against the built server binary.
 
@@ -19,8 +20,8 @@ and continues with repo-local tests.
 
 Use the GitHub Actions run page to verify:
 
-- the job is assigned to `ubuntu-latest` instead of waiting for a repository
-  runner
+- a repository runner matching `self-hosted`, `Linux`, and `X64` is online
+  and the job is assigned to that runner
 - the workspace contracts checkout step either succeeds or is skipped
   with the expected warning
 - the Go, frontend, and native smoke steps finish with the expected checks
@@ -32,8 +33,10 @@ gh run view <run-id> --log
 
 ## Recovery
 
-If CI is queued for more than a few minutes, verify the workflow still uses
-`runs-on: ubuntu-latest` and rerun the workflow from GitHub.
+If CI is queued for more than a few minutes, verify the matching repository
+runner is online, inspect its service and connectivity, and restore runner
+availability. Keep `runs-on: [self-hosted, Linux, X64]`; do not switch to a
+GitHub-hosted runner to bypass an offline runner.
 
 If smoke checks fail, reproduce locally:
 


### PR DESCRIPTION
## Summary

Restore the CI validation job to `runs-on: [self-hosted, Linux, X64]` for every event, including pull requests, as explicitly requested by the owner. This corrects the PR-only GitHub-hosted routing introduced in #316. All test steps, coverage thresholds, and permissions are unchanged. Update `docs/ci-runner.md` to match the self-hosted routing and explain offline-runner recovery without changing runner type.

## Validation and runner availability

- YAML parsing and structural comparison passed: only this job's runner selection changed.
- Full default workspace local pre-PR gate passed on integration checkpoint `63f36f8`: `go run ./scripts/go/rtk-cloud -- pre-pr --base origin/main --run-id recovery-selfhosted-local`. All selected Go/JavaScript coverage and desktop/mobile UI checks ran; no gate was disabled. The checkpoint includes this service head alongside the coordinated self-hosted corrections.
- Shared staging is excluded; no deployment or live backup/restore operation is performed.
- The owner temporarily restored self-hosted runner availability. CI run 33415951605 ran on ci-0, reached post-setup-go cleanup, then failed with GitHub's runner-lost-communication annotation. No test step is marked failed. All five runners subsequently reported offline again; restore stable connectivity before rerunning. No filesystem repair, remount, or host restart was performed by this task.
- Do not bypass CI or switch back to GitHub-hosted runners. Wait for authoritative CI to pass before merging.

Coordinate the final merged gitlink with hkt999rtk/rtk_cloud_workspace#374.
