### PR TITLE
ci: avoid setup-go cache hang on self-hosted runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false
 
       - name: Checkout workspace contracts when token is available
         env:


### PR DESCRIPTION
Disables the setup-go module cache for this validation job. The merged multi-cloud main run completed all checks but remained stuck in the setup-go post-cache step on the self-hosted runner. Dependency download remains handled by Go and npm; this removes only the Actions cache save/restore hook.