### PR TITLE
test: preserve passing UI evidence on failed reruns

### DIFF
--- a/web/scripts/test-evidence-reporter.mjs
+++ b/web/scripts/test-evidence-reporter.mjs
@@ -60,19 +60,30 @@ export default class EvidenceReporter {
   }
 
   async onEnd() {
+    const previousPath = path.join(this.runDir, 'evidence-manifest.json');
+    let previous = [];
+    if (fs.existsSync(previousPath)) {
+      try {
+        previous = JSON.parse(fs.readFileSync(previousPath, 'utf8')).cases || [];
+      } catch {
+        this.errors.push('existing evidence-manifest.json is unreadable');
+      }
+    }
+    const previousByID = new Map(previous.map((item) => [item.test_id, item]));
     const records = [];
     for (const [testID, attempts] of [...this.attempts.entries()].sort(([a], [b]) => a.localeCompare(b))) {
       const finalAttempt = attempts.at(-1);
       const screenshot = [...finalAttempt.attachments].reverse().find((item) => item.content_type === 'image/png' && item.path && fs.existsSync(item.path));
       const stableScreenshot = path.join(this.runDir, 'evidence', `${testID}.png`);
       let screenshotSHA256 = '';
-      if (screenshot) {
+      const passed = finalAttempt.status === 'passed';
+      const previousPass = previousByID.get(testID)?.assessment === 'PASS';
+      if (screenshot && (passed || !previousPass)) {
         fs.copyFileSync(screenshot.path, stableScreenshot);
         screenshotSHA256 = crypto.createHash('sha256').update(fs.readFileSync(stableScreenshot)).digest('hex');
-      } else {
+      } else if (!screenshot && !previousPass) {
         this.errors.push(`${testID}@${this.target} is missing its final viewport screenshot`);
       }
-      const passed = finalAttempt.status === 'passed';
       const flaky = passed && attempts.length > 1 && attempts.some((attempt) => attempt.status !== 'passed');
       const status = flaky ? 'FLAKY' : passed ? 'PASS' : finalAttempt.status === 'skipped' ? 'SKIP' : 'FAIL';
       const traces = finalAttempt.attachments.filter((item) => item.name === 'trace').map((item) => relative(this.runDir, item.path));
@@ -110,15 +121,6 @@ export default class EvidenceReporter {
     for (const testID of this.expected) {
       if (!this.attempts.has(testID)) {
         this.errors.push(`${testID}@${this.target} is required by tests/catalog.yaml but has no result`);
-      }
-    }
-    const previousPath = path.join(this.runDir, 'evidence-manifest.json');
-    let previous = [];
-    if (fs.existsSync(previousPath)) {
-      try {
-        previous = JSON.parse(fs.readFileSync(previousPath, 'utf8')).cases || [];
-      } catch {
-        this.errors.push('existing evidence-manifest.json is unreadable');
       }
     }
     const merged = new Map(previous.map((item) => [item.test_id, item]));

--- a/web/src/evidence-reporter.test.mjs
+++ b/web/src/evidence-reporter.test.mjs
@@ -87,6 +87,41 @@ test('evidence reporter writes stable evidence and preserves a prior passing cas
   assert.equal(reporter.purposeByTestID('UI-CA-BILLING-STG-999'), 'Validate UI-CA-BILLING-STG-999 behavior defined by the catalog and Playwright test');
 });
 
+test('evidence reporter does not overwrite a preserved passing screenshot with a failed rerun', async (t) => {
+  const runDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-admin-evidence-preserved-pass-'));
+  const firstScreenshot = path.join(runDir, 'first-attempt.png');
+  const failedScreenshot = path.join(runDir, 'failed-rerun.png');
+  fs.writeFileSync(firstScreenshot, 'passing screenshot');
+  fs.writeFileSync(failedScreenshot, 'failed rerun screenshot');
+  configureReporter(t, {
+    E2E_TEST_RUN_DIR: runDir,
+    E2E_TEST_RUN_ID: 'unit-reporter-preserved-pass',
+    E2E_TEST_TARGET: 'desktop',
+    E2E_TEST_ENVIRONMENT: 'local',
+    E2E_EXPECTED_TEST_IDS: '',
+  });
+
+  const passingReporter = new EvidenceReporter();
+  passingReporter.onBegin();
+  passingReporter.onTestEnd({ title: '[UI-CA-BILLING-001] initial pass' }, result('passed', firstScreenshot));
+  assert.equal(await passingReporter.onEnd(), undefined);
+
+  const firstManifest = JSON.parse(fs.readFileSync(path.join(runDir, 'evidence-manifest.json'), 'utf8'));
+  const firstRecord = firstManifest.cases[0];
+  const stableScreenshot = path.join(runDir, firstRecord.screenshot_path);
+  assert.equal(fs.readFileSync(stableScreenshot, 'utf8'), 'passing screenshot');
+
+  const failedReporter = new EvidenceReporter();
+  failedReporter.onBegin();
+  failedReporter.onTestEnd({ title: '[UI-CA-BILLING-001] failed scenario rerun' }, result('failed', failedScreenshot));
+  assert.equal(await failedReporter.onEnd(), undefined);
+
+  const finalManifest = JSON.parse(fs.readFileSync(path.join(runDir, 'evidence-manifest.json'), 'utf8'));
+  assert.equal(finalManifest.cases[0].assessment, 'PASS');
+  assert.equal(finalManifest.cases[0].screenshot_sha256, firstRecord.screenshot_sha256);
+  assert.equal(fs.readFileSync(stableScreenshot, 'utf8'), 'passing screenshot');
+});
+
 test('evidence reporter fails closed for invalid or incomplete evidence', async (t) => {
   const runDir = fs.mkdtempSync(path.join(os.tmpdir(), 'cloud-admin-evidence-invalid-'));
   configureReporter(t, {


### PR DESCRIPTION
## Summary
- preserve an existing passing screenshot when a later scenario-phase rerun of the same governed test fails
- keep the manifest checksum and stable screenshot consistent
- add a regression test covering the multi-phase reporter behavior

## Validation
- `npm test` (132 passed)
- `npm run build`